### PR TITLE
Fix name of get_model_ancestors

### DIFF
--- a/dbt_mcp/discovery/tools.py
+++ b/dbt_mcp/discovery/tools.py
@@ -33,8 +33,8 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
         return models_fetcher.fetch_model_details(model_name)
 
     @dbt_mcp.tool()
-    def get_model_ancestors(model_name: str) -> list[dict]:
+    def get_model_parents(model_name: str) -> list[dict]:
         """
-        Get the ancestors of a specific dbt model.
+        Get the parents of a specific dbt model.
         """
         return models_fetcher.fetch_model_parents(model_name)


### PR DESCRIPTION
This tool was named improperly. So, just fixing the name here.