### PR TITLE
Combine dbt cli stderr and stdout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,4 @@ DBT_USER_ID=your-user-id
 DBT_TOKEN=your-service-token
 DBT_PROJECT_DIR=/path/to/your/dbt/project
 DBT_PATH=/path/to/your/dbt/executable
-DBT_EXECUTABLE_TYPE=cloud # or core
 MULTICELL_ACCOUNT_PREFIX=your-account-prefix

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The MCP server takes the following configuration:
 - `DBT_TOKEN`: Your personal access token or service token. Service token is required when using the Semantic Layer.
 - `DBT_PROJECT_DIR`: The path to your dbt Project.
 - `DBT_PATH`: The path to your dbt Core or dbt Cloud CLI executable. You can find your dbt executable by running `which dbt`.
-- `DBT_EXECUTABLE_TYPE`: Set this to `core` if the `DBT_PATH` environment variable points toward dbt Core. Otherwise, dbt Cloud CLI is assumed
 
 ## Using with MCP Clients
 

--- a/install.sh
+++ b/install.sh
@@ -183,9 +183,6 @@ function configure_environment() {
     echo "The path to your dbt Core or dbt Cloud CLI executable. You can find your dbt executable by running \`which dbt\`."
     DBT_PATH=$(prompt_with_default "Enter DBT_PATH")
 
-    echo "Set this to \`core\` if the \`DBT_PATH\` environment variable points toward dbt Core. Otherwise, dbt Cloud CLI is assumed"
-    DBT_EXECUTABLE_TYPE=$(prompt_with_default "Enter DBT_EXECUTABLE_TYPE" "cloud")
-
     echo "If you are using Multi-cell, set this to your \`ACCOUNT_PREFIX\`. If you are not using Multi-cell, do not set this environment variable. You can learn more here : https://docs.getdbt.com/docs/cloud/about-cloud/access-regions-ip-addresses."
     MULTICELL_ACCOUNT_PREFIX=$(prompt_with_default "Enter MULTICELL_ACCOUNT_PREFIX" "")
 
@@ -193,7 +190,6 @@ function configure_environment() {
     cat >"${mcp_server_dir}/.env" <<EOF
 DBT_HOST="${DBT_HOST}"
 DBT_TOKEN="${DBT_TOKEN}"
-DBT_EXECUTABLE_TYPE="${DBT_EXECUTABLE_TYPE}"
 DBT_PROD_ENV_ID="${DBT_PROD_ENV_ID}"
 DBT_DEV_ENV_ID="${DBT_DEV_ENV_ID}"
 DBT_USER_ID="${DBT_USER_ID}"

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -17,7 +17,6 @@ class Config:
     discovery_enabled: bool
     remote_enabled: bool
     dbt_command: str
-    dbt_executable_type: str
     multicell_account_prefix: str | None
     remote_mcp_url: str
 
@@ -33,7 +32,6 @@ def load_config() -> Config:
     token = os.environ.get("DBT_TOKEN")
     project_dir = os.environ.get("DBT_PROJECT_DIR")
     dbt_path = os.environ.get("DBT_PATH", "dbt")
-    dbt_executable_type = os.environ.get("DBT_EXECUTABLE_TYPE", "cloud")
     disable_dbt_cli = os.environ.get("DISABLE_DBT_CLI", "false") == "true"
     disable_semantic_layer = os.environ.get("DISABLE_SEMANTIC_LAYER", "false") == "true"
     disable_discovery = os.environ.get("DISABLE_DISCOVERY", "false") == "true"
@@ -76,10 +74,6 @@ def load_config() -> Config:
             errors.append(
                 "DBT_PATH environment variable is required when dbt CLI MCP is enabled."
             )
-        if dbt_executable_type not in ["core", "cloud"]:
-            errors.append(
-                "DBT_EXECUTABLE_TYPE environment variable must be either 'core' or 'cloud' when dbt CLI MCP is enabled."
-            )
 
     if errors:
         raise ValueError("Errors found in configuration:\n\n" + "\n".join(errors))
@@ -105,7 +99,6 @@ def load_config() -> Config:
         discovery_enabled=not disable_discovery,
         remote_enabled=not disable_remote,
         dbt_command=dbt_path,
-        dbt_executable_type=dbt_executable_type,
         multicell_account_prefix=multicell_account_prefix,
         remote_mcp_url=(
             "http://" if host and host.startswith("localhost") else "https://"


### PR DESCRIPTION
This PR improves the dbt CLI log outputs to interleave stderr & stdout. This makes the dbt logs better resemble how they would appear in the terminal. This also allows us to remove the configuration requirement for describing which type of dbt executable is being used. Fixes https://github.com/dbt-labs/dbt-mcp/issues/74.