### PR TITLE
Fix remote tools when there are multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then edit `.env` with your specific environment variables:
 
 ### Install in Claude Desktop
 
-Follow [these](https://modelcontextprotocol.io/quickstart/user) instructions to add the `dbt-mcp` `claude_desktop_config.json` configuration. After you have gone through the [Setup](#setup) instructions. It can look like this. Be sure to replace `<path-to-this-directory>`:
+Follow [these](https://modelcontextprotocol.io/quickstart/user) instructions to add the `dbt-mcp` `claude_desktop_config.json` configuration after you have gone through the [Setup](#setup) instructions. It can look like this. Be sure to replace `<path-to-this-directory>`:
 
 ```json
 {
@@ -49,3 +49,4 @@ Follow [these](https://modelcontextprotocol.io/quickstart/user) instructions to 
   }
 }
 ```
+If you encounter any problems. You can try running `task run` to see errors in your terminal or examining the Claude Desktop logs at `~/Library/Logs/Claude`.

--- a/dbt_mcp/config/config.py
+++ b/dbt_mcp/config/config.py
@@ -30,7 +30,7 @@ def load_config() -> Config:
     disable_semantic_layer = os.environ.get("DISABLE_SEMANTIC_LAYER", "false") == "true"
     disable_discovery = os.environ.get("DISABLE_DISCOVERY", "false") == "true"
     disable_remote = os.environ.get("DISABLE_REMOTE", "false") == "true"
-    remote_mcp_url = os.environ.get("REMOTE_MCP_URL", "http://localhost:8000/sse")
+    remote_mcp_url = os.environ.get("REMOTE_MCP_URL", "http://localhost:8000/mcp/sse")
 
     errors = []
     if not disable_semantic_layer or not disable_discovery:

--- a/tests/integration/remote/test_remote.py
+++ b/tests/integration/remote/test_remote.py
@@ -9,7 +9,7 @@ async def test_remote_tool():
     config = load_config()
     dbt_mcp = FastMCP("Test")
     await register_remote_tools(dbt_mcp, config)
-    assert "add" in [t.name for t in await dbt_mcp.list_tools()]
-    result = await dbt_mcp.call_tool("add", {"a": "1", "b": "1"})
+    assert "echo_tool" in [t.name for t in await dbt_mcp.list_tools()]
+    result = await dbt_mcp.call_tool("echo_tool", {"message": "Hello, world!"})
     assert len(result) == 1
-    assert result[0].text == "2"
+    assert "Hello, world!" in result[0].text


### PR DESCRIPTION
I neglected to test multiple remote tools the first time around. When I started testing with multiple tools, I started seeing errors due to the `new_tool` function being reused for each tool. This PR fixes that by creating a new function for each tool.