### PR TITLE
Decrease output size for list and improve node filtering

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250701-140430.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250701-140430.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Decrease amount of data retrieved when listing models
+time: 2025-07-01T14:04:30.106017+02:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -12,6 +12,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         command: list[str],
         selector: str | None = None,
         timeout: int | None = None,
+        resource_type: list[str] | None = None,
     ) -> str:
         # Commands that should always be quiet to reduce output verbosity
         verbose_commands = ["build", "compile", "docs", "parse", "run", "test"]
@@ -19,6 +20,9 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         if selector:
             selector_params = str(selector).split(" ")
             command = command + ["--select"] + selector_params
+
+        if resource_type:
+            command = command + ["--resource-type"] + resource_type
 
         full_command = command.copy()
         # Add --quiet flag to specific commands to reduce context window usage
@@ -61,9 +65,13 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
         ),
+        resource_type: list[str] | None = Field(
+            default=["model", "snapshot"],
+            description=get_prompt("dbt_cli/args/resource_type"),
+        ),
     ) -> str:
         try:
-            return _run_dbt_command(["list"], selector, timeout=10)
+            return _run_dbt_command(["list"], selector, timeout=10, resource_type=resource_type)
         except subprocess.TimeoutExpired:
             return (
                 "Timeout: dbt list command took too long to complete. "

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -15,7 +15,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         resource_type: list[str] | None = None,
     ) -> str:
         # Commands that should always be quiet to reduce output verbosity
-        verbose_commands = ["build", "compile", "docs", "parse", "run", "test"]
+        verbose_commands = ["build", "compile", "docs", "parse", "run", "test", "list"]
 
         if selector:
             selector_params = str(selector).split(" ")
@@ -30,9 +30,6 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
             main_command = full_command[0]
             command_args = full_command[1:] if len(full_command) > 1 else []
             full_command = [main_command, "--quiet", *command_args]
-
-        # Make the format json to make it easier to parse for the LLM
-        full_command = full_command + ["--log-format", "json"]
 
         process = subprocess.Popen(
             args=[config.dbt_path, *full_command],

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -68,7 +68,9 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         ),
     ) -> str:
         try:
-            return _run_dbt_command(["list"], selector, timeout=10, resource_type=resource_type)
+            return _run_dbt_command(
+                ["list"], selector, timeout=10, resource_type=resource_type
+            )
         except subprocess.TimeoutExpired:
             return (
                 "Timeout: dbt list command took too long to complete. "

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -1,4 +1,5 @@
 import subprocess
+from collections.abc import Iterable
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -21,7 +22,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
             selector_params = str(selector).split(" ")
             command = command + ["--select"] + selector_params
 
-        if resource_type:
+        if isinstance(resource_type, Iterable):
             command = command + ["--resource-type"] + resource_type
 
         full_command = command.copy()
@@ -63,7 +64,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
             default=None, description=get_prompt("dbt_cli/args/selectors")
         ),
         resource_type: list[str] | None = Field(
-            default=["model", "snapshot"],
+            default=None,
             description=get_prompt("dbt_cli/args/resource_type"),
         ),
     ) -> str:

--- a/src/dbt_mcp/prompts/dbt_cli/args/resource_type.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/resource_type.md
@@ -1,0 +1,16 @@
+It is possible to list specific resource types we want to return.
+
+We can pick any from the following and need to return a list of all the resource types to select:
+- metric
+- semantic_model
+- saved_query
+- source
+- analysis
+- model
+- test
+- unit_test
+- exposure
+- snapshot
+- seed
+- default
+- all

--- a/src/dbt_mcp/prompts/dbt_cli/args/selectors.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/selectors.md
@@ -2,8 +2,20 @@ A selector needs be used when we need to select specific nodes or are asking to 
 
 - to select all models, just do not provide a selector
 - to select a particular model, use the selector `<model_name>`
+
+## Graph operators
+
 - to select a particular model and all the downstream ones (also known as children), use the selector `<model_name>+`
 - to select a particular model and all the upstream ones (also known as parents), use the selector `+<model_name>`
 - to select a particular model and all the downstream and upstream ones, use the selector `+<model_name>+`
 - to select the union of different selectors, separate them with a space like `selector1 selector2`
 - to select the intersection of different selectors, separate them with a comma like `selector1,selector2`
+
+## Matching nodes based on parts of their name
+
+When looking to select nodes based on parts of their names, the selector needs to be `fqn:<pattern>`. The fqn is the fully qualified name, it starts with the project or package name followed by the subfolder names and finally the node name.
+
+### Examples
+
+- to select a node from any package that contains `stg_`, we would have the selector `fqn:*stg_*`
+- to select a node from the current project that contains `stg_`, we would have the selector `fqn:project_name.*stg_*`

