### PR TITLE
Allow headers in AdminApiConfig

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250827-155713.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250827-155713.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Allow headers in AdminApiConfig
+time: 2025-08-27T15:57:13.093287-05:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -49,7 +49,7 @@ class SqlConfig(BaseModel):
 
 class AdminApiConfig(BaseModel):
     url: str
-    token: str
+    headers: dict[str, str]
     account_id: int
     prod_environment_id: int | None = None
 
@@ -229,7 +229,7 @@ def load_config() -> Config:
             url = f"https://{settings.actual_host}"
         admin_api_config = AdminApiConfig(
             url=url,
-            token=settings.dbt_token,
+            headers={"Authorization": f"Bearer {settings.dbt_token}"},
             account_id=settings.dbt_account_id,
             prod_environment_id=settings.actual_prod_environment_id,
         )

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -54,7 +54,7 @@ mock_semantic_layer_config = SemanticLayerConfig(
 
 mock_admin_api_config = AdminApiConfig(
     url="http://localhost:8000",
-    token="token",
+    headers={"Authorization": "Bearer token"},
     account_id=1,
     prod_environment_id=1,
 )

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -190,7 +190,7 @@ class TestLoadConfig:
         assert config.semantic_layer_config is not None
         assert config.admin_api_config is not None
         assert config.admin_api_config.url == "https://test.dbt.com"
-        assert config.admin_api_config.token == "test_token"
+        assert config.admin_api_config.headers == {"Authorization": "Bearer test_token"}
         assert config.admin_api_config.account_id == 123
         assert config.admin_api_config.prod_environment_id == 123
 

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -1,19 +1,20 @@
-import pytest
-import requests
 from unittest.mock import Mock, patch
 
-from dbt_mcp.dbt_admin.client import (
-    DbtAdminAPIClient,
-    AdminAPIError,
-)
+import pytest
+import requests
+
 from dbt_mcp.config.config import AdminApiConfig
+from dbt_mcp.dbt_admin.client import (
+    AdminAPIError,
+    DbtAdminAPIClient,
+)
 
 
 @pytest.fixture
 def admin_config():
     return AdminApiConfig(
         account_id=12345,
-        token="test_token",
+        headers={"Authorization": "Bearer test_token"},
         url="https://cloud.getdbt.com",
     )
 
@@ -22,7 +23,7 @@ def admin_config():
 def admin_config_with_prefix():
     return AdminApiConfig(
         account_id=12345,
-        token="test_token",
+        headers={"Authorization": "Bearer test_token"},
         url="https://eu1.cloud.getdbt.com",
     )
 
@@ -39,7 +40,7 @@ def client_with_prefix(admin_config_with_prefix):
 
 def test_client_initialization(client):
     assert client.config.account_id == 12345
-    assert client.config.token == "test_token"
+    assert client.config.headers == {"Authorization": "Bearer test_token"}
     assert client.config.url == "https://cloud.getdbt.com"
     assert client.headers["Authorization"] == "Bearer test_token"
     assert client.headers["Content-Type"] == "application/json"

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -1,19 +1,20 @@
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
+
+from dbt_mcp.config.config import AdminApiConfig, Config
 from dbt_mcp.dbt_admin.tools import (
-    register_admin_api_tools,
-    create_admin_api_tool_definitions,
     JobRunStatus,
+    create_admin_api_tool_definitions,
+    register_admin_api_tools,
 )
-from dbt_mcp.config.config import Config, AdminApiConfig
 
 
 @pytest.fixture
 def mock_admin_config():
     return AdminApiConfig(
         account_id=12345,
-        token="test_token",
+        headers={"Authorization": "Bearer test_token"},
         url="https://cloud.getdbt.com",
     )
 


### PR DESCRIPTION
This change allows us to configure the Admin API tools differently for our internal usage.