### PR TITLE
Make package version based on git tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "dbt-mcp"
-version = "0.1.3"
 description = "A MCP (Model Context Protocol) server for interacting with dbt resources."
 authors = [{ name = "dbt Labs" }]
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.12"
+dynamic = ["version"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
@@ -43,8 +43,12 @@ Source = "https://github.com/dbt-labs/dbt-mcp"
 dbt-mcp = "dbt_mcp.main:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
 include = ["src/dbt_mcp/**/*", "README.md", "LICENSE"]
+
+[tool.hatch.version]
+source = "vcs"
+

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,6 @@ wheels = [
 
 [[package]]
 name = "dbt-mcp"
-version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "dbt-sl-sdk", extra = ["sync"] },


### PR DESCRIPTION
With this change we shouldn't need to update the version by hand anymore and doing a release in GH will publish the package with the version being the same as the tag used