### PR TITLE
FIX - check disable_discovery flag before discovery config

### DIFF
--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -149,7 +149,7 @@ def load_config() -> Config:
         )
 
     discovery_config = None
-    if not disable_dbt_cli and host and actual_prod_environment_id and token:
+    if not disable_discovery and host and actual_prod_environment_id and token:
         discovery_config = DiscoveryConfig(
             multicell_account_prefix=multicell_account_prefix,
             host=host,


### PR DESCRIPTION
a quick one:
I'm assuming ya'll intend to check the `disable_discovery` arg before the discovery_config rather than `disable_dbt_cli`.

The reason this came up is that I don't have access to the discovery api since I don't have an enterprise account. I'd still like to keep the dbt_cli enabled, but do to the logic below i was also getting all the discovery tools enabled even though they aren't accessible on my account.