### PR TITLE
Add default --limit to show tool

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250813-070837.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250813-070837.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add default --limit to show tool
+time: 2025-08-13T07:08:37.699907-07:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -117,9 +117,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
 
     def show(
         sql_query: str = Field(description=get_prompt("dbt_cli/args/sql_query")),
-        limit: int | None = Field(
-            default=None, description=get_prompt("dbt_cli/args/limit")
-        ),
+        limit: int = Field(default=5, description=get_prompt("dbt_cli/args/limit")),
     ) -> str:
         args = ["show", "--inline", sql_query, "--favor-state"]
         # This is quite crude, but it should be okay for now

--- a/src/dbt_mcp/prompts/dbt_cli/args/limit.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/limit.md
@@ -1,1 +1,1 @@
-Limit the number of rows that the data platform will return. Use this in place of a `LIMIT` clause in the SQL query.
+Limit the number of rows that the data platform will return. Use this in place of a `LIMIT` clause in the SQL query. If no limit is explictly requested, use the default of 5 to prevent returning a very large result set.

--- a/src/dbt_mcp/prompts/dbt_cli/args/limit.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/limit.md
@@ -1,1 +1,1 @@
-Limit the number of rows that the data platform will return. Use this in place of a `LIMIT` clause in the SQL query. If no limit is explictly requested, use the default of 5 to prevent returning a very large result set.
+Limit the number of rows that the data platform will return. Use this in place of a `LIMIT` clause in the SQL query. If no limit is passed, use the default of 5 to prevent returning a very large result set.


### PR DESCRIPTION
# Summary
Closes #272.

# Details 
- Set explicit value in Pydantic `Field` default param and remove `None` type
- Extend prompt with guiding words of advice

# Tests
I don't have an OpenAI key to run `task:client` but was able to successfully use the MCP Inspector and test in Claude/Copilot/Cursor:

Claude - on asking about the default values for show:
<img width="599" height="683" alt="Screenshot 2025-08-13 at 9 48 51 AM" src="https://github.com/user-attachments/assets/fbac84b7-56a3-4d3b-a42e-aa2413f90bfa" />


GitHub Copilot and Cursor had the same results and limited the data:
<img width="1101" height="360" alt="Screenshot 2025-08-13 at 10 13 58 AM" src="https://github.com/user-attachments/assets/959522d6-83bb-4eeb-b1a5-030b4f7a028b" />
