### PR TITLE
Using streamable http for SQL tools

### DIFF
--- a/.changes/unreleased/Under the Hood-20250821-124711.yaml
+++ b/.changes/unreleased/Under the Hood-20250821-124711.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Using streamable http for SQL tools
+time: 2025-08-21T12:47:11.370832-05:00

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -18,7 +18,7 @@ from dbt_mcp.dbt_admin.tools import register_admin_api_tools
 from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
 from dbt_mcp.discovery.tools import register_discovery_tools
 from dbt_mcp.semantic_layer.tools import register_sl_tools
-from dbt_mcp.sql.tools import register_sql_tools
+from dbt_mcp.sql.tools import SqlToolsManager, register_sql_tools
 from dbt_mcp.tracking.tracking import UsageTracker
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,14 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
         raise e
     finally:
         logger.info("Shutting down MCP server")
-        shutdown()
+        try:
+            await SqlToolsManager.close()
+        except Exception:
+            logger.exception("Error closing SQL tools manager")
+        try:
+            shutdown()
+        except Exception:
+            logger.exception("Error shutting down MCP server")
 
 
 class DbtMCP(FastMCP):


### PR DESCRIPTION
SQL tools were originally implemented before streamable http was a viable option and before we had a remote MCP server. Now that we have the remote dbt MCP server, we can use that to make the SQL tools available. This should make our code simpler since remote tools are only defined in one place. I tested this with `task client`.