### PR TITLE
Expand tool descriptions. Support selector on show and compile.

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250725-131456.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250725-131456.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: adds support for the `compile` and `show` tools to take a selector or inline sql. Also updates MCP tool descriptions for better integration with Cline.
+time: 2025-07-25T13:14:56.775758-04:00

--- a/src/dbt_mcp/prompts/dbt_cli/build.md
+++ b/src/dbt_mcp/prompts/dbt_cli/build.md
@@ -1,8 +1,74 @@
-The dbt build command will:
+# dbt build
 
-- run models
-- test tests
-- snapshot snapshots
-- seed seeds
+## Description  
+`dbt build` is the “all-in-one” command for _productionising_ a dbt project.  
+It executes **all downstream actions** necessary to fully materialise the DAG:
 
-In DAG order.
+| Action | What it does | Notes |
+|--------|--------------|-------|
+| **run**      | Executes SQL for models and materialises them (table / view / incremental) | Always adheres to model materialisation strategy |
+| **test**     | Runs _data tests_ (`tests/`) and _schema tests_ (`yml`) against the newly-built relations | Fails the invocation if any test fails |
+| **snapshot** | Executes snapshot queries and updates snapshot tables | Only executed when snapshots exist / are selected |
+| **seed**     | Loads CSV seed files into the warehouse | Skipped when no seeds are selected |
+
+Tasks are executed **in DAG order**, so dependencies are always honoured.
+
+---
+
+## Arguments  
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `selector` | No (string) | Graph selector that limits what part of the DAG to build. Strongly recommended for large projects. See examples below for syntax. |
+
+_All standard dbt flags (`--profiles-dir`, `--vars`, `--threads`, etc.) declared in `profiles.yml` are respected automatically by the underlying CLI._
+
+---
+
+## Usage Guidelines  
+
+### ✅ DO
+* Use a **selector** whenever possible to avoid unnecessarily rebuilding the entire DAG.
+* Build **+model_name** when you want to regenerate a model _and_ its children (tests, snapshots, downstream marts, etc.).
+* Use `model_name+` sparingly; it can trigger an expensive full-DAG rebuild.
+* In CI pipelines, prefer `dbt build --select state:modified+` to build only items modified by the current commit.
+
+### ❌ DON’T
+* Combine `--select` _and_ `--exclude` in ways that leave orphaned tests; they will still execute.
+* Expect `dbt build` to skip tests—**tests always run** for selected nodes.
+
+---
+
+## Examples  
+
+### 1. Build everything
+```bash
+dbt build
+```
+
+### 2. Build a single model and everything downstream
+```bash
+dbt build --select my_model+
+```
+
+### 3. Build a model _and_ its parents (useful for local debugging)
+```bash
+dbt build --select +my_model
+```
+
+### 4. CI / PR build: only modified resources
+```bash
+dbt build --select state:modified+
+```
+
+### 5. Target only marts
+```bash
+dbt build --select fqn:*marts*
+```
+
+---
+
+## Related Commands  
+* **`dbt run`** – Only materialise models (no tests / snapshots / seeds).  
+* **`dbt test`** – Run tests only.  
+* **`dbt compile`** – Generate SQL without executing it.

--- a/src/dbt_mcp/prompts/dbt_cli/compile.md
+++ b/src/dbt_mcp/prompts/dbt_cli/compile.md
@@ -1,3 +1,70 @@
-dbt compile generates executable SQL from source model, test, and analysis files.
+# dbt compile
 
-The compile command is useful for visually inspecting the compiled output of model files. This is useful for validating complex jinja logic or macro usage.
+## Description
+`dbt compile` renders the **executable SQL** for your dbt models, tests, and analyses, letting you catch Jinja or macro errors **before** any query hits the warehouse.
+
+> **Best practice** – **Always** compile the SQL you plan to run or preview (e.g. with `dbt show`) so you fail fast on templating issues instead of during execution.
+
+---
+
+## Arguments
+
+| Name        | Required | Description |
+|-------------|----------|-------------|
+| `sql_query` | One of\* | Inline SQL string to compile via `--inline`. |
+| `selector`  | One of\* | dbt selection syntax (`stg_orders`, `+orders_mart+`, `fqn:*stg_*`, etc.) to compile via `--select`. |
+
+\* Exactly **one** of `sql_query` *or* `selector` may be supplied. If both (or neither) are provided the tool returns an error. Omitting both compiles **the entire project**&nbsp;— useful in CI.
+
+---
+
+## Usage Guidelines
+
+### ✅ DO
+* Run `compile` every time you generate or edit SQL.
+* Use **selector** when you want to compile a model or family of models without writing SQL.
+* Use **sql_query** when you’ve built an ad-hoc query and need to validate its Jinja.
+
+### ❌ DON’T
+* Skip compilation and jump straight to `show`, `run`, etc. — you risk runtime failures.
+* Provide both `sql_query` and `selector`; choose one.
+
+---
+
+## Examples
+
+### 1. Compile a single model by selector
+```python
+compile(selector="stg_orders")   # MCP tool
+```
+
+### 2. Compile inline SQL
+```python
+sql_query = """
+select * 
+from {{ ref('stg_orders') }}
+where order_total > 100
+"""
+compile(sql_query=sql_query)     # MCP tool
+```
+
+### 3. CI-style full-project compile
+```python
+compile()   # no args -> dbt compile whole project
+```
+
+### 4. End-to-end workflow with `dbt show`
+```python
+# 1️⃣ Validate the SQL renders
+compile(sql_query=my_query)
+
+# 2️⃣ Preview results once compile succeeds
+show(sql_query=my_query, limit=25)
+```
+
+---
+
+## Related Commands
+* **`dbt show`** – Preview compiled SQL results.  
+* **`dbt run`** – Materialise models after successful compilation.  
+* **`dbt parse`** – Fast structural validation without full compilation.

