### PR TITLE
Fix SL validation error message when no misspellings are found

### DIFF
--- a/.changes/unreleased/Bug Fix-20250718-182726.yaml
+++ b/.changes/unreleased/Bug Fix-20250718-182726.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix SL validation error message when no misspellings are found
+time: 2025-07-18T18:27:26.47048-05:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -128,9 +128,8 @@ class SemanticLayerFetcher:
                 " Did you mean: " + ", ".join(metric_misspelling.similar_words) + "?"
             )
             errors.append(
-                f"Metric {metric_misspelling.word} not found." + recommendations
-                if metric_misspelling.similar_words
-                else ""
+                f"Metric {metric_misspelling.word} not found."
+                + (recommendations if metric_misspelling.similar_words else "")
             )
 
         if errors:
@@ -149,9 +148,8 @@ class SemanticLayerFetcher:
                 " Did you mean: " + ", ".join(group_by_misspelling.similar_words) + "?"
             )
             errors.append(
-                f"Group by {group_by_misspelling.word} not found." + recommendations
-                if group_by_misspelling.similar_words
-                else ""
+                f"Group by {group_by_misspelling.word} not found."
+                + (recommendations if group_by_misspelling.similar_words else "")
             )
 
         if errors:


### PR DESCRIPTION
The lack of parentheses here meant that the expression would result in an empty string erroneously.