### PR TITLE
Instruct LLM to add limit as an argument instead of SQL

### DIFF
--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -1,5 +1,4 @@
 import subprocess
-from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -9,7 +8,7 @@ from dbt_mcp.prompts.prompts import get_prompt
 
 
 def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
-    def _run_dbt_command(command: list[str], selector: Optional[str] = None) -> str:
+    def _run_dbt_command(command: list[str], selector: str | None = None) -> str:
         # Commands that should always be quiet to reduce output verbosity
         verbose_commands = ["build", "compile", "docs", "parse", "run", "test"]
 
@@ -39,7 +38,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("dbt_cli/build"))
     def build(
-        selector: Optional[str] = Field(
+        selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
         ),
     ) -> str:
@@ -55,7 +54,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
 
     @dbt_mcp.tool(name="list", description=get_prompt("dbt_cli/list"))
     def ls(
-        selector: Optional[str] = Field(
+        selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
         ),
     ) -> str:
@@ -67,7 +66,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("dbt_cli/run"))
     def run(
-        selector: Optional[str] = Field(
+        selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
         ),
     ) -> str:
@@ -75,14 +74,19 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("dbt_cli/test"))
     def test(
-        selector: Optional[str] = Field(
+        selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
         ),
     ) -> str:
         return _run_dbt_command(["test"], selector)
 
     @dbt_mcp.tool(description=get_prompt("dbt_cli/show"))
-    def show(sql_query: str, limit: int | None = None) -> str:
+    def show(
+        sql_query: str = Field(description=get_prompt("dbt_cli/args/sql_query")),
+        limit: int | None = Field(
+            default=None, description=get_prompt("dbt_cli/args/limit")
+        ),
+    ) -> str:
         args = ["show", "--inline", sql_query, "--favor-state"]
         if limit:
             args.extend(["--limit", str(limit)])

--- a/src/dbt_mcp/prompts/dbt_cli/args/limit.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/limit.md
@@ -1,0 +1,1 @@
+Limit the number of rows that the data platform will return. Use this in place of a `LIMIT` clause in the SQL query.

--- a/src/dbt_mcp/prompts/dbt_cli/args/sql_query.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/sql_query.md
@@ -1,0 +1,1 @@
+This is the SQL query to run against the data platform. Do not add a limit to this query. Use the `limit` argument instead.

--- a/src/dbt_mcp/prompts/dbt_cli/show.md
+++ b/src/dbt_mcp/prompts/dbt_cli/show.md
@@ -1,1 +1,1 @@
-dbt show executes an arbitrary SQL statement against the database and returns the results. It is useful for debugging and inspecting data in your dbt project. Use the limit argument in place of a SQL `LIMIT` clause
+dbt show executes an arbitrary SQL statement against the database and returns the results. It is useful for debugging and inspecting data in your dbt project. If you are adding a limit be sure to use the `limit` argument and do not add a limit to the SQL query.


### PR DESCRIPTION
Unfortunately, the LLM isn't following instructions to use `--limit` instead of adding a limit to the SQL query. Here is an excerpt from my tests with the client:
```
user > Add a limit
[06/10/25 12:15:27] INFO     HTTP Request: POST https://api.openai.com/v1/responses "HTTP/1.1 200 OK"                                        _client.py:1025
Calling tool: show with arguments: {"sql_query":"select * from orders LIMIT 5"}
```
Even so, I think we can commit this change to try encouraging the LLM to use `--limit`. We may seek to encorporate Fusion in the future to determine if the LLM adds limit to the SQL query .