--- a/src/dbt_mcp/prompts/dbt_cli/run.md
+++ b/src/dbt_mcp/prompts/dbt_cli/run.md
@@ -1,1 +1,73 @@
-dbt run executes compiled sql model files against the current target database. dbt connects to the target database and runs the relevant SQL required to materialize all data models using the specified materialization strategies. Models are run in the order defined by the dependency graph generated during compilation.
+# dbt run
+
+## Description  
+`dbt run` **materialises models only**.  
+For each selected model dbt:
+
+1. Compiles the model’s SQL (including Jinja templating)  
+2. Connects to the current target warehouse (as defined in `profiles.yml`)  
+3. Executes the compiled SQL to create / update the relation according to its chosen _materialisation strategy_ (`table`, `view`, `incremental`, `ephemeral`, etc.)  
+
+Models execute **in topological (DAG) order**, ensuring every upstream dependency is built before its children.
+
+---
+
+## Arguments  
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `selector` | No (string) | Graph selector expression to limit which models are run (see examples). |
+| `full_refresh` | No (bool) | If `true`, incremental models are rebuilt from scratch with `INSERT … OVERWRITE`. |
+| `threads` | No (int) | Override number of warehouse connections for this invocation. |
+
+Additional dbt CLI flags (`--vars`, `--profiles-dir`, `--defer`, `--state`, etc.) are forwarded automatically when using this tool.
+
+---
+
+## Usage Guidelines  
+
+### ✅ DO
+* Use a **selector** whenever you need to run a subset of models—this saves time on large DAGs.
+* Pair `state:modified` with CI workflows to run only models changed by the current commit.
+* Set `--full-refresh` during back-fills or when changing incremental logic.
+
+### ❌ DON’T
+* Rely on `dbt run` for testing—no tests execute; follow up with `dbt test` or use `dbt build`.
+* Forget that **ephemeral** models are _compiled_ but not materialised—they will not appear in the warehouse.
+
+---
+
+## Examples  
+
+### 1. Run the entire project  
+```bash
+dbt run
+```
+
+### 2. Run a single model and its parents (staging rebuild)  
+```bash
+dbt run --select +stg_orders
+```
+
+### 3. Run all marts only  
+```bash
+dbt run --select fqn:*marts*
+```
+
+### 4. CI optimisation: run only models modified in this branch  
+```bash
+dbt run --select state:modified
+```
+
+### 5. Force-rebuild all incremental models  
+```bash
+dbt run --full-refresh
+```
+
+---
+
+## Related Commands  
+
+* **`dbt build`** – Superset that runs models _and_ downstream tests / snapshots / seeds.  
+* **`dbt test`** – Execute data & schema tests only.  
+* **`dbt compile`** – Generate compiled SQL without executing it.

