### PR TITLE
Add support for `uniqueId` in model lookup

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250508-001258.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250508-001258.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Added optional uniqueId parameter to model lookup methods for more precise model identification
+time: 2025-05-08T00:12:58.551298503-04:00

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -49,6 +49,8 @@ class GraphQLQueries:
                         edges {
                             node {
                                 name
+                                alias,
+                                uniqueId,
                                 compiledCode
                                 description
                                 database
@@ -259,20 +261,46 @@ class ModelsFetcher:
 
         return all_edges
 
-    def fetch_model_details(self, model_name: str) -> dict:
-        variables = {
-            "environmentId": self.environment_id,
-            "modelsFilter": {"identifier": model_name},
-            "first": 1,
-        }
-        result = self.api_client.execute_query(
-            GraphQLQueries.GET_MODEL_DETAILS, variables
-        )
-        raise_gql_error(result)
-        edges = result["data"]["environment"]["applied"]["models"]["edges"]
-        if not edges:
-            return {}
-        return edges[0]["node"]
+    def fetch_model_details(self, model_name: str, alias: str = None) -> dict | list[dict]:
+        if alias:
+            # If alias is provided, return up to 10 matching models
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"identifier": alias},
+                "first": 10,  # Limit to 10 models for aliases
+            }
+            result = self.api_client.execute_query(
+                GraphQLQueries.GET_MODEL_DETAILS, variables
+            )
+            raise_gql_error(result)
+            edges = result["data"]["environment"]["applied"]["models"]["edges"]
+            if not edges:
+                return {}  # Return empty dict for consistency when no results are found
+            
+            models = [edge["node"] for edge in edges]
+            
+            # Add a warning if there might be more matches
+            if len(models) == 10:
+                # Include the warning in the first model so the LLM can see it
+                if models and isinstance(models[0], dict):
+                    models[0]["warning"] = f"Found 10 models with alias '{alias}'. There might be more matches that weren't returned."
+            
+            return models
+        else:
+            # Original behavior for model_name
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"identifier": model_name},
+                "first": 1,
+            }
+            result = self.api_client.execute_query(
+                GraphQLQueries.GET_MODEL_DETAILS, variables
+            )
+            raise_gql_error(result)
+            edges = result["data"]["environment"]["applied"]["models"]["edges"]
+            if not edges:
+                return {}
+            return edges[0]["node"]
 
     def fetch_model_parents(self, model_name: str) -> list[dict]:
         variables = {

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -260,12 +260,19 @@ class ModelsFetcher:
 
         return all_edges
 
-    def fetch_model_details(self, model_name: str) -> dict:
-        variables = {
-            "environmentId": self.environment_id,
-            "modelsFilter": {"identifier": model_name},
-            "first": 1,
-        }
+    def fetch_model_details(self, model_name: str, uniqueId: str = None) -> dict:
+        if uniqueId:
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"uniqueIds": [uniqueId]},
+                "first": 1,
+            }
+        else:
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"identifier": model_name},
+                "first": 1,
+            }
         result = self.api_client.execute_query(
             GraphQLQueries.GET_MODEL_DETAILS, variables
         )

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -27,6 +27,7 @@ class GraphQLQueries:
                         edges {
                             node {
                                 name
+                                alias
                                 description
                             }
                         }

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -282,12 +282,19 @@ class ModelsFetcher:
             return {}
         return edges[0]["node"]
 
-    def fetch_model_parents(self, model_name: str) -> list[dict]:
-        variables = {
-            "environmentId": self.environment_id,
-            "modelsFilter": {"identifier": model_name},
-            "first": 1,
-        }
+    def fetch_model_parents(self, model_name: str, uniqueId: str = None) -> list[dict]:
+        if uniqueId:
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"uniqueIds": [uniqueId]},
+                "first": 1,
+            }
+        else:
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"identifier": model_name},
+                "first": 1,
+            }
         result = self.api_client.execute_query(
             GraphQLQueries.GET_MODEL_PARENTS, variables
         )
@@ -297,12 +304,19 @@ class ModelsFetcher:
             return []
         return edges[0]["node"]["parents"]
 
