### PR TITLE
Indicate type checking

### DIFF
--- a/.changes/unreleased/Under the Hood-20250615-182909.yaml
+++ b/.changes/unreleased/Under the Hood-20250615-182909.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Indicate type checking
+time: 2025-06-15T18:29:09.118498-05:00


### PR DESCRIPTION
According to PEP 561, this should indicate to any dependents of this package that it supports type checking. This is important for tools like mypy to trust the types provided by this package.