### PR TITLE
Refactor config for modularity

### DIFF
--- a/.changes/unreleased/Under the Hood-20250519-142811.yaml
+++ b/.changes/unreleased/Under the Hood-20250519-142811.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Refactor config for modularity
+time: 2025-05-19T14:28:11.906312-05:00

--- a/evals/semantic_layer/test_eval_semantic_layer.py
+++ b/evals/semantic_layer/test_eval_semantic_layer.py
@@ -21,7 +21,8 @@ from dbt_mcp.semantic_layer.types import OrderByParam, QueryMetricsSuccess
 LLM_MODEL = "gpt-4o-mini"
 llm_client = OpenAI()
 config = load_config()
-semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+assert config.semantic_layer_config
+semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
 
 
 async def expect_metadata_tool_call(

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -2,11 +2,11 @@ import subprocess
 
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config import Config
+from dbt_mcp.config.config import DbtCliConfig
 from dbt_mcp.prompts.prompts import get_prompt
 
 
-def register_dbt_cli_tools(dbt_mcp: FastMCP, config: Config) -> None:
+def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
     def _run_dbt_command(command: list[str]) -> str:
         # Commands that should always be quiet to reduce output verbosity
         verbose_commands = ["build", "compile", "docs", "parse", "run", "test"]
@@ -19,7 +19,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: Config) -> None:
             full_command = [main_command, "--quiet", *command_args]
 
         process = subprocess.Popen(
-            args=[config.dbt_command, *full_command],
+            args=[config.dbt_path, *full_command],
             cwd=config.project_dir,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -2,25 +2,21 @@ import logging
 
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config import Config
+from dbt_mcp.config.config import DiscoveryConfig
 from dbt_mcp.discovery.client import MetadataAPIClient, ModelsFetcher
 from dbt_mcp.prompts.prompts import get_prompt
 
 logger = logging.getLogger(__name__)
 
 
-def register_discovery_tools(dbt_mcp: FastMCP, config: Config) -> None:
-    if not config.host or not config.token or not config.prod_environment_id:
-        raise ValueError(
-            "Host, token, and environment ID are required to use discovery tools. To disable discovery tools, set DISABLE_DISCOVERY=true in your environment."
-        )
+def register_discovery_tools(dbt_mcp: FastMCP, config: DiscoveryConfig) -> None:
     api_client = MetadataAPIClient(
         host=config.host,
         token=config.token,
         multicell_account_prefix=config.multicell_account_prefix,
     )
     models_fetcher = ModelsFetcher(
-        api_client=api_client, environment_id=config.prod_environment_id
+        api_client=api_client, environment_id=config.environment_id
     )
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_mart_models"))

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -29,14 +29,14 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 dbt_mcp = FastMCP("dbt", lifespan=app_lifespan)
 
-if config.semantic_layer_enabled:
-    register_sl_tools(dbt_mcp, config)
+if config.semantic_layer_config:
+    register_sl_tools(dbt_mcp, config.semantic_layer_config)
 
-if config.discovery_enabled:
-    register_discovery_tools(dbt_mcp, config)
+if config.discovery_config:
+    register_discovery_tools(dbt_mcp, config.discovery_config)
 
-if config.dbt_cli_enabled:
-    register_dbt_cli_tools(dbt_mcp, config)
+if config.dbt_cli_config:
+    register_dbt_cli_tools(dbt_mcp, config.dbt_cli_config)
 
-if config.remote_enabled:
-    asyncio.run(register_remote_tools(dbt_mcp, config))
+if config.remote_config:
+    asyncio.run(register_remote_tools(dbt_mcp, config.remote_config))

--- a/src/dbt_mcp/remote/tools.py
+++ b/src/dbt_mcp/remote/tools.py
@@ -25,7 +25,7 @@ from pydantic import Field, ValidationError, WithJsonSchema, create_model
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from dbt_mcp.config.config import Config
+from dbt_mcp.config.config import RemoteConfig
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,9 @@ def get_remote_tool_fn_metadata(tool: RemoteTool) -> FuncMetadata:
     )
 
 