-    def fetch_model_children(self, model_name: str) -> list[dict]:
-        variables = {
-            "environmentId": self.environment_id,
-            "modelsFilter": {"identifier": model_name},
-            "first": 1,
-        }
+    def fetch_model_children(self, model_name: str, uniqueId: str = None) -> list[dict]:
+        if uniqueId:
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"uniqueIds": [uniqueId]},
+                "first": 1,
+            }
+        else:
+            variables = {
+                "environmentId": self.environment_id,
+                "modelsFilter": {"identifier": model_name},
+                "first": 1,
+            }
         result = self.api_client.execute_query(
             GraphQLQueries.GET_MODEL_CHILDREN, variables
         )

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -260,19 +260,17 @@ class ModelsFetcher:
 
         return all_edges
 
-    def fetch_model_details(self, model_name: str, uniqueId: str = None) -> dict:
-        if uniqueId:
-            variables = {
-                "environmentId": self.environment_id,
-                "modelsFilter": {"uniqueIds": [uniqueId]},
-                "first": 1,
-            }
-        else:
-            variables = {
-                "environmentId": self.environment_id,
-                "modelsFilter": {"identifier": model_name},
-                "first": 1,
-            }
+    def fetch_model_details(
+        self, model_name: str, unique_id: str | None = None
+    ) -> dict:
+        model_filters: dict[str, list[str] | str] = (
+            {"uniqueIds": [unique_id]} if unique_id else {"identifier": model_name}
+        )
+        variables = {
+            "environmentId": self.environment_id,
+            "modelsFilter": model_filters,
+            "first": 1,
+        }
         result = self.api_client.execute_query(
             GraphQLQueries.GET_MODEL_DETAILS, variables
         )
@@ -282,19 +280,17 @@ class ModelsFetcher:
             return {}
         return edges[0]["node"]
 
-    def fetch_model_parents(self, model_name: str, uniqueId: str = None) -> list[dict]:
-        if uniqueId:
-            variables = {
-                "environmentId": self.environment_id,
-                "modelsFilter": {"uniqueIds": [uniqueId]},
-                "first": 1,
-            }
-        else:
-            variables = {
-                "environmentId": self.environment_id,
-                "modelsFilter": {"identifier": model_name},
-                "first": 1,
-            }
+    def fetch_model_parents(
+        self, model_name: str, unique_id: str | None = None
+    ) -> list[dict]:
+        model_filters: dict[str, list[str] | str] = (
+            {"uniqueIds": [unique_id]} if unique_id else {"identifier": model_name}
+        )
+        variables = {
+            "environmentId": self.environment_id,
+            "modelsFilter": model_filters,
+            "first": 1,
+        }
         result = self.api_client.execute_query(
             GraphQLQueries.GET_MODEL_PARENTS, variables
         )
@@ -304,19 +300,17 @@ class ModelsFetcher:
             return []
         return edges[0]["node"]["parents"]
 
-    def fetch_model_children(self, model_name: str, uniqueId: str = None) -> list[dict]:
-        if uniqueId:
-            variables = {
-                "environmentId": self.environment_id,
-                "modelsFilter": {"uniqueIds": [uniqueId]},
-                "first": 1,
-            }
-        else:
-            variables = {
-                "environmentId": self.environment_id,
-                "modelsFilter": {"identifier": model_name},
-                "first": 1,
-            }
+    def fetch_model_children(
+        self, model_name: str, unique_id: str | None = None
+    ) -> list[dict]:
+        model_filters: dict[str, list[str] | str] = (
+            {"uniqueIds": [unique_id]} if unique_id else {"identifier": model_name}
+        )
+        variables = {
+            "environmentId": self.environment_id,
+            "modelsFilter": model_filters,
+            "first": 1,
+        }
         result = self.api_client.execute_query(
             GraphQLQueries.GET_MODEL_CHILDREN, variables
         )

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -51,17 +51,17 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_parents"))
-    def get_model_parents(model_name: str) -> list[dict] | str:
+    def get_model_parents(model_name: str, uniqueId: str = None) -> list[dict] | str:
         try:
