### PR TITLE
handle AdminAPI client host and url differently

### DIFF
--- a/.changes/unreleased/Under the Hood-20250822-152320.yaml
+++ b/.changes/unreleased/Under the Hood-20250822-152320.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Correctly handle admin API host containing protocol prefix
+time: 2025-08-22T15:23:20.719116+01:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -48,10 +48,9 @@ class SqlConfig(BaseModel):
 
 
 class AdminApiConfig(BaseModel):
-    host: str
+    url: str
     token: str
     account_id: int
-    multicell_account_prefix: str | None = None
     prod_environment_id: int | None = None
 
 
@@ -224,11 +223,14 @@ def load_config() -> Config:
         and settings.actual_host
         and settings.dbt_account_id
     ):
+        if settings.multicell_account_prefix:
+            url = f"https://{settings.multicell_account_prefix}.{settings.actual_host}"
+        else:
+            url = f"https://{settings.actual_host}"
         admin_api_config = AdminApiConfig(
-            host=settings.actual_host,
+            url=url,
             token=settings.dbt_token,
             account_id=settings.dbt_account_id,
-            multicell_account_prefix=settings.multicell_account_prefix,
             prod_environment_id=settings.actual_prod_environment_id,
         )
 

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -19,24 +19,15 @@ class DbtAdminAPIClient:
 
     def __init__(self, config: AdminApiConfig):
         self.config = config
-        self.base_url = self._get_base_url()
         self.headers = {
             "Authorization": f"Bearer {config.token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
 
-    def _get_base_url(self) -> str:
-        """Get the base URL for the dbt API."""
-        if self.config.multicell_account_prefix:
-            return f"https://{self.config.multicell_account_prefix}.{self.config.host}"
-        else:
-            protocol = "https://" if not self.config.host.startswith("http") else ""
-            return f"{protocol}{self.config.host}"
-
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
         """Make a request to the dbt API."""
-        url = f"{self.base_url}{endpoint}"
+        url = f"{self.config.url}{endpoint}"
 
         try:
             response = requests.request(method, url, headers=self.headers, **kwargs)
@@ -243,7 +234,7 @@ class DbtAdminAPIClient:
         }
 
         response = requests.get(
-            f"{self.base_url}/api/v2/accounts/{account_id}/runs/{run_id}/artifacts/{artifact_path}",
+            f"{self.config.url}/api/v2/accounts/{account_id}/runs/{run_id}/artifacts/{artifact_path}",
             headers=get_artifact_header,
             params=params,
         )

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -31,7 +31,8 @@ class DbtAdminAPIClient:
         if self.config.multicell_account_prefix:
             return f"https://{self.config.multicell_account_prefix}.{self.config.host}"
         else:
-            return f"https://{self.config.host}"
+            protocol = "https://" if not self.config.host.startswith("http") else ""
+            return f"{protocol}{self.config.host}"
 
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
         """Make a request to the dbt API."""

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -1,4 +1,5 @@
 from dbt_mcp.config.config import (
+    AdminApiConfig,
     Config,
     DbtCliConfig,
     DiscoveryConfig,
@@ -51,11 +52,19 @@ mock_semantic_layer_config = SemanticLayerConfig(
     prod_environment_id=1,
 )
 
+mock_admin_api_config = AdminApiConfig(
+    url="http://localhost:8000",
+    token="token",
+    account_id=1,
+    prod_environment_id=1,
+)
+
 mock_config = Config(
     tracking_config=mock_tracking_config,
     sql_config=mock_sql_config,
     dbt_cli_config=mock_dbt_cli_config,
     discovery_config=mock_discovery_config,
     semantic_layer_config=mock_semantic_layer_config,
+    admin_api_config=mock_admin_api_config,
     disable_tools=[],
 )

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -170,11 +170,13 @@ class TestLoadConfig:
             "DBT_PROD_ENV_ID": "123",
             "DBT_DEV_ENV_ID": "456",
             "DBT_USER_ID": "789",
+            "DBT_ACCOUNT_ID": "123",
             "DBT_TOKEN": "test_token",
             "DBT_PROJECT_DIR": "/test/project",
             "DISABLE_SEMANTIC_LAYER": "false",
             "DISABLE_DISCOVERY": "false",
             "DISABLE_REMOTE": "false",
+            "DISABLE_ADMIN_API": "false",
         }
 
         config = self._load_config_with_env(env_vars)
@@ -186,6 +188,11 @@ class TestLoadConfig:
         assert config.dbt_cli_config is not None
         assert config.discovery_config is not None
         assert config.semantic_layer_config is not None
+        assert config.admin_api_config is not None
+        assert config.admin_api_config.url == "https://test.dbt.com"
+        assert config.admin_api_config.token == "test_token"
+        assert config.admin_api_config.account_id == 123
+        assert config.admin_api_config.prod_environment_id == 123
 
     def test_valid_config_all_services_disabled(self):
         env_vars = {

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -14,8 +14,7 @@ def admin_config():
     return AdminApiConfig(
         account_id=12345,
         token="test_token",
-        host="cloud.getdbt.com",
-        multicell_account_prefix=None,
+        url="https://cloud.getdbt.com",
     )
 
 
@@ -24,8 +23,7 @@ def admin_config_with_prefix():
     return AdminApiConfig(
         account_id=12345,
         token="test_token",
-        host="cloud.getdbt.com",
-        multicell_account_prefix="eu1",
+        url="https://eu1.cloud.getdbt.com",
     )
 
 
@@ -42,14 +40,10 @@ def client_with_prefix(admin_config_with_prefix):
 def test_client_initialization(client):
     assert client.config.account_id == 12345
     assert client.config.token == "test_token"
-    assert client.base_url == "https://cloud.getdbt.com"
+    assert client.config.url == "https://cloud.getdbt.com"
     assert client.headers["Authorization"] == "Bearer test_token"
     assert client.headers["Content-Type"] == "application/json"
     assert client.headers["Accept"] == "application/json"
-
-
-def test_client_initialization_with_prefix(client_with_prefix):
-    assert client_with_prefix.base_url == "https://eu1.cloud.getdbt.com"
 
 
 @patch("requests.request")

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -14,8 +14,7 @@ def mock_admin_config():
     return AdminApiConfig(
         account_id=12345,
         token="test_token",
-        host="cloud.getdbt.com",
-        multicell_account_prefix=None,
+        url="https://cloud.getdbt.com",
     )
 
 


### PR DESCRIPTION
Assemble the URL for the admin API client at config load time and pass along a finished url instead of the host
