### PR TITLE
Fix missing lazy parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Intended Audience :: Developers",
 ]
 dependencies = [
-  "dbt-sl-sdk[sync]>=0.10.0",
+  "dbt-sl-sdk[sync]==0.11.0",
   # We are using some internal functions, so pinning this dependency.
   "mcp[cli]==1.6.0",
   "pandas>=2.2.3",

--- a/src/dbt_mcp/semantic_layer/sdk/sync_sl_client.py
+++ b/src/dbt_mcp/semantic_layer/sdk/sync_sl_client.py
@@ -28,6 +28,7 @@ class SyncSemanticLayerClient(
         auth_token: str,
         host: str,
         timeout: TimeoutOptions | float | int | None = None,
+        lazy: bool = False,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -44,6 +45,7 @@ class SyncSemanticLayerClient(
             gql_factory=SyncGraphQLClient,
             adbc_factory=SyncADBCClient,
             timeout=timeout,
+            lazy=lazy,
         )
 
     @contextmanager

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,9 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "adbc-driver-flightsql"
@@ -172,7 +175,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dbt-sl-sdk", extras = ["sync"], specifier = ">=0.10.0" },
+    { name = "dbt-sl-sdk", extras = ["sync"], specifier = "==0.11.0" },
     { name = "mcp", extras = ["cli"], specifier = "==1.6.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -193,7 +196,7 @@ dev = [
 
 [[package]]
 name = "dbt-sl-sdk"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "adbc-driver-flightsql" },
@@ -202,9 +205,9 @@ dependencies = [
     { name = "pyarrow" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/dc/76f7bf5343b3cd5c57830a1d5e1bfe79c189138c66219c33a0f8a81c2521/dbt_sl_sdk-0.10.0.tar.gz", hash = "sha256:cf44d72e53dbdd8ac22c194d22fac484cf5d53b62b302d74e7be5fa0f89e45d9", size = 26774 }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/3f/0ed1e5a2c1f4b880ba536179397107ffbbdd9f11080a37fb4302258e8738/dbt_sl_sdk-0.11.0.tar.gz", hash = "sha256:b25716276d03aee1228d1a28e2932f63ffd4356878072c4106f6e1664ad680e8", size = 28836 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/b5/e19e22de0f091dbf2ee3905147c6f8ee7e9542bda22e4ce98bb063ca2140/dbt_sl_sdk-0.10.0-py3-none-any.whl", hash = "sha256:b229128fbbaf0bdfc85bb06adc2139664ac1f53aafe5d8ed07ca516e1066c227", size = 44110 },
+    { url = "https://files.pythonhosted.org/packages/1d/7a/10ca303a8004089bcb69914b3a5ace943da25611417a1613fad47a40eed2/dbt_sl_sdk-0.11.0-py3-none-any.whl", hash = "sha256:bba027b38def0f64e390b0d0e0894ed41b5b0921b04edef2f5e22f555b415400", size = 46773 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
We are overriding some of the internal classes of the SL SDK, which isn't officially supported by that library. So, when they released 0.11.0, it broke our integration. This fixes that. I will work on removing our custom overrides.