-            return models_fetcher.fetch_model_parents(model_name)
+            return models_fetcher.fetch_model_parents(model_name, uniqueId)
         except Exception as e:
             logger.error(f"Error getting model parents: {e}")
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_children"))
-    def get_model_children(model_name: str) -> list[dict] | str:
+    def get_model_children(model_name: str, uniqueId: str = None) -> list[dict] | str:
         try:
-            return models_fetcher.fetch_model_children(model_name)
+            return models_fetcher.fetch_model_children(model_name, uniqueId)
         except Exception as e:
             logger.error(f"Error getting model children: {e}")
             return str(e)

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -43,9 +43,9 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_details"))
-    def get_model_details(model_name: str) -> dict | str:
+    def get_model_details(model_name: str, uniqueId: str = None) -> dict | str:
         try:
-            return models_fetcher.fetch_model_details(model_name)
+            return models_fetcher.fetch_model_details(model_name, uniqueId)
         except Exception as e:
             logger.error(f"Error getting model details: {e}")
             return str(e)

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -43,25 +43,25 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_details"))
-    def get_model_details(model_name: str, uniqueId: str = None) -> dict | str:
+    def get_model_details(model_name: str, unique_id: str | None = None) -> dict | str:
         try:
-            return models_fetcher.fetch_model_details(model_name, uniqueId)
+            return models_fetcher.fetch_model_details(model_name, unique_id)
         except Exception as e:
             logger.error(f"Error getting model details: {e}")
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_parents"))
-    def get_model_parents(model_name: str, uniqueId: str = None) -> list[dict] | str:
+    def get_model_parents(model_name: str, unique_id: str | None = None) -> list[dict] | str:
         try:
-            return models_fetcher.fetch_model_parents(model_name, uniqueId)
+            return models_fetcher.fetch_model_parents(model_name, unique_id)
         except Exception as e:
             logger.error(f"Error getting model parents: {e}")
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_children"))
-    def get_model_children(model_name: str, uniqueId: str = None) -> list[dict] | str:
+    def get_model_children(model_name: str, unique_id: str | None = None) -> list[dict] | str:
         try:
-            return models_fetcher.fetch_model_children(model_name, uniqueId)
+            return models_fetcher.fetch_model_children(model_name, unique_id)
         except Exception as e:
             logger.error(f"Error getting model children: {e}")
             return str(e)

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -51,7 +51,9 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_parents"))
-    def get_model_parents(model_name: str, unique_id: str | None = None) -> list[dict] | str:
+    def get_model_parents(
+        model_name: str, unique_id: str | None = None
+    ) -> list[dict] | str:
         try:
             return models_fetcher.fetch_model_parents(model_name, unique_id)
         except Exception as e:
@@ -59,7 +61,9 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
             return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_children"))
-    def get_model_children(model_name: str, unique_id: str | None = None) -> list[dict] | str:
+    def get_model_children(
+        model_name: str, unique_id: str | None = None
+    ) -> list[dict] | str:
         try:
             return models_fetcher.fetch_model_children(model_name, unique_id)
         except Exception as e:

--- a/src/dbt_mcp/prompts/discovery/get_model_children.md
+++ b/src/dbt_mcp/prompts/discovery/get_model_children.md
@@ -1,1 +1,21 @@
-Get the children or downstream models of a specific dbt model.
+<instructions>
+Retrieves the child models (downstream dependencies) of a specific dbt model. These are the models that depend on the specified model.
+
+You can provide either a model_name or a uniqueId, if known, to identify the model. Using uniqueId is more precise and guarantees a unique match, which is especially useful when models might have the same name in different projects.
+</instructions>
+
+<parameters>
+model_name: The name of the dbt model to retrieve children for.
+uniqueId: (Optional) The unique identifier of the model. If provided, this will be used instead of model_name for a more precise lookup. You can get the uniqueId values for all models from the get_all_models() tool.
+</parameters>
+
+<examples>
+1. Getting children for a model by name:
+   get_model_children(model_name="customer_orders")
+
+2. Getting children for a model by uniqueId (more precise):
+   get_model_children(model_name="customer_orders", uniqueId="model.my_project.customer_orders")
+   
+3. Getting children using only uniqueId:
+   get_model_children(model_name="", uniqueId="model.my_project.customer_orders")
+</examples>

