### PR TITLE
feat(dbt_cli): make dbt cli command timeout configurable

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250711-160718.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250711-160718.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Make dbt CLI command timeout configurable
+time: 2025-07-11T16:07:18.345949-05:00

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The MCP server takes the following environment variable configuration:
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DBT_PROJECT_DIR` | The path to where the repository of your dbt Project is hosted locally. This should look something like `/Users/firstnamelastname/reponame` |
 | `DBT_PATH`        | The path to your dbt Core, dbt Cloud CLI, or dbt Fusion executable. You can find your dbt executable by running `which dbt`                 |
+| `DBT_CLI_TIMEOUT` | Configure the number of seconds before your agent will timeout dbt CLI commands. Defaults to 10 seconds.                                    |
 
 It is also possible to set any environment variable supported by your dbt executable (see [here](https://docs.getdbt.com/reference/global-configs/about-global-configs#available-flags) for the ones supported in dbt Core).
 

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -35,6 +35,7 @@ class DiscoveryConfig:
 class DbtCliConfig:
     project_dir: str
     dbt_path: str
+    dbt_cli_timeout: int
 
 
 @dataclass
@@ -73,6 +74,7 @@ def load_config() -> Config:
     disable_discovery = os.environ.get("DISABLE_DISCOVERY", "false") == "true"
     disable_remote = os.environ.get("DISABLE_REMOTE", "true") == "true"
     multicell_account_prefix = os.environ.get("MULTICELL_ACCOUNT_PREFIX", None)
+    dbt_cli_timeout = int(os.environ.get("DBT_CLI_TIMEOUT", 10))
 
     # set default warn error options if not provided
     if os.environ.get("DBT_WARN_ERROR_OPTIONS") is None:
@@ -159,6 +161,7 @@ def load_config() -> Config:
         dbt_cli_config = DbtCliConfig(
             project_dir=project_dir,
             dbt_path=dbt_path,
+            dbt_cli_timeout=dbt_cli_timeout,
         )
 
     discovery_config = None

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -95,7 +95,7 @@ def register_dbt_cli_tools(dbt_mcp: FastMCP, config: DbtCliConfig) -> None:
         return _run_dbt_command(
             ["list"],
             selector,
-            timeout=10,
+            timeout=config.dbt_cli_timeout,
             resource_type=resource_type,
             is_selectable=True,
         )

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -28,6 +28,7 @@ mock_remote_config = RemoteConfig(
 mock_dbt_cli_config = DbtCliConfig(
     project_dir="/test/project",
     dbt_path="/path/to/dbt",
+    dbt_cli_timeout=10,
 )
 
 mock_discovery_config = DiscoveryConfig(


### PR DESCRIPTION
On large projects, I was seeing a custy run into timeouts using dbt list. I'm sure fusion will speed this up someday, but figured we can make this configurable via env_var.

https://dbt-labs.slack.com/archives/C08GXNELQV7/p1752264059419179