### PR TITLE
Comment out tests in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-      - name: Run tests
-        run: task test:unit
+      # TODO: Uncomment this when we have tests
+      # - name: Run tests
+      #   run: task test:unit
       - name: Build
         run: task build
       - name: Publish to PyPI


### PR DESCRIPTION
I'm commenting out the tests in the release process for now. We used to have a unit test, but I got rid of it when we migrated to using GQL. I will be able to bring this test back once we migrate back to the SDK (soon).