--- a/src/dbt_mcp/prompts/discovery/get_model_details.md
+++ b/src/dbt_mcp/prompts/discovery/get_model_details.md
@@ -1,21 +1,20 @@
 <instructions>
-Retrieves information about a specific dbt model. Specifically, it returns the compiled sql, description, column names, column descriptions, and column types.
+Retrieves information about a specific dbt model, including compiled SQL, description, and column details.
 
-You can provide either a model_name or a uniqueId, if known, to identify the model. Using uniqueId is more precise and guarantees a unique match, which is especially useful when models might have the same name or alias in different projects.
+IMPORTANT: Use uniqueId when available.
+- Using uniqueId guarantees the correct model is retrieved
+- Using only model_name may return incorrect results or fail entirely
+- If you obtained models via get_all_models(), you should always use the uniqueId from those results
 </instructions>
 
 <parameters>
-model_name: The name of the dbt model to retrieve details for.
-uniqueId: (Optional) The unique identifier of the model. If provided, this will be used instead of model_name for a more precise lookup. You can get the uniqueId from the get_all_models() tool.
+uniqueId: The unique identifier of the model (format: "model.project_name.model_name"). STRONGLY RECOMMENDED when available.
+model_name: The name of the dbt model. Only use this when uniqueId is unavailable.
 </parameters>
 
 <examples>
-1. Getting details for a model by name:
-   get_model_details(model_name="customer_orders")
-
-2. Getting details for a model by uniqueId (more precise):
-   get_model_details(model_name="customer_orders", uniqueId="model.my_project.customer_orders")
+1. PREFERRED METHOD - Using uniqueId (always use this when available):
+   get_model_details(uniqueId="model.my_project.customer_orders")
    
-3. Getting details using only uniqueId:
-   get_model_details(model_name="", uniqueId="model.my_project.customer_orders")
-</examples>
+2. FALLBACK METHOD - Using only model_name (only when uniqueId is unknown):
+   get_model_details(model_name="customer_orders")

--- a/src/dbt_mcp/prompts/discovery/get_model_details.md
+++ b/src/dbt_mcp/prompts/discovery/get_model_details.md
@@ -1,7 +1,18 @@
 <instructions>
 Retrieves information about a specific dbt model. Specifically, it returns the compiled sql, description, column names, column descriptions, and column types.
+
+If the model has an alias that differs from its name, you can provide the alias parameter to ensure the correct model is found. When using the alias parameter, the tool may return multiple models if more than one model shares the same alias.
 </instructions>
 
 <parameters>
 model_name: The name of the dbt model to retrieve details for.
+alias: (Optional) The alias of the model, if different from its name. Use this when the model is referenced by an alias in queries. If provided, may return multiple models that share the same alias.
 </parameters>
+
+<examples>
+1. Getting details for a model by name:
+   get_model_details(model_name="customer_orders")
+
+2. Getting details for a model with an alias:
+   get_model_details(model_name="customer_orders", alias="cust_orders")
+</examples>

--- a/src/dbt_mcp/prompts/discovery/get_model_details.md
+++ b/src/dbt_mcp/prompts/discovery/get_model_details.md
@@ -1,18 +1,21 @@
 <instructions>
 Retrieves information about a specific dbt model. Specifically, it returns the compiled sql, description, column names, column descriptions, and column types.
 
-If the model has an alias that differs from its name, you can provide the alias parameter to ensure the correct model is found. When using the alias parameter, the tool may return multiple models if more than one model shares the same alias.
+You can provide either a model_name or a uniqueId, if known, to identify the model. Using uniqueId is more precise and guarantees a unique match, which is especially useful when models might have the same name or alias in different projects.
 </instructions>
 
 <parameters>
 model_name: The name of the dbt model to retrieve details for.
-alias: (Optional) The alias of the model, if different from its name. Use this when the model is referenced by an alias in queries. If provided, may return multiple models that share the same alias.
+uniqueId: (Optional) The unique identifier of the model. If provided, this will be used instead of model_name for a more precise lookup. You can get the uniqueId from the get_all_models() tool.
 </parameters>
 
 <examples>
 1. Getting details for a model by name:
    get_model_details(model_name="customer_orders")
 
