### PR TITLE
Usage tracking scaffolding

### DIFF
--- a/.changes/unreleased/Under the Hood-20250521-150418.yaml
+++ b/.changes/unreleased/Under the Hood-20250521-150418.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Usage tracking scaffolding
+time: 2025-05-21T15:04:18.065176-05:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "mcp[cli]==1.6.0",
   "pandas==2.2.3",
   "python-dotenv==1.0.1",
+  "pyyaml>=6.0.2",
   "requests==2.32.3",
 ]
 [dependency-groups]
@@ -32,6 +33,7 @@ dev = [
   "pytest>=8.3.5",
   "openai>=1.71.0",
   "pyarrow-stubs>=19.1",
+  "types-pyyaml>=6.0.12.20250516",
 ]
 
 [project.urls]

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -21,47 +21,27 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: DiscoveryConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_mart_models"))
     def get_mart_models() -> list[dict] | str:
-        try:
-            mart_models = models_fetcher.fetch_models(
-                model_filter={"modelingLayer": "marts"}
-            )
-            return [m for m in mart_models if m["name"] != "metricflow_time_spine"]
-        except Exception as e:
-            logger.error(f"Error getting mart models: {e}")
-            return str(e)
+        mart_models = models_fetcher.fetch_models(
+            model_filter={"modelingLayer": "marts"}
+        )
+        return [m for m in mart_models if m["name"] != "metricflow_time_spine"]
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_all_models"))
     def get_all_models() -> list[dict] | str:
-        try:
-            return models_fetcher.fetch_models()
-        except Exception as e:
-            logger.error(f"Error getting all models: {e}")
-            return str(e)
+        return models_fetcher.fetch_models()
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_details"))
     def get_model_details(model_name: str, unique_id: str | None = None) -> dict | str:
-        try:
-            return models_fetcher.fetch_model_details(model_name, unique_id)
-        except Exception as e:
-            logger.error(f"Error getting model details: {e}")
-            return str(e)
+        return models_fetcher.fetch_model_details(model_name, unique_id)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_parents"))
     def get_model_parents(
         model_name: str, unique_id: str | None = None
     ) -> list[dict] | str:
-        try:
-            return models_fetcher.fetch_model_parents(model_name, unique_id)
-        except Exception as e:
-            logger.error(f"Error getting model parents: {e}")
-            return str(e)
+        return models_fetcher.fetch_model_parents(model_name, unique_id)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_children"))
     def get_model_children(
         model_name: str, unique_id: str | None = None
     ) -> list[dict] | str:
-        try:
-            return models_fetcher.fetch_model_children(model_name, unique_id)
-        except Exception as e:
-            logger.error(f"Error getting model children: {e}")
-            return str(e)
+        return models_fetcher.fetch_model_children(model_name, unique_id)

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -1,15 +1,24 @@
 import asyncio
 import logging
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Sequence
+from contextlib import (
+    asynccontextmanager,
+)
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import (
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+)
 
 from dbt_mcp.config.config import load_config
 from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
 from dbt_mcp.discovery.tools import register_discovery_tools
 from dbt_mcp.remote.tools import register_remote_tools
 from dbt_mcp.semantic_layer.tools import register_sl_tools
+from dbt_mcp.tracking.tracking import UsageTracker
 
 config = load_config()
 logger = logging.getLogger(__name__)
@@ -27,7 +36,45 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
         logger.info("Shutting down MCP server")
 
 
-dbt_mcp = FastMCP("dbt", lifespan=app_lifespan)
+class DbtMCP(FastMCP):
+    def __init__(self, usage_tracker: UsageTracker, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.usage_tracker = usage_tracker
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        logger.info(f"Calling tool: {name}")
+        result = None
+        try:
+            result = await super().call_tool(
+                name,
+                arguments,
+            )
+        except Exception as e:
+            logger.error(f"Error calling tool: {name} with arguments: {arguments}: {e}")
+            self.usage_tracker.emit_tool_called_event(
+                config=config.tracking_config,
+                tool_name=name,
+                arguments=arguments,
+                error_message=str(e),
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=str(e),
+                )
+            ]
+        self.usage_tracker.emit_tool_called_event(
+            config=config.tracking_config,
+            tool_name=name,
+            arguments=arguments,
+            error_message=None,
+        )
+        return result
+
+
+dbt_mcp = DbtMCP(usage_tracker=UsageTracker(), name="dbt", lifespan=app_lifespan)
 
 if config.semantic_layer_config:
     register_sl_tools(dbt_mcp, config.semantic_layer_config)

--- a/src/dbt_mcp/remote/tools.py
+++ b/src/dbt_mcp/remote/tools.py
@@ -124,21 +124,14 @@ async def register_remote_tools(dbt_mcp: FastMCP, config: RemoteConfig) -> None:
                             tool_call_jsonrpc_response.result
                         )
                     except ValidationError as e:
-                        return [
-                            TextContent(
-                                type="text",
-                                text=f"Failed to parse tool response for {tool_name}: "
-                                + f"{e}",
-                            )
-                        ]
+                        raise ValueError(
+                            f"Failed to parse tool response for {tool_name}: {e}"
+                        ) from e
                     if tool_call_result.isError:
