### PR TITLE
Improve remote tools error logging

### DIFF
--- a/.changes/unreleased/Under the Hood-20250530-122155.yaml
+++ b/.changes/unreleased/Under the Hood-20250530-122155.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Improve remote tools error logging
+time: 2025-05-30T12:21:55.459865-05:00

--- a/src/dbt_mcp/remote/tools.py
+++ b/src/dbt_mcp/remote/tools.py
@@ -65,7 +65,7 @@ def _get_remote_tools(base_url: str, headers: dict[str, str]) -> list[RemoteTool
             )
             return ListToolsResult.model_validate(list_tools_response.result).tools
     except Exception as e:
-        print(f"Error getting remote tools: {e}")
+        logger.error(f"Error getting remote tools: {e}")
         return []
 
 


### PR DESCRIPTION
Now that remote tools are expected to work for anyone who has them enabled. This error message can be made more apparent.