### PR TITLE
Catch every tool error and surface as string

### DIFF
--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -20,27 +20,42 @@ def register_discovery_tools(dbt_mcp: FastMCP, config: DiscoveryConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_mart_models"))
     def get_mart_models() -> list[dict] | str:
-        mart_models = models_fetcher.fetch_models(
-            model_filter={"modelingLayer": "marts"}
-        )
-        return [m for m in mart_models if m["name"] != "metricflow_time_spine"]
+        try:
+            mart_models = models_fetcher.fetch_models(
+                model_filter={"modelingLayer": "marts"}
+            )
+            return [m for m in mart_models if m["name"] != "metricflow_time_spine"]
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_all_models"))
     def get_all_models() -> list[dict] | str:
-        return models_fetcher.fetch_models()
+        try:
+            return models_fetcher.fetch_models()
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_details"))
     def get_model_details(model_name: str, unique_id: str | None = None) -> dict | str:
-        return models_fetcher.fetch_model_details(model_name, unique_id)
+        try:
+            return models_fetcher.fetch_model_details(model_name, unique_id)
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_parents"))
     def get_model_parents(
         model_name: str, unique_id: str | None = None
     ) -> list[dict] | str:
-        return models_fetcher.fetch_model_parents(model_name, unique_id)
+        try:
+            return models_fetcher.fetch_model_parents(model_name, unique_id)
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("discovery/get_model_children"))
     def get_model_children(
         model_name: str, unique_id: str | None = None
     ) -> list[dict] | str:
-        return models_fetcher.fetch_model_children(model_name, unique_id)
+        try:
+            return models_fetcher.fetch_model_children(model_name, unique_id)
+        except Exception as e:
+            return str(e)

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -22,15 +22,24 @@ def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/list_metrics"))
     def list_metrics() -> list[MetricToolResponse] | str:
-        return semantic_layer_fetcher.list_metrics()
+        try:
+            return semantic_layer_fetcher.list_metrics()
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/get_dimensions"))
     def get_dimensions(metrics: list[str]) -> list[DimensionToolResponse] | str:
-        return semantic_layer_fetcher.get_dimensions(metrics=metrics)
+        try:
+            return semantic_layer_fetcher.get_dimensions(metrics=metrics)
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/get_entities"))
     def get_entities(metrics: list[str]) -> list[EntityToolResponse] | str:
-        return semantic_layer_fetcher.get_entities(metrics=metrics)
+        try:
+            return semantic_layer_fetcher.get_entities(metrics=metrics)
+        except Exception as e:
+            return str(e)
 
     @dbt_mcp.tool(description=get_prompt("semantic_layer/query_metrics"))
     def query_metrics(
@@ -40,14 +49,17 @@ def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
         where: str | None = None,
         limit: int | None = None,
     ) -> str:
-        result = semantic_layer_fetcher.query_metrics(
-            metrics=metrics,
-            group_by=group_by,
-            order_by=order_by,
-            where=where,
-            limit=limit,
-        )
-        if isinstance(result, QueryMetricsSuccess):
-            return result.result
-        else:
-            return result.error
+        try:
+            result = semantic_layer_fetcher.query_metrics(
+                metrics=metrics,
+                group_by=group_by,
+                order_by=order_by,
+                where=where,
+                limit=limit,
+            )
+            if isinstance(result, QueryMetricsSuccess):
+                return result.result
+            else:
+                return result.error
+        except Exception as e:
+            return str(e)


### PR DESCRIPTION
This PR catches errors from tool calls and surfaces them as strings. This should fix https://github.com/dbt-labs/dbt-mcp/issues/203. I was able to reproduce the error and confirm that this solution fixes the problem. It is unfortunate that this is necessary, but it seems Claude specifically is having a hard time handling thrown exceptions with the latest version of the MCP SDK.