### PR TITLE
Set value to start from when using changie

### DIFF
--- a/.changes/header.tpl.md
+++ b/.changes/header.tpl.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/.changes/unreleased/Enhancement or New Feature-20250528-084448.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250528-084448.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Set pre-changie value to 0.1.13
+time: 2025-05-28T08:44:48.91959+02:00

--- a/.changes/v0.1.3.md
+++ b/.changes/v0.1.3.md
@@ -1,0 +1,2 @@
+## v0.1.3 and before
+* Initial releases before using changie


### PR DESCRIPTION
We need to create an entry for the latest version we released on PyPi before using changie so that `changie latest` will return this version and `changie batch` will now from where to increment.

Without this file changie tries to release a new version considering that the current one is `0.0.0`