### PR TITLE
Enable remote tools in production

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250520-130237.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250520-130237.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Enable remote tools in production
+time: 2025-05-20T13:02:37.216585-05:00

--- a/evals/semantic_layer/test_eval_semantic_layer.py
+++ b/evals/semantic_layer/test_eval_semantic_layer.py
@@ -153,7 +153,6 @@ def initial_messages(content: str) -> ResponseInputParam:
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_explicit_tool_request(content: str, expected_tool: str):
     response = llm_client.responses.create(
         model=LLM_MODEL,
@@ -166,7 +165,6 @@ async def test_explicit_tool_request(content: str, expected_tool: str):
     assert response.output[0].name == expected_tool
 
 
-@pytest.mark.asyncio
 async def test_semantic_layer_fulfillment_query():
     tools = await get_tools()
     messages = initial_messages(
@@ -190,7 +188,6 @@ async def test_semantic_layer_fulfillment_query():
     )
 
 
-@pytest.mark.asyncio
 async def test_semantic_layer_food_revenue_per_month():
     tools = await get_tools()
     messages = initial_messages(
@@ -239,7 +236,6 @@ async def test_semantic_layer_food_revenue_per_month():
     )
 
 
-@pytest.mark.asyncio
 async def test_semantic_layer_what_percentage_of_orders_were_large():
     tools = await get_tools()
     messages = initial_messages(

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -28,11 +28,12 @@ class DbtCliConfig:
 
 @dataclass
 class RemoteConfig:
+    multicell_account_prefix: str | None
+    host: str
     user_id: int
     dev_environment_id: int
     prod_environment_id: int
     token: str
-    remote_mcp_base_url: str
 
 
 @dataclass
@@ -119,14 +120,12 @@ def load_config() -> Config:
         and host
     ):
         remote_config = RemoteConfig(
+            multicell_account_prefix=multicell_account_prefix,
             user_id=int(user_id),
             token=token,
             dev_environment_id=int(dev_environment_id),
             prod_environment_id=actual_prod_environment_id,
-            remote_mcp_base_url=(
-                "http://" if host and host.startswith("localhost") else "https://"
-            )
-            + f"{host}/mcp",
+            host=host,
         )
 
     dbt_cli_config = None

--- a/tests/integration/remote/test_remote.py
+++ b/tests/integration/remote/test_remote.py
@@ -1,11 +1,9 @@
-import pytest
 from mcp.server.fastmcp import FastMCP
 
 from dbt_mcp.config.config import load_config
 from dbt_mcp.remote.tools import register_remote_tools
 
 
-@pytest.mark.asyncio
 async def test_remote_tool_execute_sql():
     config = load_config()
     dbt_mcp = FastMCP("Test")
@@ -17,7 +15,6 @@ async def test_remote_tool_execute_sql():
     assert "1" in result[0].text
 
 
-@pytest.mark.asyncio
 async def test_remote_tool_text_to_sql():
     config = load_config()
     dbt_mcp = FastMCP("Test")

--- a/tests/integration/remote/test_remote.py
+++ b/tests/integration/remote/test_remote.py
@@ -1,15 +1,27 @@
 import pytest
-from dbt_mcp.remote.tools import register_remote_tools
-from dbt_mcp.config.config import load_config
 from mcp.server.fastmcp import FastMCP
+
+from dbt_mcp.config.config import load_config
+from dbt_mcp.remote.tools import register_remote_tools
 
 
 @pytest.mark.asyncio
-async def test_remote_tool():
+async def test_remote_tool_execute_sql():
     config = load_config()
     dbt_mcp = FastMCP("Test")
-    await register_remote_tools(dbt_mcp, config)
-    assert "echo_tool" in [t.name for t in await dbt_mcp.list_tools()]
-    result = await dbt_mcp.call_tool("echo_tool", {"message": "Hello, world!"})
+    await register_remote_tools(dbt_mcp, config.remote_config)
+    tools = await dbt_mcp.list_tools()
+    print(tools)
+    result = await dbt_mcp.call_tool("execute_sql", {"sql": "SELECT 1"})
     assert len(result) == 1
-    assert "Hello, world!" in result[0].text
+    assert "1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_remote_tool_text_to_sql():
+    config = load_config()
+    dbt_mcp = FastMCP("Test")
+    await register_remote_tools(dbt_mcp, config.remote_config)
+    result = await dbt_mcp.call_tool("text_to_sql", {"text": "SELECT 1"})
+    assert len(result) == 1
+    assert "SELECT 1" in result[0].text

--- a/tests/integration/semantic_layer/test_semantic_layer.py
+++ b/tests/integration/semantic_layer/test_semantic_layer.py
@@ -8,20 +8,20 @@ config = load_config()
 
 
 def test_semantic_layer_list_metrics():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     metrics = semantic_layer_fetcher.list_metrics()
     assert len(metrics) > 0
 
 
 def test_semantic_layer_list_dimensions():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     metrics = semantic_layer_fetcher.list_metrics()
     dimensions = semantic_layer_fetcher.get_dimensions(metrics=[metrics[0].name])
     assert len(dimensions) > 0
 
 
 def test_semantic_layer_query_metrics():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     result = semantic_layer_fetcher.query_metrics(
         metrics=["revenue"],
         group_by=[
@@ -36,7 +36,7 @@ def test_semantic_layer_query_metrics():
 
 
 def test_semantic_layer_query_metrics_invalid_query():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     result = semantic_layer_fetcher.query_metrics(
         metrics=["food_revenue"],
         group_by=[
@@ -67,7 +67,7 @@ def test_semantic_layer_query_metrics_invalid_query():
 
 
 def test_semantic_layer_query_metrics_with_group_by_grain():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     result = semantic_layer_fetcher.query_metrics(
         metrics=["revenue"],
         group_by=[
@@ -82,7 +82,7 @@ def test_semantic_layer_query_metrics_with_group_by_grain():
 
 
 def test_semantic_layer_query_metrics_with_order_by():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     result = semantic_layer_fetcher.query_metrics(
         metrics=["revenue"],
         group_by=[
@@ -98,14 +98,14 @@ def test_semantic_layer_query_metrics_with_order_by():
 
 
 def test_semantic_layer_query_metrics_with_misspellings():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     result = semantic_layer_fetcher.query_metrics(["revehue"])
     assert result is not None
     assert "revenue" in result
 
 
 def test_semantic_layer_get_entities():
-    semantic_layer_fetcher = get_semantic_layer_fetcher(config)
+    semantic_layer_fetcher = get_semantic_layer_fetcher(config.semantic_layer_config)
     entities = semantic_layer_fetcher.get_entities(
         metrics=["count_dbt_copilot_requests"]
     )

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -8,11 +8,12 @@ from dbt_mcp.config.config import (
 
 mock_config = Config(
     remote_config=RemoteConfig(
+        multicell_account_prefix=None,
         prod_environment_id=1,
         dev_environment_id=1,
         user_id=1,
         token="token",
-        remote_mcp_base_url="http://localhost/mcp/sse",
+        host="http://localhost/mcp",
     ),
     dbt_cli_config=DbtCliConfig(
         project_dir="/test/project",


### PR DESCRIPTION
Up until now, remote tools have only worked in development. This PR allows them to work in production by updating how the URL is handled.