### PR TITLE
Remove check from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-      - name: Run check
-        run: task check
       - name: Run tests
         run: task test:unit
       # TODO: Actually build the package instead of releasing a placeholder


### PR DESCRIPTION
Running the checks isn't necessary. We are already running them each PR. One of the checks doesn't allow running it on `main`, so that isn't compatible with the process to release to PyPI.