### PR TITLE
Update diagram to local one

### DIFF
--- a/.changes/unreleased/Under the Hood-20250528-084611.yaml
+++ b/.changes/unreleased/Under the Hood-20250528-084611.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Point to the correct diagram in README
+time: 2025-05-28T08:46:11.110407+02:00

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This MCP (Model Context Protocol) server provides tools to interact with dbt. Re
 
 ## Architecture
 
-![architecture diagram of the dbt MCP server](https://github.com/user-attachments/assets/89b8a24b-da7b-4e54-ba48-afceaa56f956)
+![architecture diagram of the dbt MCP server](./docs/d2.png)
 
 ## Setup
 


### PR DESCRIPTION
Right now we are pointing at an old version that was copy/paster instead of the latest image generated