### PR TITLE
Add note to README - warning for VS Code setup with WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Cursor MCP docs [here](https://docs.cursor.com/context/model-context-protocol) f
 1. Open the Settings menu (Command + Comma) and select the correct tab atop the page for your use case
     - `Workspace` - configures the server in the context of your workspace
     - `User` - configures the server in the context of your user
+    - **Note for WSL users**: If you're using VS Code with WSL, you'll need to configure WSL-specific settings. Run the **Preferences: Open Remote Settings** command from the Command Palette (F1) or select the **Remote** tab in the Settings editor. Local User settings are reused in WSL but can be overridden with WSL-specific settings. Configuring MCP servers in the local User settings will not work properly in a WSL environment.
 
 2. Select Features → Chat
 


### PR DESCRIPTION
Adding note to README section "Using with MCP Clients" to resolve a confusion / pain point experienced by a WSL user as reported here in dbt Slack channel #tools-dbt-mcp: https://getdbt.slack.com/archives/C08NGJYD563/p1745436550950899

Borrowed wording from https://code.visualstudio.com/docs/remote/wsl#_wsl-specific-settings

<img width="931" alt="Screenshot 2025-04-25 at 9 33 49 PM" src="https://github.com/user-attachments/assets/956b2b56-8f1d-4256-b338-3c7e3508e617" />