### PR TITLE
Add `ToolAnnotations`

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250726-053207.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250726-053207.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add ToolAnnotations
+time: 2025-07-26T05:32:07.606678-07:00

--- a/.changes/unreleased/Under the Hood-20250726-053152.yaml
+++ b/.changes/unreleased/Under the Hood-20250726-053152.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Fix initialization integration test
+time: 2025-07-26T05:31:52.185494-07:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -7,9 +7,13 @@ from pydantic import Field
 
 from dbt_mcp.config.config import DbtCliConfig
 from dbt_mcp.prompts.prompts import get_prompt
+<<<<<<< Updated upstream
 from dbt_mcp.tools.definitions import ToolDefinition
 from dbt_mcp.tools.register import register_tools
 from dbt_mcp.tools.tool_names import ToolName
+=======
+from dbt_mcp.tools.annotations import create_tool_annotations
+>>>>>>> Stashed changes
 
 
 def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition]:
@@ -68,6 +72,15 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         except Exception as e:
             return str(e)
 
+<<<<<<< Updated upstream
+=======
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/build"),
+        annotations=create_tool_annotations(
+            title="dbt build", destructive_hint=True, idempotent_hint=False
+        ),
+    )
+>>>>>>> Stashed changes
     def build(
         selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
@@ -75,12 +88,34 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     ) -> str:
         return _run_dbt_command(["build"], selector, is_selectable=True)
 
+<<<<<<< Updated upstream
     def compile() -> str:
         return _run_dbt_command(["compile"])
 
     def docs() -> str:
         return _run_dbt_command(["docs", "generate"])
 
+=======
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/compile"),
+        annotations=create_tool_annotations(title="dbt compile"),
+    )
+    def compile() -> str:
+        return _run_dbt_command(["compile"])
+
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/docs"),
+        annotations=create_tool_annotations(title="dbt docs"),
+    )
+    def docs() -> str:
+        return _run_dbt_command(["docs", "generate"])
+
+    @dbt_mcp.tool(
+        name="list",
+        description=get_prompt("dbt_cli/list"),
+        annotations=create_tool_annotations(title="dbt list"),
+    )
+>>>>>>> Stashed changes
     def ls(
         selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
@@ -97,9 +132,25 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             is_selectable=True,
         )
 
+<<<<<<< Updated upstream
     def parse() -> str:
         return _run_dbt_command(["parse"])
 
+=======
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/parse"),
+        annotations=create_tool_annotations(title="dbt parse"),
+    )
+    def parse() -> str:
+        return _run_dbt_command(["parse"])
+
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/run"),
+        annotations=create_tool_annotations(
+            title="dbt run", destructive_hint=True, idempotent_hint=False
+        ),
+    )
+>>>>>>> Stashed changes
     def run(
         selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
@@ -107,6 +158,15 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     ) -> str:
         return _run_dbt_command(["run"], selector, is_selectable=True)
 
+<<<<<<< Updated upstream
+=======
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/test"),
+        annotations=create_tool_annotations(
+            title="dbt test", destructive_hint=True, idempotent_hint=False
+        ),
+    )
+>>>>>>> Stashed changes
     def test(
         selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/selectors")
@@ -114,6 +174,13 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     ) -> str:
         return _run_dbt_command(["test"], selector, is_selectable=True)
 
