### PR TITLE
Move Discover headers to config

### DIFF
--- a/.changes/unreleased/Under the Hood-20250702-130435.yaml
+++ b/.changes/unreleased/Under the Hood-20250702-130435.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Move Discover headers to config
+time: 2025-07-02T13:04:35.396445-05:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -27,8 +27,8 @@ class SemanticLayerConfig:
 @dataclass
 class DiscoveryConfig:
     url: str
+    headers: dict[str, str]
     environment_id: int
-    token: str
 
 
 @dataclass
@@ -169,8 +169,11 @@ def load_config() -> Config:
             url = f"https://metadata.{actual_host}/graphql"
         discovery_config = DiscoveryConfig(
             url=url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
             environment_id=actual_prod_environment_id,
-            token=token,
         )
 
     semantic_layer_config = None

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -188,12 +188,9 @@ class GraphQLQueries:
 
 
 class MetadataAPIClient:
-    def __init__(self, *, url: str, token: str):
+    def __init__(self, *, url: str, headers: dict[str, str]):
         self.url = url
-        self.headers = {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
+        self.headers = headers
 
     def execute_query(self, query: str, variables: dict) -> dict:
         response = requests.post(

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def register_discovery_tools(dbt_mcp: FastMCP, config: DiscoveryConfig) -> None:
     api_client = MetadataAPIClient(
         url=config.url,
-        token=config.token,
+        headers=config.headers,
     )
     models_fetcher = ModelsFetcher(
         api_client=api_client, environment_id=config.environment_id

--- a/tests/integration/discovery/test_discovery.py
+++ b/tests/integration/discovery/test_discovery.py
@@ -12,7 +12,13 @@ def api_client() -> MetadataAPIClient:
 
     if not host or not token:
         raise ValueError("DBT_HOST and DBT_TOKEN environment variables are required")
-    return MetadataAPIClient(url=f"https://metadata.{host}/graphql", token=token)
+    return MetadataAPIClient(
+        url=f"https://metadata.{host}/graphql",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
 
 
 @pytest.fixture

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -32,7 +32,10 @@ mock_dbt_cli_config = DbtCliConfig(
 
 mock_discovery_config = DiscoveryConfig(
     url="http://localhost:8000",
-    token="token",
+    headers={
+        "Authorization": "Bearer token",
+        "Content-Type": "application/json",
+    },
     environment_id=1,
 )
 


### PR DESCRIPTION
This should allow for greater flexibility in the headers passed to the Discovery API. This is particularly useful for our internal usage.