### PR TITLE
Properly closing SL connection in the case of an exception

### DIFF
--- a/dbt_mcp/semantic_layer/sdk/sync_adbc_client.py
+++ b/dbt_mcp/semantic_layer/sdk/sync_adbc_client.py
@@ -40,9 +40,8 @@ class SyncADBCClient(BaseADBCClient):
 
         All requests made during the same session will reuse the same connection.
         """
-        # TODO: I'm unsure why this error is happening.
-        # if self._conn_unsafe is not None:
-        #     raise ValueError("A client session is already open.")
+        if self._conn_unsafe is not None:
+            raise ValueError("A client session is already open.")
 
         ctx = self._get_connection_context_manager()
         with ctx as conn:

--- a/dbt_mcp/semantic_layer/sdk/sync_sl_client.py
+++ b/dbt_mcp/semantic_layer/sdk/sync_sl_client.py
@@ -49,9 +49,8 @@ class SyncSemanticLayerClient(
     @contextmanager
     def session(self) -> Iterator[Self]:
         """Establish a connection with the dbt Semantic Layer's servers."""
-        # TODO: I'm unsure why this error is happening.
-        # if self._has_session:
-        #     raise ValueError("Cannot open session within session.")
+        if self._has_session:
+            raise ValueError("Cannot open session within session.")
 
         with self._gql.session(), self._adbc.session():
             self._has_session = True

--- a/tests/integration/semantic_layer/test_semantic_layer.py
+++ b/tests/integration/semantic_layer/test_semantic_layer.py
@@ -1,7 +1,6 @@
-from dbtsl.api.shared.query_params import GroupByParam, GroupByType
-
 from dbt_mcp.config.config import load_config
 from dbt_mcp.semantic_layer.client import get_semantic_layer_fetcher
+from dbt_mcp.semantic_layer.sdk.query_params import GroupByParam, GroupByType
 from dbt_mcp.semantic_layer.types import OrderByParam
 
 config = load_config()
@@ -27,10 +26,41 @@ def test_semantic_layer_query_metrics():
         group_by=[
             GroupByParam(
                 name="metric_time",
-                type=GroupByType.DIMENSION,
+                type=GroupByType.TIME_DIMENSION,
                 grain=None,
             )
         ],
+    )
+    assert result is not None
+
+
+def test_semantic_layer_query_metrics_invalid_query():
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    result = semantic_layer_fetcher.query_metrics(
+        metrics=["food_revenue"],
+        group_by=[
+            GroupByParam(
+                name="order_id__location__location_name",
+                type=GroupByType.CATEGORICAL_DIMENSION,
+                grain=None,
+            ),
+            GroupByParam(
+                name="metric_time",
+                type=GroupByType.TIME_DIMENSION,
+                grain="MONTH",
+            ),
+        ],
+        order_by=[
+            OrderByParam(
+                name="metric_time",
+                descending=True,
+            ),
+            OrderByParam(
+                name="food_revenue",
+                descending=True,
+            ),
+        ],
+        limit=5,
     )
     assert result is not None
 
@@ -42,7 +72,7 @@ def test_semantic_layer_query_metrics_with_group_by_grain():
         group_by=[
             GroupByParam(
                 name="metric_time",
-                type=GroupByType.DIMENSION,
+                type=GroupByType.TIME_DIMENSION,
                 grain="day",
             )
         ],
@@ -57,7 +87,7 @@ def test_semantic_layer_query_metrics_with_order_by():
         group_by=[
             GroupByParam(
                 name="metric_time",
-                type=GroupByType.DIMENSION,
+                type=GroupByType.TIME_DIMENSION,
                 grain=None,
             )
         ],


### PR DESCRIPTION
This PR ensures that the SL connection is closed in the event of an exception. It is unclear to me why the connection was not being closed properly before. I looked into the SL SDK code and read up on `@contextmanager,` and the connection should have been closed, even if there was an exception. However, apparently these connections weren't being cleaned up properly, and this PR fixes it. I no longer see `Cannot open session within session` errors.