### PR TITLE
Fix remote tools connection exception

### DIFF
--- a/dbt_mcp/remote/tools.py
+++ b/dbt_mcp/remote/tools.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import (
@@ -5,8 +6,6 @@ from typing import (
     Any,
 )
 
-import httpcore
-import httpx
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.server.fastmcp import FastMCP
@@ -23,6 +22,8 @@ from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
 from dbt_mcp.config.config import Config
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -75,14 +76,8 @@ async def list_remote_tools(
     try:
         async with sse_mcp_connection_context(url, headers) as session:
             result = (await session.list_tools()).tools
-    except* (
-        httpx.ConnectError,
-        httpx.ReadTimeout,
-        httpx.ConnectTimeout,
-        httpcore.ConnectTimeout,
-        httpx.RemoteProtocolError,
-    ) as e:
-        print(f"Connection error while listing remote tools: {e}")
+    except Exception as e:
+        logger.error(f"Connection error while listing remote tools: {e}")
     return result
 
 


### PR DESCRIPTION
From a recent PR, the remote tools were trying to connect to dbt Cloud, which intentionally doesn't work right now. It was throwing an error I hadn't accounted for. Instead of catching every possible networking error individually, I think it is better to just catch all errors and log errors in this case. You should still see error logs in your terminal until we get MCP in cloud setup (soon), so that is expected.