+<<<<<<< Updated upstream
+=======
+    @dbt_mcp.tool(
+        description=get_prompt("dbt_cli/show"),
+        annotations=create_tool_annotations(title="dbt show"),
+    )
+>>>>>>> Stashed changes
     def show(
         sql_query: str = Field(description=get_prompt("dbt_cli/args/sql_query")),
         limit: int | None = Field(

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -8,7 +8,11 @@ from dbt_mcp.discovery.client import MetadataAPIClient, ModelsFetcher
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.tools.definitions import ToolDefinition
 from dbt_mcp.tools.register import register_tools
+<<<<<<< Updated upstream
 from dbt_mcp.tools.tool_names import ToolName
+=======
+from dbt_mcp.tools.annotations import create_tool_annotations
+>>>>>>> Stashed changes
 
 logger = logging.getLogger(__name__)
 
@@ -63,22 +67,27 @@ def create_discovery_tool_definitions(config: DiscoveryConfig) -> list[ToolDefin
         ToolDefinition(
             description=get_prompt("discovery/get_mart_models"),
             fn=get_mart_models,
+            annotations=create_tool_annotations(title="Get Mart Models"),
         ),
         ToolDefinition(
             description=get_prompt("discovery/get_all_models"),
             fn=get_all_models,
+            annotations=create_tool_annotations(title="Get All Models"),
         ),
         ToolDefinition(
             description=get_prompt("discovery/get_model_details"),
             fn=get_model_details,
+            annotations=create_tool_annotations(title="Get Model Details"),
         ),
         ToolDefinition(
             description=get_prompt("discovery/get_model_parents"),
             fn=get_model_parents,
+            annotations=create_tool_annotations(title="Get Model Parents"),
         ),
         ToolDefinition(
             description=get_prompt("discovery/get_model_children"),
             fn=get_model_children,
+            annotations=create_tool_annotations(title="Get Model Children"),
         ),
     ]
 

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -20,7 +20,11 @@ from dbt_mcp.semantic_layer.types import (
 )
 from dbt_mcp.tools.definitions import ToolDefinition
 from dbt_mcp.tools.register import register_tools
+<<<<<<< Updated upstream
 from dbt_mcp.tools.tool_names import ToolName
+=======
+from dbt_mcp.tools.annotations import create_tool_annotations
+>>>>>>> Stashed changes
 
 logger = logging.getLogger(__name__)
 
@@ -77,18 +81,22 @@ def create_sl_tool_definitions(
         ToolDefinition(
             description=get_prompt("semantic_layer/list_metrics"),
             fn=list_metrics,
+            annotations=create_tool_annotations(title="List Metrics"),
         ),
         ToolDefinition(
             description=get_prompt("semantic_layer/get_dimensions"),
             fn=get_dimensions,
+            annotations=create_tool_annotations(title="Get Dimensions"),
         ),
         ToolDefinition(
             description=get_prompt("semantic_layer/get_entities"),
             fn=get_entities,
+            annotations=create_tool_annotations(title="Get Entities"),
         ),
         ToolDefinition(
             description=get_prompt("semantic_layer/query_metrics"),
             fn=query_metrics,
+            annotations=create_tool_annotations(title="Query Metrics"),
         ),
     ]
 

--- a/src/dbt_mcp/tools/annotations.py
+++ b/src/dbt_mcp/tools/annotations.py
@@ -1,0 +1,28 @@
+from mcp.types import ToolAnnotations
+
+
+def create_tool_annotations(
+    title: str | None = None,
+    read_only_hint: bool = True,
+    destructive_hint: bool = False,
+    idempotent_hint: bool = True,
+    open_world_hint: bool = True,
+) -> ToolAnnotations:
+    """
+    Create tool annotations. Defaults to read-only, non-destructive,
+    idempotent, and open-world hints. Forced to explicitly set hints
+    to destructive and non-idempotent.
+    Args:
+        - title: Human-readable title for the tool
+        - read_only_hint: Whether the tool only reads data
+        - destructive_hint: Whether the tool makes destructive changes
+        - idempotent_hint: Whether repeated calls have the same effect
+        - open_world_hint: Whether the tool interacts with external systems
+    """
+    return ToolAnnotations(
+        title=title,
+        readOnlyHint=read_only_hint,
+        destructiveHint=destructive_hint,
+        idempotentHint=idempotent_hint,
+        openWorldHint=open_world_hint,
+    )

--- a/tests/integration/initialization/test_initialization.py
+++ b/tests/integration/initialization/test_initialization.py
@@ -7,7 +7,7 @@ from tests.mocks.config import mock_config
 
 def test_initialization():
     with patch("dbt_mcp.config.config.load_config", return_value=mock_config):
-        result = asyncio.run(create_dbt_mcp())
+        result = asyncio.run(create_dbt_mcp(mock_config))
 
     assert result is not None
     assert hasattr(result, "usage_tracker")


### PR DESCRIPTION
# Summary
Closes issues #198 and #242 (?).

Introduces `ToolAnnotations` to all 17 registered tools within the dbt-mcp server..  this is essentially a way to provide "hints" [(i.e human-readable titles and operational hints)](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations) that allow agent UIs to display tools in a nice format while also giving users a heads up about the natue of a tool call: is it read only? destructive? idememptoent? does it interact with external systems?

Read more [here](https://blog.marcnuri.com/mcp-tool-annotations-introduction).


# Details
- Added a new module, `src/dbt_mcp/tools/annotations.py` with the following defaults:
    - `read_only_hint=True`
      - Most tools in the dbt-mcp are read-only. It is enabled for tools that only query data or metadata, so this defaults to True.
    - `destructive_hint=False`
      - Since most tools are read-only, tools default to False. This must be explicitly overridden for operations that modify data or state (like dbt run, dbt build. etc).
      - Should the default actually be the opposite such that we assume destructuve behaviour unless explicitly set otherwise?
    - `idempotent_hint=True`
      - Again, as most tool calls are read-only, this defaults to False.
    - `open_world_hint=True`
      - Since most tools interact with external systems like a dbt project or a database, this defaults to True.
- More details on what annotations were applied to what tools:
    - Destructive Tools (?):
        - dbt build, dbt run, dbt test
    - Read-Only Tools:
        - dbt compile (?), dbt docs, dbt list, dbt parse, dbt show
        - list_metrics, get_dimensions, get_entities, query_metrics
        - get_mart_models, get_all_models, get_model_details, get_model_parents, get_model_children
- Again, each tool is also given a human-readable title to look nicer for agent UIs and users

I think a discussion can be had to vet if the applied annotations make sense here!

# Tests
I didn't add any tests for these changes, but I did update `tests/integration/initialization/test_initialization.py`. A recent change introduced in PR #224 made it so that you need to pass in the `dbt_mcp.config.Config` class as an argument to `create_dbt_mcp()` . Added the `mock_config` object  as a param to keep parity and fix the failing initialization test.