-2. Getting details for a model with an alias:
-   get_model_details(model_name="customer_orders", alias="cust_orders")
+2. Getting details for a model by uniqueId (more precise):
+   get_model_details(model_name="customer_orders", uniqueId="model.my_project.customer_orders")
+   
+3. Getting details using only uniqueId:
+   get_model_details(model_name="", uniqueId="model.my_project.customer_orders")
 </examples>

--- a/src/dbt_mcp/prompts/discovery/get_model_parents.md
+++ b/src/dbt_mcp/prompts/discovery/get_model_parents.md
@@ -1,1 +1,21 @@
-Get the parents of a specific dbt model.
+<instructions>
+Retrieves the parent models of a specific dbt model. These are the models that the specified model depends on.
+
+You can provide either a model_name or a uniqueId, if known, to identify the model. Using uniqueId is more precise and guarantees a unique match, which is especially useful when models might have the same name in different projects.
+</instructions>
+
+<parameters>
+model_name: The name of the dbt model to retrieve parents for.
+uniqueId: (Optional) The unique identifier of the model. If provided, this will be used instead of model_name for a more precise lookup. You can get the uniqueId values for all models from the get_all_models() tool.
+</parameters>
+
+<examples>
+1. Getting parents for a model by name:
+   get_model_parents(model_name="customer_orders")
+
+2. Getting parents for a model by uniqueId (more precise):
+   get_model_parents(model_name="customer_orders", uniqueId="model.my_project.customer_orders")
+   
+3. Getting parents using only uniqueId:
+   get_model_parents(model_name="", uniqueId="model.my_project.customer_orders")
+</examples>

--- a/tests/integration/discovery/test_discovery.py
+++ b/tests/integration/discovery/test_discovery.py
@@ -94,3 +94,52 @@ def test_fetch_model_parents(models_fetcher: ModelsFetcher):
 
     # Validate filtered results
     assert len(filtered_results) > 0
+
+
+def test_fetch_model_parents_with_uniqueId(models_fetcher: ModelsFetcher):
+    models = models_fetcher.fetch_models()
+    model = models[0]
+    model_name = model["name"]
+    unique_id = model["uniqueId"]
+
+    # Fetch by name
+    results_by_name = models_fetcher.fetch_model_parents(model_name)
+    
+    # Fetch by uniqueId
+    results_by_uniqueId = models_fetcher.fetch_model_parents(model_name, unique_id)
+    
+    # Validate that both methods return the same result
+    assert len(results_by_name) == len(results_by_uniqueId)
+    if len(results_by_name) > 0:
+        # Compare the first parent's name if there are any parents
+        assert results_by_name[0]["name"] == results_by_uniqueId[0]["name"]
+
+
+def test_fetch_model_children(models_fetcher: ModelsFetcher):
+    models = models_fetcher.fetch_models()
+    model_name = models[0]["name"]
+
+    # Fetch filtered results
+    filtered_results = models_fetcher.fetch_model_children(model_name)
+
+    # Validate filtered results
+    assert isinstance(filtered_results, list)
+
+
+def test_fetch_model_children_with_uniqueId(models_fetcher: ModelsFetcher):
+    models = models_fetcher.fetch_models()
+    model = models[0]
+    model_name = model["name"]
+    unique_id = model["uniqueId"]
+
+    # Fetch by name
+    results_by_name = models_fetcher.fetch_model_children(model_name)
+    
+    # Fetch by uniqueId
+    results_by_uniqueId = models_fetcher.fetch_model_children(model_name, unique_id)
+    
+    # Validate that both methods return the same result
+    assert len(results_by_name) == len(results_by_uniqueId)
+    if len(results_by_name) > 0:
+        # Compare the first child's name if there are any children
+        assert results_by_name[0]["name"] == results_by_uniqueId[0]["name"]

--- a/tests/integration/discovery/test_discovery.py
+++ b/tests/integration/discovery/test_discovery.py
@@ -68,6 +68,23 @@ def test_fetch_model_details(models_fetcher: ModelsFetcher):
     assert len(filtered_results) > 0
 
 