--- a/tests/unit/dbt_cli/test_cli_integration.py
+++ b/tests/unit/dbt_cli/test_cli_integration.py
@@ -40,25 +40,25 @@ class TestDbtCliIntegration(unittest.TestCase):
         # Test cases for different command types
         test_cases = [
             # Command name, args, expected command list
-            ("build", [], ["/path/to/dbt", "build", "--quiet", "--log-format", "json"]),
+            ("build", [], ["/path/to/dbt", "build", "--quiet"]),
             (
                 "compile",
                 [],
-                ["/path/to/dbt", "compile", "--quiet", "--log-format", "json"],
+                ["/path/to/dbt", "compile", "--quiet"],
             ),
             (
                 "docs",
                 [],
-                ["/path/to/dbt", "docs", "--quiet", "generate", "--log-format", "json"],
+                ["/path/to/dbt", "docs", "--quiet", "generate"],
             ),
             (
                 "ls",
                 [],
-                ["/path/to/dbt", "list", "--log-format", "json"],
-            ),  # Non-verbose command
-            ("parse", [], ["/path/to/dbt", "parse", "--quiet", "--log-format", "json"]),
-            ("run", [], ["/path/to/dbt", "run", "--quiet", "--log-format", "json"]),
-            ("test", [], ["/path/to/dbt", "test", "--quiet", "--log-format", "json"]),
+                ["/path/to/dbt", "list", "--quiet"],
+            ),
+            ("parse", [], ["/path/to/dbt", "parse", "--quiet"]),
+            ("run", [], ["/path/to/dbt", "run", "--quiet"]),
+            ("test", [], ["/path/to/dbt", "test", "--quiet"]),
             (
                 "show",
                 ["SELECT * FROM model"],
@@ -69,8 +69,6 @@ class TestDbtCliIntegration(unittest.TestCase):
                     "SELECT * FROM model",
                     "--favor-state",
                     "--output",
-                    "json",
-                    "--log-format",
                     "json",
                 ],
             ),
@@ -87,8 +85,6 @@ class TestDbtCliIntegration(unittest.TestCase):
                     "10",
                     "--output",
                     "json",
-                    "--log-format",
-                    "json",
                 ],
             ),
         ]
@@ -104,11 +100,9 @@ class TestDbtCliIntegration(unittest.TestCase):
             mock_popen.assert_called_once()
             actual_args = mock_popen.call_args.kwargs.get("args")
 
-            has_quiet = False if command_name == "ls" else True
-            num_params = 3 if has_quiet else 2
+            num_params = 3
 
             self.assertEqual(actual_args[:num_params], expected_args[:num_params])
-            self.assertEqual(actual_args[-2:], ["--log-format", "json"])
 
             # Verify correct working directory
             self.assertEqual(mock_popen.call_args.kwargs.get("cwd"), "/test/project")

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -49,8 +49,6 @@ def mock_fastmcp():
                 "-1",
                 "--output",
                 "json",
-                "--log-format",
-                "json",
             ],
         ),
         # SQL with lowercase limit - should set --limit=-1
@@ -65,8 +63,6 @@ def mock_fastmcp():
                 "--limit",
                 "-1",
                 "--output",
-                "json",
-                "--log-format",
                 "json",
             ],
         ),
@@ -83,8 +79,6 @@ def mock_fastmcp():
                 "10",
                 "--output",
                 "json",
-                "--log-format",
-                "json",
             ],
         ),
         # No limits at all - should not include --limit flag
@@ -97,8 +91,6 @@ def mock_fastmcp():
                 "SELECT * FROM my_model",
                 "--favor-state",
                 "--output",
-                "json",
-                "--log-format",
                 "json",
             ],
         ),
@@ -191,8 +183,6 @@ def test_run_command_correctly_formatted(
         "--quiet",
         "--select",
         "my_model",
-        "--log-format",
-        "json",
     ]
 
 
@@ -224,7 +214,6 @@ def test_show_command_correctly_formatted(
     assert args_list[2] == "--inline"
     assert args_list[3] == "SELECT * FROM my_model"
     assert args_list[4] == "--favor-state"
-    assert args_list[-2:] == ["--log-format", "json"]
 
 
 def test_list_command_timeout_handling(monkeypatch: MonkeyPatch, mock_fastmcp):
@@ -244,11 +233,11 @@ def test_list_command_timeout_handling(monkeypatch: MonkeyPatch, mock_fastmcp):
     list_tool = tools["ls"]
 
     # Test timeout case
-    result = list_tool()
+    result = list_tool(resource_type=["model", "snapshot"])
     assert "Timeout: dbt list command took too long to complete" in result
     assert "Try using a more specific selector" in result
 
     # Test with selector - should still timeout
-    result = list_tool(selector="my_model")
+    result = list_tool(selector="my_model", resource_type=["model"])
     assert "Timeout: dbt list command took too long to complete" in result
     assert "Try using a more specific selector" in result


### PR DESCRIPTION
Improvements related to #178 and #175 and maybe #165 as well

A few things to decrease the amount of data that `list` returns
- only select specific resource types (excluding tests by default should help a lot)
- allow searching nodes by parts of their name
- returning text and not JSON (we lose some info but it is not that useful)
- run with `--quiet` (even with `--quiet` we still list objects)