### PR TITLE
Fix for multicell and empty Discovery API results

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Then edit `.env` with your specific environment variables:
 - `DISABLE_DBT_CLI`: Set this to `true` to disable dbt Core and dbt Cloud CLI MCP objects. Otherwise, they are enabled.
 - `DISABLE_SEMANTIC_LAYER`: Set this to `true` to disable dbt Semantic Layer MCP objects. Otherwise, they are enabled.
 - `DISABLE_DISCOVERY`: Set this to `true` to disable dbt Discovery API MCP objects. Otherwise, they are enabled.
-- `DBT_HOST`: Your dbt Cloud instance hostname. This will look like an `Access URL` found [here](https://docs.getdbt.com/docs/cloud/about-cloud/access-regions-ip-addresses).
-- `DBT_ENV_ID`: Your dbt environment ID
+- `DBT_HOST`: Your dbt Cloud instance hostname. This will look like an `Access URL` found [here](https://docs.getdbt.com/docs/cloud/about-cloud/access-regions-ip-addresses). If you are using Multi-cell, do not include the `ACCOUNT_PREFIX` here.
+- `MULTICELL_ACCOUNT_PREFIX`: If you are using Multi-cell, set this to your `ACCOUNT_PREFIX`. If you are not using Multi-cell, do not set this environment variable. You can learn more [here](https://docs.getdbt.com/docs/cloud/about-cloud/access-regions-ip-addresses).
+- `DBT_ENV_ID`: Your dbt environment ID.
 - `DBT_TOKEN`: Your personal access token or service token. Service token is required when using the Semantic Layer.
 - `DBT_PROJECT_DIR`: The path to your dbt Project.
 - `DBT_PATH`: The path to your dbt Core or dbt Cloud CLI executable. You can find your dbt executable by running `which dbt`.

--- a/dbt_mcp/config/config.py
+++ b/dbt_mcp/config/config.py
@@ -16,6 +16,7 @@ class Config:
     dbt_command: str
     dbt_executable_type: str
     remote_mcp_url: str
+    multicell_account_prefix: str | None
 
 def load_config() -> Config:
     load_dotenv()
@@ -31,6 +32,7 @@ def load_config() -> Config:
     disable_discovery = os.environ.get("DISABLE_DISCOVERY", "false") == "true"
     disable_remote = os.environ.get("DISABLE_REMOTE", "false") == "true"
     remote_mcp_url = os.environ.get("REMOTE_MCP_URL", "http://localhost:8000/mcp/sse")
+    multicell_account_prefix = os.environ.get("MULTICELL_ACCOUNT_PREFIX", None)
 
     errors = []
     if not disable_semantic_layer or not disable_discovery:
@@ -65,4 +67,5 @@ def load_config() -> Config:
         dbt_command=dbt_path,
         dbt_executable_type=dbt_executable_type,
         remote_mcp_url=remote_mcp_url,
+        multicell_account_prefix=multicell_account_prefix,
     )

--- a/dbt_mcp/discovery/tools.py
+++ b/dbt_mcp/discovery/tools.py
@@ -3,8 +3,10 @@ from dbt_mcp.config.config import Config
 from dbt_mcp.discovery.client import MetadataAPIClient, ModelsFetcher
 
 def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
-    api_client = MetadataAPIClient(config.host, config.token)
-    models_fetcher = ModelsFetcher(api_client, config.environment_id)
+    if not config.host or not config.token or not config.environment_id:
+        raise ValueError("Host, token, and environment ID are required to use discovery tools. To disable discovery tools, set DISABLE_DISCOVERY=true in your environment.")
+    api_client = MetadataAPIClient(host=config.host, token=config.token, multicell_account_prefix=config.multicell_account_prefix)
+    models_fetcher = ModelsFetcher(api_client=api_client, environment_id=config.environment_id)
 
     @dbt_mcp.tool()
     def get_mart_models() -> list[dict]:

--- a/dbt_mcp/remote/tools.py
+++ b/dbt_mcp/remote/tools.py
@@ -57,7 +57,7 @@ async def list_remote_tools(config: Config, headers: dict[str, Any]) -> list[Rem
     try:
         async with sse_mcp_connection_context(config.remote_mcp_url, headers) as session:
             result = (await session.list_tools()).tools
-    except* (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout, httpcore.ConnectTimeout) as e:
+    except* (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout, httpcore.ConnectTimeout, httpx.RemoteProtocolError) as e:
         print(f"Connection error while listing remote tools: {e}")
     return result
 

--- a/dbt_mcp/semantic_layer/client.py
+++ b/dbt_mcp/semantic_layer/client.py
@@ -1,15 +1,17 @@
+import time
 from contextlib import contextmanager
-from functools import cache, lru_cache
+from functools import cache
 from typing import Any, Generator, LiteralString, Protocol
 
+import requests
 from dbtsl import SemanticLayerClient
+from dbtsl.models.dimension import Dimension
+from dbtsl.models.metric import Metric
+
 from dbt_mcp.config.config import Config
 from dbt_mcp.semantic_layer.levenshtein import get_misspellings
 from dbt_mcp.semantic_layer.types import DimensionToolResponse, MetricToolResponse
-from dbtsl.models.dimension import Dimension
-from dbtsl.models.metric import Metric
-import time
-import requests
+
 
 class SemanticLayerClientProtocol(Protocol):
     @contextmanager
@@ -213,7 +215,10 @@ class SemanticLayerFetcher:
             return "No results returned."
 
 def get_semantic_layer_fetcher(config: Config) -> SemanticLayerFetcher:
-    host = f"semantic-layer.{config.host}"
+    if config.multicell_account_prefix:
+        host = f"{config.multicell_account_prefix}.semantic-layer.{config.host}"
+    else:
+        host = f"semantic-layer.{config.host}"
     semantic_layer_client = SemanticLayerClient(
         environment_id=config.environment_id,
         auth_token=config.token,

--- a/dbt_mcp/semantic_layer/tools.py
+++ b/dbt_mcp/semantic_layer/tools.py
@@ -5,6 +5,8 @@ from mcp.server.fastmcp import FastMCP
 from dbt_mcp.semantic_layer.types import DimensionToolResponse, MetricToolResponse
 
 def register_sl_tools(dbt_mcp: FastMCP, config: Config) -> None:
+    if not config.host or not config.token or not config.environment_id:
+        raise ValueError("Host, token, and environment ID are required to use semantic layer tools. To disable semantic layer tools, set DISABLE_SEMANTIC_LAYER=true in your environment.")
     semantic_layer_fetcher = get_semantic_layer_fetcher(config)
 
     @dbt_mcp.tool()


### PR DESCRIPTION
This PR adds support for MC environments. For MC, I decided to require that the user add a separate env var for their MC account prefix. This isn't ideal as more configuration is required, but I think it is more reliable than trying to infer if the host is MC or not. This PR also fixes errors being thrown when the Disco API returns empty results. I don't have an MC account, so I wasn't able to test that, but I did test that there were no regressions with my MT account.