### PR TITLE
Expose `meta` attribute in list_metrics

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250828-121655.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250828-121655.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Adding the ability to return the config.meta attribute from list metrics to give the LLM more context
+time: 2025-08-28T12:16:55.17476-04:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -76,6 +76,7 @@ class SemanticLayerFetcher:
                 type=m.get("type"),
                 label=m.get("label"),
                 description=m.get("description"),
+                metadata=(m.get("config") or {}).get("meta", ""),
             )
             for m in metrics_result["data"]["metrics"]
         ]

--- a/src/dbt_mcp/semantic_layer/gql/gql.py
+++ b/src/dbt_mcp/semantic_layer/gql/gql.py
@@ -6,6 +6,9 @@ query GetMetrics($environmentId: BigInt!) {
     label
     description
     type
+    config {
+      meta
+    }
   }
 }
     """,

--- a/src/dbt_mcp/semantic_layer/types.py
+++ b/src/dbt_mcp/semantic_layer/types.py
@@ -17,6 +17,7 @@ class MetricToolResponse:
     type: MetricType
     label: str | None = None
     description: str | None = None
+    metadata: str | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Context
`meta` is a arbitrary dict that the user can define with any key/value entry. This allows users to provide additional information as they wish. We should surface this into the tool call as usually users put information such as owners, etc...