### PR TITLE
Make model_name of get_model_details optional

### DIFF
--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -254,11 +254,16 @@ class ModelsFetcher:
         return all_edges
 
     def fetch_model_details(
-        self, model_name: str, unique_id: str | None = None
+        self, model_name: str | None = None, unique_id: str | None = None
     ) -> dict:
-        model_filters: dict[str, list[str] | str] = (
-            {"uniqueIds": [unique_id]} if unique_id else {"identifier": model_name}
-        )
+        model_filters: dict[str, list[str] | str]
+        if unique_id:
+            model_filters = {"uniqueIds": [unique_id]}
+        elif model_name:
+            model_filters = {"identifier": model_name}
+        else:
+            raise ValueError("Either model_name or unique_id must be provided")
+
         variables = {
             "environmentId": self.environment_id,
             "modelsFilter": model_filters,

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -6,10 +6,10 @@ from mcp.server.fastmcp import FastMCP
 from dbt_mcp.config.config import DiscoveryConfig
 from dbt_mcp.discovery.client import MetadataAPIClient, ModelsFetcher
 from dbt_mcp.prompts.prompts import get_prompt
+from dbt_mcp.tools.annotations import create_tool_annotations
 from dbt_mcp.tools.definitions import ToolDefinition
 from dbt_mcp.tools.register import register_tools
 from dbt_mcp.tools.tool_names import ToolName
-from dbt_mcp.tools.annotations import create_tool_annotations
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,9 @@ def create_discovery_tool_definitions(config: DiscoveryConfig) -> list[ToolDefin
         except Exception as e:
             return str(e)
 
-    def get_model_details(model_name: str, unique_id: str | None = None) -> dict | str:
+    def get_model_details(
+        model_name: str | None = None, unique_id: str | None = None
+    ) -> dict | str:
         try:
             return models_fetcher.fetch_model_details(model_name, unique_id)
         except Exception as e:


### PR DESCRIPTION
The prompt for `get_model_details` strongly suggests using unique_id instead of model_name [here](https://github.com/dbt-labs/dbt-mcp/blob/main/src/dbt_mcp/prompts/discovery/get_model_details.md?plain=1#L4). However, model name is still a required parameter. This results in errors like this:

```
Error executing tool get_model_details: 1 validation error for get_model_detailsArguments
model_name
  Field required [type=missing, input_value={'unique_id': 'model.jaff...c_layer_testing.orders'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

For a tool call like
```
get_model_details({"unique_id":"model.jaffle_semantic_layer_testing.orders"})
```

I tested this with `task client` and it works well.