### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP (Model Context Protocol) server provides tools to interact with dbt. Read [this](https://docs.getdbt.com/blog/introducing-dbt-mcp-server) blog to learn more.
 
+<a href="https://glama.ai/mcp/servers/@dbt-labs/dbt-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dbt-labs/dbt-mcp/badge" alt="dbt-mcp MCP server" />
+</a>
+
 ## Architecture
 
 ![architecture diagram of the dbt MCP server](https://github.com/user-attachments/assets/89b8a24b-da7b-4e54-ba48-afceaa56f956)


### PR DESCRIPTION
This PR adds a badge for the [dbt-mcp](https://glama.ai/mcp/servers/@dbt-labs/dbt-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dbt-labs/dbt-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dbt-labs/dbt-mcp/badge" alt="dbt-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.