### PR TITLE
Pin all dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,13 @@ classifiers = [
   "Intended Audience :: Developers",
 ]
 dependencies = [
+  # Pinning all dependencies because this app is installed with pip
+  # and we want to have a consistent install as much as possible.
   "dbt-sl-sdk[sync]==0.11.0",
-  # We are using some internal functions, so pinning this dependency.
   "mcp[cli]==1.6.0",
-  "pandas>=2.2.3",
-  "python-dotenv>=1.0.1",
-  "requests>=2.32.3",
+  "pandas==2.2.3",
+  "python-dotenv==1.0.1",
+  "requests==2.32.3",
 ]
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -177,9 +177,9 @@ dev = [
 requires-dist = [
     { name = "dbt-sl-sdk", extras = ["sync"], specifier = "==0.11.0" },
     { name = "mcp", extras = ["cli"], specifier = "==1.6.0" },
-    { name = "pandas", specifier = ">=2.2.3" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "pandas", specifier = "==2.2.3" },
+    { name = "python-dotenv", specifier = "==1.0.1" },
+    { name = "requests", specifier = "==2.32.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -901,11 +901,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920 }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256 },
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
 ]
 
 [[package]]


### PR DESCRIPTION
Our current install process is with pip in `install.sh`. `install.sh` makes for an easy installation process, but using pip can mean that users can get different installations of dbt-mcp. The best way to fix this would be to install the app from the `uv.lock` file, not with pip. However, this would require that users have uv installed. In the future, we can use [uv export](https://github.com/astral-sh/uv/issues/12584?utm_source=chatgpt.com) and install from pylock.toml with pip, but [that isn't supported yet](https://github.com/pypa/pip/issues/13334). In the meantime, pinning all dependencies should help provide for a more consistent install.