### PR TITLE
Rename ls tool to list

### DIFF
--- a/dbt_mcp/dbt_cli/tools.py
+++ b/dbt_mcp/dbt_cli/tools.py
@@ -38,7 +38,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: Config) -> None:
         """
         return _run_dbt_command(["docs", "generate"])
 
-    @dbt_mcp.tool()
+    @dbt_mcp.tool(name="list")
     def ls() -> str:
         """
         List the resources in the project


### PR DESCRIPTION
In Python, you can't name a function `list` because this is a keyword. This is a simple rename to allow the `dbt list` tool to surface correctly.