### PR TITLE
Remove valid owner checker

### DIFF
--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -12,5 +12,5 @@ jobs:
     - uses: mszostok/codeowners-validator@v0.7.2
       with:
         github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"
-        checks: "owners,duppatterns"
+        checks: "duppatterns"
         experimental_checks: "notowned"


### PR DESCRIPTION
This part of the codeowners validator check requires Github authorization and fails on public repos.