### PR TITLE
Stateless Remote MCP support

### DIFF
--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -19,7 +19,7 @@ class Config:
     dbt_command: str
     dbt_executable_type: str
     multicell_account_prefix: str | None
-    remote_mcp_url: str
+    remote_mcp_base_url: str
 
 
 def load_config() -> Config:
@@ -107,8 +107,8 @@ def load_config() -> Config:
         dbt_command=dbt_path,
         dbt_executable_type=dbt_executable_type,
         multicell_account_prefix=multicell_account_prefix,
-        remote_mcp_url=(
+        remote_mcp_base_url=(
             "http://" if host and host.startswith("localhost") else "https://"
         )
-        + f"{host}/mcp/sse",
+        + f"{host}/mcp",
     )


### PR DESCRIPTION
The current implementation of the Python SDK is stateful. There is work underway to fix this: https://github.com/modelcontextprotocol/python-sdk/issues/443. However, currently we need to eject from the MCP framework to use stateless requests. This is to avoid issues described in this issue: https://github.com/modelcontextprotocol/python-sdk/issues/520, for example. I tested this in Claude by listing and making a request to a remote tool.