### PR TITLE
Added ability to disable certain tools when registering the MCP server

### DIFF
--- a/.changes/unreleased/Under the Hood-20250717-213422.yaml
+++ b/.changes/unreleased/Under the Hood-20250717-213422.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Adding the ability to exclude certain tools when registering
+time: 2025-07-17T21:34:22.971538-04:00

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The MCP server takes the following environment variable configuration:
 | `DISABLE_SEMANTIC_LAYER` | `false` | Set this to `true` to disable dbt Semantic Layer MCP objects                    |
 | `DISABLE_DISCOVERY`      | `false` | Set this to `true` to disable dbt Discovery API MCP objects                     |
 | `DISABLE_REMOTE`         | `true`  | Set this to `false` to enable remote MCP objects                                |
+| `DISABLE_TOOLS`          | ""      | Set this to a list of tool names delimited by a `,` to disable certain tools    |
 
 
 ### Configuration for Discovery, Semantic Layer, and Remote Tools

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -56,6 +56,7 @@ class Config:
     dbt_cli_config: DbtCliConfig | None
     discovery_config: DiscoveryConfig | None
     semantic_layer_config: SemanticLayerConfig | None
+    disable_tools: list[str]
 
 
 def load_config() -> Config:
@@ -76,6 +77,7 @@ def load_config() -> Config:
     disable_remote = os.environ.get("DISABLE_REMOTE", "true") == "true"
     multicell_account_prefix = os.environ.get("MULTICELL_ACCOUNT_PREFIX", None)
     dbt_cli_timeout = int(os.environ.get("DBT_CLI_TIMEOUT", 10))
+    disable_tools = os.environ.get("DISABLE_TOOLS", "").split(",")
 
     # set default warn error options if not provided
     if os.environ.get("DBT_WARN_ERROR_OPTIONS") is None:
@@ -230,4 +232,5 @@ def load_config() -> Config:
         dbt_cli_config=dbt_cli_config,
         discovery_config=discovery_config,
         semantic_layer_config=semantic_layer_config,
+        disable_tools=disable_tools,
     )

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -1,5 +1,6 @@
 import logging
 
+from collections.abc import Sequence
 from mcp.server.fastmcp import FastMCP
 
 from dbt_mcp.config.config import DiscoveryConfig
@@ -81,8 +82,13 @@ def create_discovery_tool_definitions(config: DiscoveryConfig) -> list[ToolDefin
     ]
 
 
-def register_discovery_tools(dbt_mcp: FastMCP, config: DiscoveryConfig) -> None:
+def register_discovery_tools(
+    dbt_mcp: FastMCP,
+    config: DiscoveryConfig,
+    exclude_tools: Sequence[str] = [],
+) -> None:
     register_tools(
         dbt_mcp,
         create_discovery_tool_definitions(config),
+        exclude_tools,
     )

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -91,18 +91,18 @@ async def create_dbt_mcp():
 
     if config.semantic_layer_config:
         logger.info("Registering semantic layer tools")
-        register_sl_tools(dbt_mcp, config.semantic_layer_config)
+        register_sl_tools(dbt_mcp, config.semantic_layer_config, config.disable_tools)
 
     if config.discovery_config:
         logger.info("Registering discovery tools")
-        register_discovery_tools(dbt_mcp, config.discovery_config)
+        register_discovery_tools(dbt_mcp, config.discovery_config, config.disable_tools)
 
     if config.dbt_cli_config:
         logger.info("Registering dbt cli tools")
-        register_dbt_cli_tools(dbt_mcp, config.dbt_cli_config)
+        register_dbt_cli_tools(dbt_mcp, config.dbt_cli_config, config.disable_tools)
 
     if config.remote_config:
         logger.info("Registering remote tools")
-        await register_remote_tools(dbt_mcp, config.remote_config)
+        await register_remote_tools(dbt_mcp, config.remote_config, config.disable_tools)
 
     return dbt_mcp

--- a/src/dbt_mcp/remote/tools.py
+++ b/src/dbt_mcp/remote/tools.py
@@ -69,7 +69,11 @@ def _get_remote_tools(base_url: str, headers: dict[str, str]) -> list[RemoteTool
         return []
 
 
-async def register_remote_tools(dbt_mcp: FastMCP, config: RemoteConfig) -> None:
+async def register_remote_tools(
+    dbt_mcp: FastMCP,
+    config: RemoteConfig,
+    exclude_tools: Sequence[str] = [],
+) -> None:
     is_local = config.host and config.host.startswith("localhost")
     path = "/mcp" if is_local else "/api/ai/mcp"
     scheme = "http://" if is_local else "https://"
@@ -88,6 +92,9 @@ async def register_remote_tools(dbt_mcp: FastMCP, config: RemoteConfig) -> None:
         f"Loaded remote tools: {', '.join([tool.name for tool in remote_tools])}",
     )
     for tool in remote_tools:
+        if tool.name in exclude_tools:
+            continue
+
         # Create a new function using a factory to avoid closure issues
         def create_tool_function(tool_name: str):
             async def tool_function(*args, **kwargs) -> Sequence[ContentBlock]:

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 import logging
 
 from dbtsl.api.shared.query_params import GroupByParam
@@ -91,7 +92,11 @@ def create_sl_tool_definitions(
     ]
 
 
-def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
+def register_sl_tools(
+    dbt_mcp: FastMCP,
+    config: SemanticLayerConfig,
+    exclude_tools: Sequence[str] = [],
+) -> None:
     register_tools(
         dbt_mcp,
         create_sl_tool_definitions(
@@ -102,4 +107,5 @@ def register_sl_tools(dbt_mcp: FastMCP, config: SemanticLayerConfig) -> None:
                 host=config.host,
             ),
         ),
+        exclude_tools,
     )

--- a/src/dbt_mcp/tools/register.py
+++ b/src/dbt_mcp/tools/register.py
@@ -1,10 +1,17 @@
+from collections.abc import Sequence
 from mcp.server.fastmcp import FastMCP
 
 from dbt_mcp.tools.definitions import ToolDefinition
 
 
-def register_tools(dbt_mcp: FastMCP, tool_definitions: list[ToolDefinition]) -> None:
+def register_tools(
+    dbt_mcp: FastMCP,
+    tool_definitions: list[ToolDefinition],
+    exclude_tools: Sequence[str] = [],
+) -> None:
     for tool_definition in tool_definitions:
+        if tool_definition.get_name() in exclude_tools:
+            continue
         dbt_mcp.tool(
             name=tool_definition.get_name(),
             title=tool_definition.title,

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -57,4 +57,5 @@ mock_config = Config(
     dbt_cli_config=mock_dbt_cli_config,
     discovery_config=mock_discovery_config,
     semantic_layer_config=mock_semantic_layer_config,
+    disable_tools=[],
 )


### PR DESCRIPTION
## Context
Allow the flexibility to specify certain tools to disable instead of needing to register all tools. This is useful for when certain tools may not be needed.