### PR TITLE
Allow querying with entities in the group by

### DIFF
--- a/.changes/unreleased/Bug Fix-20250714-132325.yaml
+++ b/.changes/unreleased/Bug Fix-20250714-132325.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Allow passing entities in the group by
+time: 2025-07-14T13:23:25.604557-04:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -131,19 +131,21 @@ class SemanticLayerFetcher:
         if errors:
             return f"Errors: {', '.join(errors)}"
 
-        available_dimensions = [d.name for d in self.get_dimensions(metrics)]
-        dimension_misspellings = get_misspellings(
+        available_group_by = [d.name for d in self.get_dimensions(metrics)] + [
+            e.name for e in self.get_entities(metrics)
+        ]
+        group_by_misspellings = get_misspellings(
             targets=[g.name for g in group_by or []],
-            words=available_dimensions,
+            words=available_group_by,
             top_k=5,
         )
-        for dimension_misspelling in dimension_misspellings:
+        for group_by_misspelling in group_by_misspellings:
             recommendations = (
-                " Did you mean: " + ", ".join(dimension_misspelling.similar_words) + "?"
+                " Did you mean: " + ", ".join(group_by_misspelling.similar_words) + "?"
             )
             errors.append(
-                f"Dimension {dimension_misspelling.word} not found." + recommendations
-                if dimension_misspelling.similar_words
+                f"Group by {group_by_misspelling.word} not found." + recommendations
+                if group_by_misspelling.similar_words
                 else ""
             )
 


### PR DESCRIPTION
## Context
Fixes #209 

There's an issue with grouping by entities due to the spelling check which just checks for dimensions. Adding entities as part of it as well to resolve this.