### PR TITLE
Add support for Cloud CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DBT_ENV_ID=your-environment-id
 DBT_TOKEN=your-service-token
 DBT_PROJECT_DIR=/path/to/your/dbt/project
 DBT_PATH=/path/to/your/dbt/executable
+DBT_EXECUTABLE_TYPE=cloud # or core

--- a/README.md
+++ b/README.md
@@ -19,46 +19,33 @@ cd dbt-mcp-prototype
 cp .env.example .env
 ```
 Then edit `.env` with your specific environment variables:
-- `DISABLE_DBT_CORE`: Set this to `true` to disable dbt Core MCP objects. Otherwise, they are enabled.
+- `DISABLE_DBT_CLI`: Set this to `true` to disable dbt Core and dbt Cloud CLI MCP objects. Otherwise, they are enabled.
 - `DISABLE_SEMANTIC_LAYER`: Set this to `true` to disable dbt Semantic Layer MCP objects. Otherwise, they are enabled.
 - `DISABLE_DISCOVERY`: Set this to `true` to disable dbt Discovery API MCP objects. Otherwise, they are enabled.
 - `DBT_HOST`: Your dbt Cloud instance hostname. This will look like an `Access URL` found [here](https://docs.getdbt.com/docs/cloud/about-cloud/access-regions-ip-addresses).
 - `DBT_ENV_ID`: Your dbt environment ID
 - `DBT_TOKEN`: Your personal access token or service token. Service token is required when using the Semantic Layer.
 - `DBT_PROJECT_DIR`: The path to your dbt Project.
-- `DBT_PATH`: The path to your dbt executable.
+- `DBT_PATH`: The path to your dbt Core or dbt Cloud CLI executable. You can find your dbt executable by running `which dbt`.
+- `DBT_EXECUTABLE_TYPE`: Set this to `core` if the `DBT_PATH` environment variable points toward dbt Core. Otherwise, dbt Cloud CLI is assumed
 
 
 ### Install in Claude Desktop
 
-```shell
-mcp install dbt_mcp/main.py --name "dbt" --with "mcp[cli]" --with "requests>=2.31.0" --with "python-dotenv>=1.0.0"
-```
-
-This command will add an entry like the following to `claude_desktop_config.json`:
+Follow [these](https://modelcontextprotocol.io/quickstart/user) instructions to add the `dbt-mcp` `claude_desktop_config.json` configuration. After you have gone through the [Setup](#setup) instructions. It can look like this. Be sure to replace `<path-to-this-directory>`:
 
 ```json