-def _get_remote_tools(config: Config, headers: dict[str, str]) -> list[RemoteTool]:
+def _get_remote_tools(
+    config: RemoteConfig, headers: dict[str, str]
+) -> list[RemoteTool]:
     try:
         with Client(base_url=config.remote_mcp_base_url, headers=headers) as client:
             list_tools_response = JSONRPCResponse.model_validate_json(
@@ -68,9 +70,7 @@ def _get_remote_tools(config: Config, headers: dict[str, str]) -> list[RemoteToo
         return []
 
 
-async def register_remote_tools(dbt_mcp: FastMCP, config: Config) -> None:
-    assert config.dev_environment_id is not None
-    assert config.user_id is not None
+async def register_remote_tools(dbt_mcp: FastMCP, config: RemoteConfig) -> None:
     headers = {
         "Authorization": f"Bearer {config.token}",
         "x-dbt-prod-environment-id": str(config.prod_environment_id),

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -4,7 +4,7 @@ from time import time
 from dbtsl.api.shared.query_params import GroupByParam
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config import Config
+from dbt_mcp.config.config import SemanticLayerConfig
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.semantic_layer.client import get_semantic_layer_fetcher
 from dbt_mcp.semantic_layer.types import (
@@ -18,14 +18,7 @@ from dbt_mcp.semantic_layer.types import (
 logger = logging.getLogger(__name__)
 
 
-def register_sl_tools(dbt_mcp: FastMCP, config: Config) -> None:
-    host = config.host
-    if not host or not config.token or not config.prod_environment_id:
-        raise ValueError(
-            "Host, token, and environment ID are required to use semantic layer tools. "
-            + "To disable semantic layer tools, "
-            + "set DISABLE_SEMANTIC_LAYER=true in your environment."
-        )
+def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
     semantic_layer_fetcher = get_semantic_layer_fetcher(config)
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/list_metrics"))

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -1,0 +1,33 @@
+from dbt_mcp.config.config import (
+    Config,
+    DbtCliConfig,
+    DiscoveryConfig,
+    RemoteConfig,
+    SemanticLayerConfig,
+)
+
+mock_config = Config(
+    remote_config=RemoteConfig(
+        prod_environment_id=1,
+        dev_environment_id=1,
+        user_id=1,
+        token="token",
+        remote_mcp_base_url="http://localhost/mcp/sse",
+    ),
+    dbt_cli_config=DbtCliConfig(
+        project_dir="/test/project",
+        dbt_path="/path/to/dbt",
+    ),
+    discovery_config=DiscoveryConfig(
+        host="localhost",
+        token="token",
+        multicell_account_prefix=None,
+        environment_id=1,
+    ),
+    semantic_layer_config=SemanticLayerConfig(
+        host="localhost",
+        service_token="token",
+        multicell_account_prefix=None,
+        prod_environment_id=1,
+    ),
+)

--- a/tests/unit/dbt_cli/test_cli_integration.py
+++ b/tests/unit/dbt_cli/test_cli_integration.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-
-from dbt_mcp.config.config import Config
+from tests.mocks.config import mock_config
 
 
 class TestDbtCliIntegration(unittest.TestCase):
@@ -22,21 +21,6 @@ class TestDbtCliIntegration(unittest.TestCase):
 
         # Create a mock FastMCP and Config
         mock_fastmcp = MagicMock()
-        config = Config(
-            host="localhost",
-            prod_environment_id=1,
-            dev_environment_id=1,
-            user_id=1,
-            token="token",
-            project_dir="/test/project",
-            dbt_cli_enabled=True,
-            semantic_layer_enabled=True,
-            discovery_enabled=True,
-            remote_enabled=True,
-            dbt_command="/path/to/dbt",  # Custom dbt path
-            multicell_account_prefix=None,
-            remote_mcp_base_url="http://localhost/mcp/sse",
-        )
 
         # Patch the tool decorator to capture functions
         tools = {}
@@ -51,7 +35,7 @@ class TestDbtCliIntegration(unittest.TestCase):
         mock_fastmcp.tool = mock_tool_decorator
 
         # Register the tools
-        register_dbt_cli_tools(mock_fastmcp, config)
+        register_dbt_cli_tools(mock_fastmcp, mock_config.dbt_cli_config)
 
         # Test cases for different command types
         test_cases = [

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-
-from dbt_mcp.config.config import Config
+from tests.mocks.config import mock_config
 
 
 class TestDbtCliTools(unittest.TestCase):
@@ -18,21 +17,6 @@ class TestDbtCliTools(unittest.TestCase):
 
         # Create a mock FastMCP and Config
         mock_fastmcp = MagicMock()
-        config = Config(
-            host="localhost",
-            prod_environment_id=1,
-            dev_environment_id=1,
-            user_id=1,
-            token="token",
-            project_dir="/test/project",
-            dbt_cli_enabled=True,
-            semantic_layer_enabled=True,
-            discovery_enabled=True,
-            remote_enabled=True,
-            dbt_command="dbt",
-            multicell_account_prefix=None,
-            remote_mcp_base_url="http://localhost/mcp/sse",
-        )
 
         # Capture the registered tools
         tools = {}
@@ -48,7 +32,7 @@ class TestDbtCliTools(unittest.TestCase):
         mock_fastmcp.tool = mock_tool_decorator
 
         # Register the tools
-        register_dbt_cli_tools(mock_fastmcp, config)
+        register_dbt_cli_tools(mock_fastmcp, mock_config.dbt_cli_config)
 
         # Test each verbose command (build, compile, docs, parse, run, test)
         verbose_commands = ["build", "compile", "docs", "parse", "run", "test"]
@@ -64,11 +48,13 @@ class TestDbtCliTools(unittest.TestCase):
             if command == "docs":
                 # For docs command, check if ["docs", "generate"] gets transformed to ["docs", "--quiet", "generate"]
                 args_list = mock_popen.call_args.kwargs.get("args")
-                self.assertEqual(args_list, ["dbt", "docs", "--quiet", "generate"])
+                self.assertEqual(
+                    args_list, ["/path/to/dbt", "docs", "--quiet", "generate"]
+                )
             else:
                 # Check if the --quiet flag was added
                 args_list = mock_popen.call_args.kwargs.get("args")
-                self.assertEqual(args_list, ["dbt", command, "--quiet"])
+                self.assertEqual(args_list, ["/path/to/dbt", command, "--quiet"])
 
     @patch("subprocess.Popen")
     def test_non_verbose_commands_not_modified(self, mock_popen):
@@ -82,21 +68,6 @@ class TestDbtCliTools(unittest.TestCase):
 
         # Create a mock FastMCP and Config
         mock_fastmcp = MagicMock()
-        config = Config(
-            host="localhost",
-            prod_environment_id=1,
-            dev_environment_id=1,
-            user_id=1,
-            token="token",
-            project_dir="/test/project",
-            dbt_cli_enabled=True,
-            semantic_layer_enabled=True,
-            discovery_enabled=True,
-            remote_enabled=True,
-            dbt_command="dbt",
-            multicell_account_prefix=None,
-            remote_mcp_base_url="http://localhost/mcp/sse",
-        )
 
         # Capture the registered tools
         tools = {}
@@ -112,7 +83,7 @@ class TestDbtCliTools(unittest.TestCase):
         mock_fastmcp.tool = mock_tool_decorator
 
         # Register the tools
-        register_dbt_cli_tools(mock_fastmcp, config)
+        register_dbt_cli_tools(mock_fastmcp, mock_config.dbt_cli_config)
 
         # Test "list" (non-verbose) command
         mock_popen.reset_mock()
@@ -120,7 +91,7 @@ class TestDbtCliTools(unittest.TestCase):
 
         # Check that --quiet flag was NOT added
         args_list = mock_popen.call_args.kwargs.get("args")
-        self.assertEqual(args_list, ["dbt", "list"])
+        self.assertEqual(args_list, ["/path/to/dbt", "list"])
 
     @patch("subprocess.Popen")
     def test_show_command_correctly_formatted(self, mock_popen):
@@ -134,21 +105,6 @@ class TestDbtCliTools(unittest.TestCase):
 
         # Create a mock FastMCP and Config
         mock_fastmcp = MagicMock()
-        config = Config(
-            host="localhost",
-            prod_environment_id=1,
-            dev_environment_id=1,
-            user_id=1,
-            token="token",
-            project_dir="/test/project",
-            dbt_cli_enabled=True,
-            semantic_layer_enabled=True,
-            discovery_enabled=True,
-            remote_enabled=True,
-            dbt_command="dbt",
-            multicell_account_prefix=None,
-            remote_mcp_base_url="http://localhost/mcp/sse",
-        )
 
         # Capture the registered tools
         tools = {}
@@ -164,7 +120,7 @@ class TestDbtCliTools(unittest.TestCase):
         mock_fastmcp.tool = mock_tool_decorator
 
         # Register the tools
-        register_dbt_cli_tools(mock_fastmcp, config)
+        register_dbt_cli_tools(mock_fastmcp, mock_config.dbt_cli_config)
 
         # Test show command with and without limit
         mock_popen.reset_mock()
@@ -175,7 +131,7 @@ class TestDbtCliTools(unittest.TestCase):
         self.assertEqual(
             args_list,
             [
-                "dbt",
+                "/path/to/dbt",
                 "show",
                 "--inline",
                 "SELECT * FROM my_model",
@@ -194,7 +150,7 @@ class TestDbtCliTools(unittest.TestCase):
         self.assertEqual(
             args_list,
             [
-                "dbt",
+                "/path/to/dbt",
                 "show",
                 "--inline",
                 "SELECT * FROM my_model",


### PR DESCRIPTION
This PR refactors the Config class so that each tool type has its own config class. This helps with modularity, and it makes it more apparent which fields are required for each type of tool. I tested each tool type in Claude.