+def test_fetch_model_details_with_uniqueId(models_fetcher: ModelsFetcher):
+    models = models_fetcher.fetch_models()
+    model = models[0]
+    model_name = model["name"]
+    unique_id = model["uniqueId"]
+
+    # Fetch by name
+    results_by_name = models_fetcher.fetch_model_details(model_name)
+    
+    # Fetch by uniqueId
+    results_by_uniqueId = models_fetcher.fetch_model_details(model_name, unique_id)
+    
+    # Validate that both methods return the same result
+    assert results_by_name["uniqueId"] == results_by_uniqueId["uniqueId"]
+    assert results_by_name["name"] == results_by_uniqueId["name"]
+
+
 def test_fetch_model_parents(models_fetcher: ModelsFetcher):
     models = models_fetcher.fetch_models()
     model_name = models[0]["name"]

--- a/tests/integration/discovery/test_discovery.py
+++ b/tests/integration/discovery/test_discovery.py
@@ -76,10 +76,10 @@ def test_fetch_model_details_with_uniqueId(models_fetcher: ModelsFetcher):
 
     # Fetch by name
     results_by_name = models_fetcher.fetch_model_details(model_name)
-    
+
     # Fetch by uniqueId
     results_by_uniqueId = models_fetcher.fetch_model_details(model_name, unique_id)
-    
+
     # Validate that both methods return the same result
     assert results_by_name["uniqueId"] == results_by_uniqueId["uniqueId"]
     assert results_by_name["name"] == results_by_uniqueId["name"]
@@ -104,10 +104,10 @@ def test_fetch_model_parents_with_uniqueId(models_fetcher: ModelsFetcher):
 
     # Fetch by name
     results_by_name = models_fetcher.fetch_model_parents(model_name)
-    
+
     # Fetch by uniqueId
     results_by_uniqueId = models_fetcher.fetch_model_parents(model_name, unique_id)
-    
+
     # Validate that both methods return the same result
     assert len(results_by_name) == len(results_by_uniqueId)
     if len(results_by_name) > 0:
@@ -134,10 +134,10 @@ def test_fetch_model_children_with_uniqueId(models_fetcher: ModelsFetcher):
 
     # Fetch by name
     results_by_name = models_fetcher.fetch_model_children(model_name)
-    
+
     # Fetch by uniqueId
     results_by_uniqueId = models_fetcher.fetch_model_children(model_name, unique_id)
-    
+
     # Validate that both methods return the same result
     assert len(results_by_name) == len(results_by_uniqueId)
     if len(results_by_name) > 0:


### PR DESCRIPTION
# Description
This PR adds an optional `uniqueId` parameter to model lookup methods for more precise model identification. When provided, the `uniqueId` parameter creates a filter with `{"uniqueIds": [uniqueId]}` instead of `{"identifier": _model_name_}`

# Problem
The current implementation only allows looking up models by _name_ using the `identifier` filter in the GraphQL API. Due to how the Discovery API treats aliased models, when a model has an alias that differs from its name, using the model name in the `identifier` filter will return an empty result even if the model exists. This creates inconsistent behavior when consumers try to get details for models based on names mentioned by users or by what it finds in the existing `get_models()` tool.

# Solution
This PR includes a set of backward-compatible solutions:
- Expanded the information returned by several `discovery.client` methods to include the `uniqueId` values.
- Added optional `uniqueId` parameter to `fetch_model_details()`, `fetch_model_parents()`, and `fetch_model_children()`
- Updated tool functions to accept the new `uniqueId` parameter and pass it to the underlying methods
- Enhanced the prompt files to explain the new argument and provide clear examples for LLMs

# Benefits
- More precise model lookups using `uniqueId` after initial discovery
- Consistent way to reference models regardless of naming/aliasing
- Fewer failed lookups when models have aliases different from their names

# Tests
- Added missing tests for `fetch_model_children` which didn't previously exist. (This is a possible oversight from PR #101) 
- Added tests for methods with the `uniqueId` parameter to verify lookups work correctly