+{
+  "mcpServers": {
     "dbt": {
-      "command": "uv",
+      "command": "<path-to-this-directory>/.venv/bin/mcp",
       "args": [
         "run",
-        "--with",
-        "mcp[cli]",
-        "--with",
-        "python-dotenv>=1.0.0",
-        "--with",
-        "requests",
-        "mcp",
-        "run",
-        "/YOUR_INSTALL_PATH/dbt-mcp-prototype/main.py"
+        "<path-to-this-directory>/dbt_mcp/main.py"
       ]
-    },
-```
-
-Assuming `EDITOR` environment variable is configured and standard install location of Claude Desktop for macOS, you can examine it like this:
-
-```shell
-$EDITOR ~/Library/Application\ Support/Claude/claude_desktop_config.json
+    }
+  }
+}
 ```
 
 ### Local development

--- a/dbt_mcp/config/config.py
+++ b/dbt_mcp/config/config.py
@@ -5,33 +5,15 @@ from dotenv import load_dotenv
 
 @dataclass
 class Config:
-    host: str
-    environment_id: int
-    token: str
+    host: str | None
+    environment_id: int | None
+    token: str | None
     project_dir: str | None
-    dbt_core_enabled: bool
+    dbt_cli_enabled: bool
     semantic_layer_enabled: bool
     discovery_enabled: bool
     dbt_command: str
-
-def _validate_env_vars(
-    *,
-    host: str | None,
-    environment_id: str | None,
-    token: str | None,
-    project_dir: str | None,
-    dbt_path: str | None,
-) -> tuple[str, str, str, str | None, str | None]:
-    if not host or not environment_id or not token:
-        raise ValueError(
-            "Missing at least one of these required environment variables: " +
-            "DBT_HOST, DBT_ENV_ID, DBT_TOKEN."
-        )
-    if host.startswith("metadata") or host.startswith("semantic-layer"):
-        raise ValueError("Host must not start with 'metadata' or 'semantic-layer'.")
-    if (not project_dir or not dbt_path) and not os.getenv("DISABLE_DBT_CORE"):
-        raise ValueError("Project directory and dbt path are required when dbt core MCP is enabled.")
-    return host, environment_id, token, project_dir, dbt_path
+    dbt_executable_type: str
 
 def load_config() -> Config:
     load_dotenv()
@@ -40,23 +22,41 @@ def load_config() -> Config:
     environment_id = os.environ.get("DBT_ENV_ID")
     token = os.environ.get("DBT_TOKEN")
     project_dir = os.environ.get("DBT_PROJECT_DIR")
-    dbt_path = os.environ.get("DBT_PATH")
+    dbt_path = os.environ.get("DBT_PATH", "dbt")
+    dbt_executable_type = os.environ.get("DBT_EXECUTABLE_TYPE", "cloud")
+    disable_dbt_cli = os.environ.get("DISABLE_DBT_CLI", "false") == "true"
+    disable_semantic_layer = os.environ.get("DISABLE_SEMANTIC_LAYER", "false") == "true"
+    disable_discovery = os.environ.get("DISABLE_DISCOVERY", "false") == "true"
 
-    host, environment_id, token, project_dir, dbt_path = _validate_env_vars(
-        host=host,
-        environment_id=environment_id,
-        token=token,
-        project_dir=project_dir,
-        dbt_path=dbt_path,
-    )
+    errors = []
+    if not disable_semantic_layer or not disable_discovery:
+        if not host:
+            errors.append("DBT_HOST environment variable is required when semantic layer or discovery is enabled.")
+        if not environment_id:
+            errors.append("DBT_ENV_ID environment variable is required when semantic layer or discovery is enabled.")
+        if not token:
+            errors.append("DBT_TOKEN environment variable is required when semantic layer or discovery is enabled.")
+        if host and (host.startswith("metadata") or host.startswith("semantic-layer")):
+            errors.append("DBT_HOST must not start with 'metadata' or 'semantic-layer'.")
+    if not disable_dbt_cli:
+        if not project_dir:
+            errors.append("DBT_PROJECT_DIR environment variable is required when dbt CLI MCP is enabled.")
+        if not dbt_path:
+            errors.append("DBT_PATH environment variable is required when dbt CLI MCP is enabled.")
+        if dbt_executable_type not in ["core", "cloud"]:
+            errors.append("DBT_EXECUTABLE_TYPE environment variable must be either 'core' or 'cloud' when dbt CLI MCP is enabled.")
+
+    if errors:
+        raise ValueError("Errors found in configuration:\n\n" + "\n".join(errors))
 
     return Config(
         host=host,
-        environment_id=int(environment_id),
+        environment_id=int(environment_id) if environment_id else None,
         token=token,
         project_dir=project_dir,
-        dbt_core_enabled=os.getenv("DISABLE_DBT_CORE") != "true",
-        semantic_layer_enabled=os.getenv("DISABLE_SEMANTIC_LAYER") != "true",
-        discovery_enabled=os.getenv("DISABLE_DISCOVERY") != "true",
-        dbt_command=dbt_path or "dbt",
+        dbt_cli_enabled=not disable_dbt_cli,
+        semantic_layer_enabled=not disable_semantic_layer,
+        discovery_enabled=not disable_discovery,
+        dbt_command=dbt_path,
+        dbt_executable_type=dbt_executable_type,
     )

--- a/dbt_mcp/dbt_cli/tools.py
+++ b/dbt_mcp/dbt_cli/tools.py
@@ -2,15 +2,20 @@ import subprocess
 from config.config import Config
 from mcp.server.fastmcp import FastMCP
 
-def register_dbt_core_tools(dbt_mcp: FastMCP, config: Config) -> None:
+def register_dbt_cli_tools(dbt_mcp: FastMCP, config: Config) -> None:
 
     def _run_dbt_command(command: list[str]) -> str:
-        return subprocess.run(
+        result = subprocess.run(
             args=[config.dbt_command, *command],
             cwd=config.project_dir,
             capture_output=True,
             text=True,
-        ).stdout
+        )
+        # Cloud CLI reports errors to stderr, Core CLI reports errors to stdout
+        if config.dbt_executable_type == "cloud" and  result.returncode != 0:
+            return result.stderr
+        else:
+            return result.stdout
 
     @dbt_mcp.tool()
     def build() -> str:

--- a/dbt_mcp/main.py
+++ b/dbt_mcp/main.py
@@ -1,9 +1,8 @@
-import os
 from mcp.server.fastmcp import FastMCP
 from config.config import load_config
 from semantic_layer.tools import register_sl_tools
 from discovery.tools import register_discovery_tools
-from dbt_core.tools import register_dbt_core_tools
+from dbt_cli.tools import register_dbt_cli_tools
 
 dbt_mcp = FastMCP("dbt")
 
@@ -15,8 +14,8 @@ if config.semantic_layer_enabled:
 if config.discovery_enabled:
     register_discovery_tools(dbt_mcp, config)
 
-if config.dbt_core_enabled:
-    register_dbt_core_tools(dbt_mcp, config)
+if config.dbt_cli_enabled:
+    register_dbt_cli_tools(dbt_mcp, config)
 
 print("Starting dbt MCP server")
 dbt_mcp.run()


### PR DESCRIPTION
This PR changes some configurations to make the MCP server compatible with Cloud CLI. dbt Core & dbt Cloud CLI have very similar CLIs, so this is a relatively straightforward change.