### PR TITLE
Apply dbt_cli_timeout to all dbt commands

### DIFF
--- a/.changes/unreleased/Bug Fix-20250725-091731.yaml
+++ b/.changes/unreleased/Bug Fix-20250725-091731.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Apply dbt_cli_timeout to all dbt commands
+time: 2025-07-25T09:17:31.943529-05:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -16,7 +16,6 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     def _run_dbt_command(
         command: list[str],
         selector: str | None = None,
-        timeout: int | None = None,
         resource_type: list[str] | None = None,
         is_selectable: bool = False,
     ) -> str:
@@ -58,7 +57,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-            output, _ = process.communicate(timeout=timeout)
+            output, _ = process.communicate(timeout=config.dbt_cli_timeout)
             return output or "OK"
         except subprocess.TimeoutExpired:
             return "Timeout: dbt command took too long to complete." + (
@@ -94,7 +93,6 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         return _run_dbt_command(
             ["list"],
             selector,
-            timeout=config.dbt_cli_timeout,
             resource_type=resource_type,
             is_selectable=True,
         )


### PR DESCRIPTION
I'm not sure why we were only applying `dbt_cli_timeout` to the `list` tool, but I think it should apply to all tools, especially because that is how it is referenced in the readme:
```
Configure the number of seconds before your agent will timeout dbt CLI commands.
```