### PR TITLE
Fix issue with relative path for some dbt CLI

### DIFF
--- a/.changes/unreleased/Bug Fix-20250701-111233.yaml
+++ b/.changes/unreleased/Bug Fix-20250701-111233.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix when people provide `DBT_PROJECT_DIR` as  a relative path
+time: 2025-07-01T11:12:33.111527+02:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from mcp.server.fastmcp import FastMCP
@@ -30,9 +31,14 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         # Make the format json to make it easier to parse for the LLM
         full_command = full_command + ["--log-format", "json"]
 
+        # We change the path only if this is an absolute path, otherwise we can have
+        # problems with relative paths applied multiple times as DBT_PROJECT_DIR
+        # is applied to dbt Core and Fusion as well (but not the dbt Cloud CLI)
+        cwd_path = config.project_dir if os.path.isabs(config.project_dir) else None
+
         process = subprocess.Popen(
             args=[config.dbt_path, *full_command],
-            cwd=config.project_dir,
+            cwd=cwd_path,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,


### PR DESCRIPTION
Closes #176 

Not the cleanest fix, but today there is a different behavior between dbt core/Fusion and the dbt Cloud CLI in relation to the env var `DBT_PROJECT_DIR`.

If they are all aligned one day we could just remove the `cwd` part.