### PR TITLE
Move adding  to the code itself

### DIFF
--- a/.changes/unreleased/Under the Hood-20250604-163054.yaml
+++ b/.changes/unreleased/Under the Hood-20250604-163054.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Move `--selector` to the code instead of the prompt
+time: 2025-06-04T16:30:54.308231+02:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -15,7 +15,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
 
         if selector:
             selector_params = str(selector).split(" ")
-            command = command + selector_params
+            command = command + ["--select"] + selector_params
 
         full_command = command.copy()
         # Add --quiet flag to specific commands to reduce context window usage

--- a/src/dbt_mcp/prompts/dbt_cli/args/selectors.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/selectors.md
@@ -1,10 +1,10 @@
-It is important to add the `--select` before the selector if any selector needs to be provided.
-If you provide a selector, DO NOT forget adding `--select` in front!
+A selector needs be used when we need to select specific nodes or are asking to do actions on specific nodes.
+A node can be a model, a test, a seed or a snapshot
 
-- to select all models, just do not provide a selector.
-- to select a particular model, use the selector `--select <model_name>`
-- to select a particular model and all the downstream ones (also known as children), use the selector `--select <model_name>+`
-- to select a particular model and all the upstream ones (also known as parents), use the selector `--select +<model_name>`
-- to select a particular model and all the downstream and upstream ones, use the selector `--select +<model_name>+`
-- to select the union of different selectors, separate them with a space like `--select selector1 selector2`
-- to select the intersection of different selectors, separate them with a comma like `--select selector1,selector2`
+- to select all models, just do not provide a selector
+- to select a particular model, use the selector `<model_name>`
+- to select a particular model and all the downstream ones (also known as children), use the selector `<model_name>+`
+- to select a particular model and all the upstream ones (also known as parents), use the selector `+<model_name>`
+- to select a particular model and all the downstream and upstream ones, use the selector `+<model_name>+`
+- to select the union of different selectors, separate them with a space like `selector1 selector2`
+- to select the intersection of different selectors, separate them with a comma like `selector1,selector2`


### PR DESCRIPTION
Closes #143 

Moving adding `--selector`  to the code instead of the prompt seems to get a better success rate from my spot checks in Claude Desktop.