-                        return [
-                            TextContent(
-                                type="text",
-                                text=f"Tool {tool_name} reported an error: "
-                                + f"{tool_call_result.content}",
-                            )
-                        ]
+                        raise ValueError(
+                            f"Tool {tool_name} reported an error: "
+                            + f"{tool_call_result.content}"
+                        )
                     return tool_call_result.content
 
             return tool_function

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -23,39 +23,27 @@ def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/list_metrics"))
     def list_metrics() -> list[MetricToolResponse] | str:
-        try:
-            start_time = time()
-            result = semantic_layer_fetcher.list_metrics()
-            end_time = time()
-            logger.info(f"list_metrics took {end_time - start_time} seconds")
-            return result
-        except Exception as e:
-            logger.error(f"Error listing metrics: {e}")
-            return str(e)
+        start_time = time()
+        result = semantic_layer_fetcher.list_metrics()
+        end_time = time()
+        logger.info(f"list_metrics took {end_time - start_time} seconds")
+        return result
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/get_dimensions"))
     def get_dimensions(metrics: list[str]) -> list[DimensionToolResponse] | str:
-        try:
-            start_time = time()
-            result = semantic_layer_fetcher.get_dimensions(metrics=metrics)
-            end_time = time()
-            logger.info(f"get_dimensions took {end_time - start_time} seconds")
-            return result
-        except Exception as e:
-            logger.error(f"Error getting dimensions: {e}")
-            return str(e)
+        start_time = time()
+        result = semantic_layer_fetcher.get_dimensions(metrics=metrics)
+        end_time = time()
+        logger.info(f"get_dimensions took {end_time - start_time} seconds")
+        return result
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/get_entities"))
     def get_entities(metrics: list[str]) -> list[EntityToolResponse] | str:
-        try:
-            start_time = time()
-            result = semantic_layer_fetcher.get_entities(metrics=metrics)
-            end_time = time()
-            logger.info(f"get_entities took {end_time - start_time} seconds")
-            return result
-        except Exception as e:
-            logger.error(f"Error getting entities: {e}")
-            return str(e)
+        start_time = time()
+        result = semantic_layer_fetcher.get_entities(metrics=metrics)
+        end_time = time()
+        logger.info(f"get_entities took {end_time - start_time} seconds")
+        return result
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/query_metrics"))
     def query_metrics(
@@ -65,21 +53,17 @@ def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
         where: str | None = None,
         limit: int | None = None,
     ) -> str:
-        try:
-            start_time = time()
-            result = semantic_layer_fetcher.query_metrics(
-                metrics=metrics,
-                group_by=group_by,
-                order_by=order_by,
-                where=where,
-                limit=limit,
-            )
-            end_time = time()
-            logger.info(f"query_metrics took {end_time - start_time} seconds")
-            if isinstance(result, QueryMetricsSuccess):
-                return result.result
-            else:
-                return result.error
-        except Exception as e:
-            logger.error(f"Error querying metrics: {e}")
-            return str(e)
+        start_time = time()
+        result = semantic_layer_fetcher.query_metrics(
+            metrics=metrics,
+            group_by=group_by,
+            order_by=order_by,
+            where=where,
+            limit=limit,
+        )
+        end_time = time()
+        logger.info(f"query_metrics took {end_time - start_time} seconds")
+        if isinstance(result, QueryMetricsSuccess):
+            return result.result
+        else:
+            return result.error

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Any
+
+from dbt_mcp.config.config import TrackingConfig
+
+
+@dataclass
+class ToolCalledEvent:
+    tool_name: str
+    arguments: dict[str, Any]
+    error_message: str | None
+    prod_environment_id: int | None
+    dev_environment_id: int | None
+    dbt_cloud_user_id: int | None
+    local_user_id: str | None
+
+
+class UsageTracker:
+    def emit_tool_called_event(
+        self,
+        config: TrackingConfig,
+        tool_name: str,
+        arguments: dict[str, Any],
+        error_message: str | None = None,
+    ):
+        pass  # TODO

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -4,9 +4,16 @@ from dbt_mcp.config.config import (
     DiscoveryConfig,
     RemoteConfig,
     SemanticLayerConfig,
+    TrackingConfig,
 )
 
 mock_config = Config(
+    tracking_config=TrackingConfig(
+        prod_environment_id=1,
+        dev_environment_id=1,
+        dbt_cloud_user_id=1,
+        local_user_id="1",
+    ),
     remote_config=RemoteConfig(
         multicell_account_prefix=None,
         prod_environment_id=1,

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pandas" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "requests" },
 ]
 
@@ -171,6 +172,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
 
@@ -180,6 +182,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = "==1.6.0" },
     { name = "pandas", specifier = "==2.2.3" },
     { name = "python-dotenv", specifier = "==1.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = "==2.32.3" },
 ]
 
@@ -192,6 +195,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "ruff", specifier = ">=0.11.2" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
     { name = "types-requests", specifier = ">=2.32.0.20250328" },
 ]
 
@@ -1086,6 +1090,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711, upload_time = "2025-02-27T19:17:34.807Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061, upload_time = "2025-02-27T19:17:32.111Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload_time = "2025-05-16T03:08:04.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload_time = "2025-05-16T03:08:04.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR sets up the codebase to emit usage tracking. This PR doesn't emit events yet, but it should be straightforward to add that soon. This is implemented by overriding the `call_tool` method and emitting events after each tool call. This method is also used to catch exceptions, so I was also able to remove some redundant try-except blocks.