### PR TITLE
Require changelog entries for each PR

### DIFF
--- a/.changes/unreleased/Under the Hood-20250423-134646.yaml
+++ b/.changes/unreleased/Under the Hood-20250423-134646.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Require changelog entries for each PR
+time: 2025-04-23T13:46:46.125931-05:00

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '* {{.Body}}'
 kinds:
-    - label: Breaking Changes
+    - label: Breaking Change
       auto: major
     - label: Enhancement or New Feature
       auto: minor

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,36 @@
+name: Check CHANGELOG
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-changelog:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'Release: v')"
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: setup python
+        uses: ./.github/actions/setup-python
+        id: setup-python
+      - name: Check for changes
+        run: |
+          ALL_CHANGES=$(git diff --name-only HEAD origin/main)
+
+          CHANGIE=$(echo "$ALL_CHANGES" | grep -E "\.changes/unreleased/.*\.yaml" || true)
+          if [ "$CHANGIE" == "" ]; then
+            echo "No files added to '.changes/unreleased/'. Make sure you run 'changie new'."
+            exit 1
+          fi
+
+          CHANGELOG=$(echo "$ALL_CHANGES" | grep -E "CHANGELOG\.md" || true)
+          if [ "$CHANGELOG" != "" ]; then
+            echo "Don't edit 'CHANGELOG.md' manually nor run 'changie merge'."
+            exit 1
+          fi

--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   validate-codeowners:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,9 @@ jobs:
   check:
     name: Check styling
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -24,6 +27,9 @@ jobs:
   unit-test:
     name: Unit test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     needs:
       - check
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
         run: task build
       - name: Publish to test PyPI
         if: inputs.pypi-server == 'test-pypi'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           packages-dir: ./dist
           repository-url: https://test.pypi.org/legacy/
       - name: Publish to PyPI
         if: inputs.pypi-server == 'pypi'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           packages-dir: ./dist


### PR DESCRIPTION
This PR adds CI checks to enforce that every PR contains a changelog entry.

[PR 87](https://github.com/dbt-labs/dbt-mcp/pull/87) was also accidentally merged into this one, so there are also some unrelated security updates here.