### PR TITLE
Update Discovery config for simpler usage

### DIFF
--- a/.changes/unreleased/Under the Hood-20250630-140854.yaml
+++ b/.changes/unreleased/Under the Hood-20250630-140854.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Update Discovery config for simpler usage
+time: 2025-06-30T14:08:54.598024-05:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -26,8 +26,7 @@ class SemanticLayerConfig:
 
 @dataclass
 class DiscoveryConfig:
-    multicell_account_prefix: str | None
-    host: str
+    url: str
     environment_id: int
     token: str
 
@@ -159,9 +158,12 @@ def load_config() -> Config:
 
     discovery_config = None
     if not disable_discovery and actual_host and actual_prod_environment_id and token:
+        if multicell_account_prefix:
+            url = f"https://{multicell_account_prefix}.metadata.{actual_host}/graphql"
+        else:
+            url = f"https://metadata.{actual_host}/graphql"
         discovery_config = DiscoveryConfig(
-            multicell_account_prefix=multicell_account_prefix,
-            host=actual_host,
+            url=url,
             environment_id=actual_prod_environment_id,
             token=token,
         )

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -143,7 +143,7 @@ class GraphQLQueries:
                         }
                         edges {
                             node {
-                                parents 
+                                parents
     """)
         + COMMON_FIELDS_PARENTS_CHILDREN
         + textwrap.dedent("""
@@ -172,7 +172,7 @@ class GraphQLQueries:
                         }
                         edges {
                             node {
-                                children 
+                                children
     """)
         + COMMON_FIELDS_PARENTS_CHILDREN
         + textwrap.dedent("""
@@ -188,13 +188,8 @@ class GraphQLQueries:
 
 
 class MetadataAPIClient:
-    def __init__(
-        self, *, host: str, token: str, multicell_account_prefix: str | None = None
-    ):
-        if multicell_account_prefix:
-            self.url = f"https://{multicell_account_prefix}.metadata.{host}/graphql"
-        else:
-            self.url = f"https://metadata.{host}/graphql"
+    def __init__(self, *, url: str, token: str):
+        self.url = url
         self.headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -11,9 +11,8 @@ logger = logging.getLogger(__name__)
 
 def register_discovery_tools(dbt_mcp: FastMCP, config: DiscoveryConfig) -> None:
     api_client = MetadataAPIClient(
-        host=config.host,
+        url=config.url,
         token=config.token,
-        multicell_account_prefix=config.multicell_account_prefix,
     )
     models_fetcher = ModelsFetcher(
         api_client=api_client, environment_id=config.environment_id

--- a/tests/integration/discovery/test_discovery.py
+++ b/tests/integration/discovery/test_discovery.py
@@ -12,7 +12,7 @@ def api_client() -> MetadataAPIClient:
 
     if not host or not token:
         raise ValueError("DBT_HOST and DBT_TOKEN environment variables are required")
-    return MetadataAPIClient(host=host, token=token)
+    return MetadataAPIClient(url=f"https://metadata.{host}/graphql", token=token)
 
 
 @pytest.fixture

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -31,9 +31,8 @@ mock_dbt_cli_config = DbtCliConfig(
 )
 
 mock_discovery_config = DiscoveryConfig(
-    host="http://localhost:8000",
+    url="http://localhost:8000",
     token="token",
-    multicell_account_prefix=None,
     environment_id=1,
 )
 


### PR DESCRIPTION
This PR updates the Discovery config to make it a bit simpler to use. This is relevant for our internal usage of this toolset, where the URL is constructed differently from external usage. This update may also have to be applied the SL toolset, but I just updated the Discovery config for now.

I tested this with `task client` and utilized a Discovery tool with that.