--- a/src/dbt_mcp/prompts/dbt_cli/show.md
+++ b/src/dbt_mcp/prompts/dbt_cli/show.md
@@ -1,1 +1,111 @@
-dbt show executes an arbitrary SQL statement against the database and returns the results. It is useful for debugging and inspecting data in your dbt project. If you are adding a limit be sure to use the `limit` argument and do not add a limit to the SQL query.
+# dbt show
+
+## Description
+`dbt show` lets you **preview data** without materialising anything in the warehouse.  
+It can run either:
+
+* **Inline SQL** provided via `--inline`, or  
+* A **model / node selector** provided via `--select`
+
+Typical use-cases include:
+
+* Previewing rows from a model or source
+* Testing intermediate CTE logic inside complex models
+* Performing quick ad-hoc analyses without creating tables/views
+
+Because the command simply returns a result set, it is fast and safe to run in development environments.
+
+---
+
+## Arguments
+
+| Name        | Required | Description |
+|-------------|----------|-------------|
+| `sql_query` | One of\* | SQL to execute. Do **not** append a semicolon or `LIMIT` clause. |
+| `selector`  | One of\* | dbt selection syntax (e.g. `stg_orders`, `+orders_mart+`, `fqn:*stg_*`). |
+| `limit`     | No       | Maximum rows to return. If omitted the query is unbounded. Recommended default: **20-100** while exploring. |
+
+\* Exactly **one** of `sql_query` *or* `selector` must be supplied. Supplying both (or neither) will result in an error.
+
+---
+
+## Usage Guidelines
+
+### ✅ DO
+* For SQL, use fully-qualified dbt references, e.g. `{{ ref('stg_orders') }}` or `{{ source('raw', 'payments') }}`.
+* Wrap the SQL string in triple-quoted Python strings when calling the tool.
+* Start with a reasonable `limit` while iterating, then remove/raise it once satisfied.
+* Use selectors for quick previews of existing models without writing SQL.
+
+### ❌ DON’T
+* Pass **both** `sql_query` and `selector` together.
+* Add a `LIMIT` clause inside `sql_query`; use the `limit` argument instead.
+* Include a trailing semicolon—dbt adds this automatically.
+
+---
+
+## Examples
+
+### 1. Preview first 25 rows of a staging model (SQL)
+```python
+sql_query = """
+select *
+from {{ ref('stg_orders') }}
+"""
+limit = 25
+```
+
+### 2. Preview a model using a selector (no SQL required)
+```python
+selector = "stg_orders"
+limit = 25
+```
+
+### 3. Inspect an intermediate CTE in a model under development
+```python
+sql_query = """
+with base as (
+    select * from {{ ref('stg_payments') }}
+),
+filtered as (
+    select * from base where status = 'completed'
+)
+select * from filtered
+"""
+limit = 20
+```
+
+### 4. Ad-hoc join of two marts to answer a quick business question
+```python
+sql_query = """
+select
+    o.order_id,
+    o.order_total,
+    c.customer_segment
+from {{ ref('orders_mart') }} o
+join {{ ref('customers_mart') }} c
+    on o.customer_id = c.customer_id
+where o.order_total > 100
+"""
+limit = 50
+```
+
+---
+
+## Common Pitfalls & Troubleshooting
+
+| Symptom | Likely Cause | Resolution |
+|---------|--------------|------------|
+| `Must supply exactly one of --inline or --select` | Passed neither or both arguments | Provide only `sql_query` **or** `selector`. |
+| `Query exceeds maximum result size` | No or very high `limit` | Lower the `limit` value. |
+| `relation "…" does not exist` | Wrong target / schema | Verify `dbt debug` & target schema. |
+| `Compilation Error` | Invalid Jinja in `sql_query` | Check templating & refs; run `dbt compile`. |
+
+---
+
+## Related Commands
+
+* **`dbt compile`** – Validate SQL/Jinja without hitting the database.  
+* **`dbt run`** – Materialise the results as a model after you’re satisfied with the query.  
+
+For deeper details see the [official dbt docs on `dbt show`](https://docs.getdbt.com/reference/commands/show).

--- a/src/dbt_mcp/prompts/dbt_cli/test.md
+++ b/src/dbt_mcp/prompts/dbt_cli/test.md
@@ -1,1 +1,70 @@
-dbt test runs data tests defined on models, sources, snapshots, and seeds and unit tests defined on SQL models.
+# dbt test
+
+## Description  
+`dbt test` **executes assertions against your data** to validate business logic and data quality.  
+It runs two categories of tests:
+
+| Test Type        | Defined On | Purpose                                                       |
+|------------------|------------|---------------------------------------------------------------|
+| **Schema / Data**| Models, sources, snapshots, seeds | Validate column constraints (e.g. `unique`, `not_null`, `accepted_values`) and _generic_ integrity rules. |
+| **Unit**         | SQL models | Assert the behaviour of custom business logic in *unit-test* YAML files. |
+
+A successful run returns **zero failures**. Any failure sets a non-zero exit-code, making `dbt test` CI-friendly.
+
+---
+
+## Arguments  
+
+| Name        | Required | Description |
+|-------------|----------|-------------|
+| `selector`  | No (string) | dbt selection syntax to limit which tests run (see examples). |
+
+---
+
+## Usage Guidelines  
+
+### ✅ DO
+* Use **selectors** to run only the tests relevant to your change set—speeds up feedback loops.
+* Pair `state:modified` with CI pipelines to test resources changed by the current commit.
+* Keep tests close to logic: schema tests in the same YAML as models; unit tests alongside SQL.
+
+### ❌ DON’T
+* Rely solely on data tests for pipeline integrity—complement with `dbt build` in production.
+* Ignore failures in CI; treat any regression as a blocker before merge.
+
+---
+
+## Examples  
+
+### 1. Run **all** tests in the project  
+```bash
+dbt test
+```
+
+### 2. Run tests for a single staging model only  
+```bash
+dbt test --select stg_orders
+```
+
+### 3. CI optimisation – test only modified resources  
+```bash
+dbt test --select state:modified
+```
+
+### 4. Test a model **and** its downstream dependants  
+```bash
+dbt test --select stg_customers+
+```
+
+### 5. Validate unit tests only (by folder pattern)  
+```bash
+dbt test --select fqn:*unit_tests*
+```
+
+---
+
+## Related Commands  
+
+* **`dbt build`** – Superset that runs models _and_ downstream tests / snapshots / seeds.  
+* **`dbt run`** – Materialise models before testing (data tests do not execute here).  
+* **`dbt compile`** – Validate SQL/Jinja separately before running tests.

--- a/tests/unit/dbt_cli/test_cli_integration.py
+++ b/tests/unit/dbt_cli/test_cli_integration.py
@@ -39,62 +39,101 @@ class TestDbtCliIntegration(unittest.TestCase):
 
         # Test cases for different command types
         test_cases = [
-            # Command name, args, expected command list
-            ("build", [], ["/path/to/dbt", "build", "--quiet"]),
+            # Command name, kwargs, expected command list
+            ("build", {}, ["/path/to/dbt", "build", "--quiet"]),
             (
                 "compile",
-                [],
+                {},
                 ["/path/to/dbt", "compile", "--quiet"],
             ),
             (
                 "docs",
-                [],
+                {},
                 ["/path/to/dbt", "docs", "--quiet", "generate"],
             ),
             (
                 "ls",
-                [],
+                {},
                 ["/path/to/dbt", "list", "--quiet"],
             ),
-            ("parse", [], ["/path/to/dbt", "parse", "--quiet"]),
-            ("run", [], ["/path/to/dbt", "run", "--quiet"]),
-            ("test", [], ["/path/to/dbt", "test", "--quiet"]),
+            ("parse", {}, ["/path/to/dbt", "parse", "--quiet"]),
+            ("run", {}, ["/path/to/dbt", "run", "--quiet"]),
+            ("test", {}, ["/path/to/dbt", "test", "--quiet"]),
             (
                 "show",
-                ["SELECT * FROM model"],
+                {"sql_query": "SELECT * FROM model"},
                 [
                     "/path/to/dbt",
                     "show",
+                    "--favor-state",
                     "--inline",
                     "SELECT * FROM model",
-                    "--favor-state",
                     "--output",
                     "json",
                 ],
             ),
             (
                 "show",
-                ["SELECT * FROM model", 10],
+                {"sql_query": "SELECT * FROM model", "limit": 10},
                 [
                     "/path/to/dbt",
                     "show",
+                    "--favor-state",
                     "--inline",
                     "SELECT * FROM model",
-                    "--favor-state",
                     "--limit",
                     "10",
                     "--output",
                     "json",
                 ],
             ),
+            (
+                "show",
+                {"selector": "my_model"},
+                [
+                    "/path/to/dbt",
+                    "show",
+                    "--favor-state",
+                    "--select",
+                    "my_model",
+                    "--output",
+                    "json",
+                ],
+            ),
+            (
+                "compile",
+                {"sql_query": "SELECT * FROM model"},
+                [
+                    "/path/to/dbt",
+                    "compile",
+                    "--quiet",
+                    "--inline",
+                    "SELECT * FROM model",
+                ],
+            ),
+            (
+                "compile",
+                {"selector": "my_model"},
+                [
+                    "/path/to/dbt",
+                    "compile",
+                    "--quiet",
+                    "--select",
+                    "my_model",
+                ],
+            ),
         ]
 
         # Run each test case
-        for command_name, args, expected_args in test_cases:
+        for command_name, kwargs, expected_args in test_cases:
+            print(command_name)
+            print(kwargs)
+            print(expected_args)
             mock_popen.reset_mock()
 
             # Call the function
-            result = tools[command_name](*args)
+            result = tools[command_name](**kwargs)
+            print(result)
 
             # Verify the command was called correctly
             mock_popen.assert_called_once()


### PR DESCRIPTION
hey folks!

this is mostly vibe coded, so pls feel free to critique heavily. this PR does the following:
1. updates the tool descriptions for the dbt cli. this has helped Cline better call specific tools.
2. adds selectors to the show and compile commands. this has helped cline rely more on dbt models vs generating its own inline code.

I've updated tests and added a changie - lmk what else you need!