### PR TITLE
Add repo read permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       # this permission is required for trusted publishing
       # see https://github.com/marketplace/actions/pypi-publish
       id-token: write
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This permission is required to read the repo: https://github.com/dbt-labs/dbt-mcp/actions/runs/14208565454/job/39811418750