### PR TITLE
Add `alias` field to Discovery `GET_MODEL_DETAILS`

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250804-152555.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250804-152555.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add alias field to GET_MODEL_DETAILS GraphQL query
+time: 2025-08-04T15:25:55.232301153-04:00

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -54,6 +54,7 @@ class GraphQLQueries:
                                 description
                                 database
                                 schema
+                                alias
                                 catalog {
                                     columns {
                                         description

--- a/src/dbt_mcp/prompts/discovery/get_model_details.md
+++ b/src/dbt_mcp/prompts/discovery/get_model_details.md
@@ -1,5 +1,5 @@
 <instructions>
-Retrieves information about a specific dbt model, including compiled SQL, description, and column details.
+Retrieves information about a specific dbt model, including compiled SQL, description, database, schema, alias, and column details.
 
 IMPORTANT: Use uniqueId when available.
 - Using uniqueId guarantees the correct model is retrieved


### PR DESCRIPTION
# Description
This PR adds the `alias` field to the `GET_MODEL_DETAILS` GraphQL query, enabling MCP clients to retrieve model alias information through the discovery tools.

# Changes
This is an additive, backwards-compatible, non-breaking extension of the existing `GET_MODEL_DETAILS` query.
- Added `alias` field to the `GET_MODEL_DETAILS` GraphQL query in `src/dbt_mcp/discovery/client.py`
- Updated documentation in `src/dbt_mcp/prompts/discovery/get_model_details.md` to reflect that alias is now included in the response

# Why ?
dbt models can have aliases that differ from their model names. This information is valuable for:
- Understanding the actual table/view name in the database
- Debugging issues where the model name differs from the database object name
- Providing more-complete model metadata to MCP clients

# Testing
- [X] All unit tests pass (`task test:unit`)

# Checklist
- [x] Created changelog entry using `changie new`
- [x] Tests pass
- [x] Docs updated

# Type of Change (changie categories)
- [ ] Breaking Change
- [x] Enhancement or New Feature
- [ ] Under the Hood
- [ ] Bug Fix
- [ ] Security
