### PR TITLE
Fix order by to allow for ordering by metrics

### DIFF
--- a/.changes/unreleased/Bug Fix-20250624-140038.yaml
+++ b/.changes/unreleased/Bug Fix-20250624-140038.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fixing bug when ordering SL query by a metric
+time: 2025-06-24T14:00:38.069411-04:00


### PR DESCRIPTION
## Context
Issue: #180. Anytime anyone wants to order by a metric, it fails as we hard pinned the parameter being passed to the SDK as a `OrderByGroupBy` which won't work for metrics. Adding support by parsing out the queried metrics/group-by and properly parsing it into the correct order by object.