### PR TITLE
Add tools for fetching exposures

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250909-114729.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250909-114729.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add tools to retrieve exposure information from Disco API
+time: 2025-09-09T11:47:29.521205+02:00

--- a/src/dbt_mcp/prompts/discovery/get_exposure_details.md
+++ b/src/dbt_mcp/prompts/discovery/get_exposure_details.md
@@ -1,0 +1,22 @@
+Get detailed information about one or more exposures by name or unique IDs.
+
+Parameters:
+- unique_ids (optional): List of unique IDs of exposures (e.g., ["exposure.project.exposure1", "exposure.project.exposure2"]) (more efficient - uses GraphQL filter)
+
+Returns a list of detailed information dictionaries, each including:
+- name: The name of the exposure
+- description: Detailed description of the exposure
+- exposureType: Type of exposure (application, dashboard, analysis, etc.)
+- maturity: Maturity level of the exposure (high, medium, low)
+- ownerName: Name of the exposure owner
+- ownerEmail: Email of the exposure owner
+- url: URL associated with the exposure
+- label: Optional label for the exposure
+- parents: List of parent models/sources that this exposure depends on
+- meta: Additional metadata associated with the exposure
+- freshnessStatus: Current freshness status of the exposure
+- uniqueId: The unique identifier for this exposure
+
+Example usage:
+- Get single exposure by unique ID: get_exposure_details(unique_ids=["exposure.analytics.customer_dashboard"])
+- Get multiple exposures by unique IDs: get_exposure_details(unique_ids=["exposure.analytics.dashboard1", "exposure.sales.report2"])

--- a/src/dbt_mcp/prompts/discovery/get_exposures.md
+++ b/src/dbt_mcp/prompts/discovery/get_exposures.md
@@ -1,0 +1,7 @@
+Get the id, name, description, and url of all exposures in the dbt environment. Exposures represent downstream applications or analyses that depend on dbt models.
+
+Returns information including:
+- uniqueId: The unique identifier for this exposure taht can then be used to get more details about the exposure
+- name: The name of the exposure
+- description: Description of the exposure
+- url: URL associated with the exposure

--- a/src/dbt_mcp/tools/policy.py
+++ b/src/dbt_mcp/tools/policy.py
@@ -88,6 +88,12 @@ tool_policies = {
     ToolName.GET_ALL_MODELS.value: ToolPolicy(
         name=ToolName.GET_ALL_MODELS.value, behavior=ToolBehavior.METADATA
     ),
+    ToolName.GET_EXPOSURES.value: ToolPolicy(
+        name=ToolName.GET_EXPOSURES.value, behavior=ToolBehavior.METADATA
+    ),
+    ToolName.GET_EXPOSURE_DETAILS.value: ToolPolicy(
+        name=ToolName.GET_EXPOSURE_DETAILS.value, behavior=ToolBehavior.METADATA
+    ),
     # SQL tools
     ToolName.TEXT_TO_SQL.value: ToolPolicy(
         name=ToolName.TEXT_TO_SQL.value, behavior=ToolBehavior.METADATA

--- a/src/dbt_mcp/tools/tool_names.py
+++ b/src/dbt_mcp/tools/tool_names.py
@@ -33,6 +33,8 @@ class ToolName(Enum):
     GET_MODEL_PARENTS = "get_model_parents"
     GET_MODEL_CHILDREN = "get_model_children"
     GET_MODEL_HEALTH = "get_model_health"
+    GET_EXPOSURES = "get_exposures"
+    GET_EXPOSURE_DETAILS = "get_exposure_details"
 
     # SQL tools
     TEXT_TO_SQL = "text_to_sql"

--- a/src/dbt_mcp/tools/toolsets.py
+++ b/src/dbt_mcp/tools/toolsets.py
@@ -30,6 +30,8 @@ toolsets = {
         ToolName.GET_MODEL_PARENTS,
         ToolName.GET_MODEL_CHILDREN,
         ToolName.GET_MODEL_HEALTH,
+        ToolName.GET_EXPOSURES,
+        ToolName.GET_EXPOSURE_DETAILS,
     },
     Toolset.DBT_CLI: {
         ToolName.BUILD,

--- a/tests/unit/discovery/test_exposures_fetcher.py
+++ b/tests/unit/discovery/test_exposures_fetcher.py
@@ -1,0 +1,550 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from dbt_mcp.discovery.client import ExposuresFetcher, MetadataAPIClient
+
+
+@pytest.fixture
+def mock_api_client():
+    return Mock(spec=MetadataAPIClient)
+
+
+@pytest.fixture
+def exposures_fetcher(mock_api_client):
+    return ExposuresFetcher(api_client=mock_api_client, environment_id=123)
+
+
+def test_fetch_exposures_single_page(exposures_fetcher, mock_api_client):
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None
+                        },
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "test_exposure",
+                                    "uniqueId": "exposure.test.test_exposure",
+                                    "exposureType": "application",
+                                    "maturity": "high",
+                                    "ownerEmail": "test@example.com",
+                                    "ownerName": "Test Owner",
+                                    "url": "https://example.com",
+                                    "meta": {},
+                                    "freshnessStatus": "Unknown",
+                                    "description": "Test exposure",
+                                    "label": None,
+                                    "parents": [
+                                        {"uniqueId": "model.test.parent_model"}
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposures()
+    
+    assert len(result) == 1
+    assert result[0]["name"] == "test_exposure"
+    assert result[0]["uniqueId"] == "exposure.test.test_exposure"
+    assert result[0]["exposureType"] == "application"
+    assert result[0]["maturity"] == "high"
+    assert result[0]["ownerEmail"] == "test@example.com"
+    assert result[0]["ownerName"] == "Test Owner"
+    assert result[0]["url"] == "https://example.com"
+    assert result[0]["meta"] == {}
+    assert result[0]["freshnessStatus"] == "Unknown"
+    assert result[0]["description"] == "Test exposure"
+    assert result[0]["parents"] == [{"uniqueId": "model.test.parent_model"}]
+    
+    mock_api_client.execute_query.assert_called_once()
+    args, kwargs = mock_api_client.execute_query.call_args
+    assert args[1]["environmentId"] == 123
+    assert args[1]["first"] == 100
+
+
+def test_fetch_exposures_multiple_pages(exposures_fetcher, mock_api_client):
+    page1_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": True,
+                            "endCursor": "cursor123"
+                        },
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "exposure1",
+                                    "uniqueId": "exposure.test.exposure1",
+                                    "exposureType": "application",
+                                    "maturity": "high",
+                                    "ownerEmail": "test1@example.com",
+                                    "ownerName": "Test Owner 1",
+                                    "url": "https://example1.com",
+                                    "meta": {},
+                                    "freshnessStatus": "Unknown",
+                                    "description": "Test exposure 1",
+                                    "label": None,
+                                    "parents": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    page2_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": "cursor456"
+                        },
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "exposure2",
+                                    "uniqueId": "exposure.test.exposure2",
+                                    "exposureType": "dashboard",
+                                    "maturity": "medium",
+                                    "ownerEmail": "test2@example.com",
+                                    "ownerName": "Test Owner 2",
+                                    "url": "https://example2.com",
+                                    "meta": {"key": "value"},
+                                    "freshnessStatus": "Fresh",
+                                    "description": "Test exposure 2",
+                                    "label": "Label 2",
+                                    "parents": [
+                                        {"uniqueId": "model.test.parent_model2"}
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.side_effect = [page1_response, page2_response]
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposures()
+    
+    assert len(result) == 2
+    assert result[0]["name"] == "exposure1"
+    assert result[1]["name"] == "exposure2"
+    assert result[1]["meta"] == {"key": "value"}
+    assert result[1]["label"] == "Label 2"
+    
+    assert mock_api_client.execute_query.call_count == 2
+    
+    # Check first call (no cursor)
+    first_call = mock_api_client.execute_query.call_args_list[0]
+    assert first_call[0][1]["environmentId"] == 123
+    assert first_call[0][1]["first"] == 100
+    assert "after" not in first_call[0][1]
+    
+    # Check second call (with cursor)
+    second_call = mock_api_client.execute_query.call_args_list[1]
+    assert second_call[0][1]["environmentId"] == 123
+    assert second_call[0][1]["first"] == 100
+    assert second_call[0][1]["after"] == "cursor123"
+
+
+def test_fetch_exposures_empty_response(exposures_fetcher, mock_api_client):
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None
+                        },
+                        "edges": []
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposures()
+    
+    assert len(result) == 0
+    assert isinstance(result, list)
+
+
+def test_fetch_exposures_handles_malformed_edges(exposures_fetcher, mock_api_client):
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None
+                        },
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "valid_exposure",
+                                    "uniqueId": "exposure.test.valid_exposure",
+                                    "exposureType": "application",
+                                    "maturity": "high",
+                                    "ownerEmail": "test@example.com",
+                                    "ownerName": "Test Owner",
+                                    "url": "https://example.com",
+                                    "meta": {},
+                                    "freshnessStatus": "Unknown",
+                                    "description": "Valid exposure",
+                                    "label": None,
+                                    "parents": []
+                                }
+                            },
+                            {"invalid": "edge"},  # Missing "node" key
+                            {"node": "not_a_dict"},  # Node is not a dict
+                            {
+                                "node": {
+                                    "name": "another_valid_exposure",
+                                    "uniqueId": "exposure.test.another_valid_exposure",
+                                    "exposureType": "dashboard",
+                                    "maturity": "low",
+                                    "ownerEmail": "test2@example.com",
+                                    "ownerName": "Test Owner 2",
+                                    "url": "https://example2.com",
+                                    "meta": {},
+                                    "freshnessStatus": "Stale",
+                                    "description": "Another valid exposure",
+                                    "label": None,
+                                    "parents": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposures()
+    
+    # Should only get the valid exposures (malformed edges should be filtered out)
+    assert len(result) == 2
+    assert result[0]["name"] == "valid_exposure"
+    assert result[1]["name"] == "another_valid_exposure"
+
+
+def test_fetch_exposure_details_by_unique_ids_single(exposures_fetcher, mock_api_client):
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "customer_dashboard",
+                                    "uniqueId": "exposure.analytics.customer_dashboard",
+                                    "exposureType": "dashboard",
+                                    "maturity": "high",
+                                    "ownerEmail": "analytics@example.com",
+                                    "ownerName": "Analytics Team",
+                                    "url": "https://dashboard.example.com/customers",
+                                    "meta": {"team": "analytics", "priority": "high"},
+                                    "freshnessStatus": "Fresh",
+                                    "description": "Customer analytics dashboard",
+                                    "label": "Customer Dashboard",
+                                    "parents": [
+                                        {"uniqueId": "model.analytics.customers"},
+                                        {"uniqueId": "model.analytics.customer_metrics"}
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposure_details(
+            unique_ids=["exposure.analytics.customer_dashboard"]
+        )
+    
+    assert isinstance(result, list)
+    assert len(result) == 1
+    exposure = result[0]
+    assert exposure["name"] == "customer_dashboard"
+    assert exposure["uniqueId"] == "exposure.analytics.customer_dashboard"
+    assert exposure["exposureType"] == "dashboard"
+    assert exposure["maturity"] == "high"
+    assert exposure["ownerEmail"] == "analytics@example.com"
+    assert exposure["ownerName"] == "Analytics Team"
+    assert exposure["url"] == "https://dashboard.example.com/customers"
+    assert exposure["meta"] == {"team": "analytics", "priority": "high"}
+    assert exposure["freshnessStatus"] == "Fresh"
+    assert exposure["description"] == "Customer analytics dashboard"
+    assert exposure["label"] == "Customer Dashboard"
+    assert len(exposure["parents"]) == 2
+    assert exposure["parents"][0]["uniqueId"] == "model.analytics.customers"
+    assert exposure["parents"][1]["uniqueId"] == "model.analytics.customer_metrics"
+    
+    mock_api_client.execute_query.assert_called_once()
+    args, kwargs = mock_api_client.execute_query.call_args
+    assert args[1]["environmentId"] == 123
+    assert args[1]["first"] == 1
+    assert args[1]["filter"] == {"uniqueIds": ["exposure.analytics.customer_dashboard"]}
+
+
+def test_fetch_exposure_details_by_unique_ids_multiple(exposures_fetcher, mock_api_client):
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "customer_dashboard",
+                                    "uniqueId": "exposure.analytics.customer_dashboard",
+                                    "exposureType": "dashboard",
+                                    "maturity": "high",
+                                    "ownerEmail": "analytics@example.com",
+                                    "ownerName": "Analytics Team",
+                                    "url": "https://dashboard.example.com/customers",
+                                    "meta": {"team": "analytics", "priority": "high"},
+                                    "freshnessStatus": "Fresh",
+                                    "description": "Customer analytics dashboard",
+                                    "label": "Customer Dashboard",
+                                    "parents": []
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "sales_report",
+                                    "uniqueId": "exposure.sales.sales_report",
+                                    "exposureType": "analysis",
+                                    "maturity": "medium",
+                                    "ownerEmail": "sales@example.com",
+                                    "ownerName": "Sales Team",
+                                    "url": None,
+                                    "meta": {},
+                                    "freshnessStatus": "Stale",
+                                    "description": "Monthly sales analysis report",
+                                    "label": None,
+                                    "parents": [
+                                        {"uniqueId": "model.sales.sales_data"}
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposure_details(
+            unique_ids=["exposure.analytics.customer_dashboard", "exposure.sales.sales_report"]
+        )
+    
+    assert isinstance(result, list)
+    assert len(result) == 2
+    
+    # Check first exposure
+    exposure1 = result[0]
+    assert exposure1["name"] == "customer_dashboard"
+    assert exposure1["uniqueId"] == "exposure.analytics.customer_dashboard"
+    assert exposure1["exposureType"] == "dashboard"
+    
+    # Check second exposure
+    exposure2 = result[1]
+    assert exposure2["name"] == "sales_report"
+    assert exposure2["uniqueId"] == "exposure.sales.sales_report"
+    assert exposure2["exposureType"] == "analysis"
+    
+    mock_api_client.execute_query.assert_called_once()
+    args, kwargs = mock_api_client.execute_query.call_args
+    assert args[1]["environmentId"] == 123
+    assert args[1]["first"] == 2
+    assert args[1]["filter"] == {"uniqueIds": ["exposure.analytics.customer_dashboard", "exposure.sales.sales_report"]}
+
+
+def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
+    # Mock the response for fetch_exposures (which gets called when filtering by name)
+    mock_exposures_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None
+                        },
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "sales_report",
+                                    "uniqueId": "exposure.sales.sales_report",
+                                    "exposureType": "analysis",
+                                    "maturity": "medium",
+                                    "ownerEmail": "sales@example.com",
+                                    "ownerName": "Sales Team",
+                                    "url": None,
+                                    "meta": {},
+                                    "freshnessStatus": "Stale",
+                                    "description": "Monthly sales analysis report",
+                                    "label": None,
+                                    "parents": [
+                                        {"uniqueId": "model.sales.sales_data"}
+                                    ]
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "other_exposure",
+                                    "uniqueId": "exposure.other.other_exposure",
+                                    "exposureType": "dashboard",
+                                    "maturity": "high",
+                                    "ownerEmail": "other@example.com",
+                                    "ownerName": "Other Team",
+                                    "url": None,
+                                    "meta": {},
+                                    "freshnessStatus": "Fresh",
+                                    "description": "Other exposure",
+                                    "label": None,
+                                    "parents": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_exposures_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposure_details(exposure_name="sales_report")
+    
+    assert isinstance(result, list)
+    assert len(result) == 1
+    exposure = result[0]
+    assert exposure["name"] == "sales_report"
+    assert exposure["uniqueId"] == "exposure.sales.sales_report"
+    assert exposure["exposureType"] == "analysis"
+    assert exposure["maturity"] == "medium"
+    assert exposure["url"] is None
+    assert exposure["meta"] == {}
+    assert exposure["freshnessStatus"] == "Stale"
+    assert exposure["label"] is None
+    
+    # Should have called the GET_EXPOSURES query (not GET_EXPOSURE_DETAILS)
+    mock_api_client.execute_query.assert_called_once()
+    args, kwargs = mock_api_client.execute_query.call_args
+    assert args[1]["environmentId"] == 123
+    assert args[1]["first"] == 100  # PAGE_SIZE for fetch_exposures
+
+
+def test_fetch_exposure_details_not_found(exposures_fetcher, mock_api_client):
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "edges": []
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposure_details(
+            unique_ids=["exposure.nonexistent.exposure"]
+        )
+    
+    assert result == []
+
+
+def test_get_exposure_filters_unique_ids(exposures_fetcher):
+    filters = exposures_fetcher._get_exposure_filters(
+        unique_ids=["exposure.test.test_exposure"]
+    )
+    assert filters == {"uniqueIds": ["exposure.test.test_exposure"]}
+
+
+def test_get_exposure_filters_multiple_unique_ids(exposures_fetcher):
+    filters = exposures_fetcher._get_exposure_filters(
+        unique_ids=["exposure.test.test1", "exposure.test.test2"]
+    )
+    assert filters == {"uniqueIds": ["exposure.test.test1", "exposure.test.test2"]}
+
+
+def test_get_exposure_filters_name_raises_error(exposures_fetcher):
+    with pytest.raises(ValueError, match="ExposureFilter only supports uniqueIds"):
+        exposures_fetcher._get_exposure_filters(exposure_name="test_exposure")
+
+
+def test_get_exposure_filters_no_params(exposures_fetcher):
+    with pytest.raises(ValueError, match="unique_ids must be provided for exposure filtering"):
+        exposures_fetcher._get_exposure_filters()
+
+
+def test_fetch_exposure_details_by_name_not_found(exposures_fetcher, mock_api_client):
+    # Mock empty response for fetch_exposures
+    mock_response = {
+        "data": {
+            "environment": {
+                "definition": {
+                    "exposures": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None
+                        },
+                        "edges": []
+                    }
+                }
+            }
+        }
+    }
+    
+    mock_api_client.execute_query.return_value = mock_response
+    
+    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+        result = exposures_fetcher.fetch_exposure_details(exposure_name="nonexistent_exposure")
+    
+    assert result == []

--- a/tests/unit/discovery/test_exposures_fetcher.py
+++ b/tests/unit/discovery/test_exposures_fetcher.py
@@ -20,10 +20,7 @@ def test_fetch_exposures_single_page(exposures_fetcher, mock_api_client):
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": False,
-                            "endCursor": None
-                        },
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
                         "edges": [
                             {
                                 "node": {
@@ -40,21 +37,21 @@ def test_fetch_exposures_single_page(exposures_fetcher, mock_api_client):
                                     "label": None,
                                     "parents": [
                                         {"uniqueId": "model.test.parent_model"}
-                                    ]
+                                    ],
                                 }
                             }
-                        ]
+                        ],
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposures()
-    
+
     assert len(result) == 1
     assert result[0]["name"] == "test_exposure"
     assert result[0]["uniqueId"] == "exposure.test.test_exposure"
@@ -67,7 +64,7 @@ def test_fetch_exposures_single_page(exposures_fetcher, mock_api_client):
     assert result[0]["freshnessStatus"] == "Unknown"
     assert result[0]["description"] == "Test exposure"
     assert result[0]["parents"] == [{"uniqueId": "model.test.parent_model"}]
-    
+
     mock_api_client.execute_query.assert_called_once()
     args, kwargs = mock_api_client.execute_query.call_args
     assert args[1]["environmentId"] == 123
@@ -80,10 +77,7 @@ def test_fetch_exposures_multiple_pages(exposures_fetcher, mock_api_client):
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": True,
-                            "endCursor": "cursor123"
-                        },
+                        "pageInfo": {"hasNextPage": True, "endCursor": "cursor123"},
                         "edges": [
                             {
                                 "node": {
@@ -98,25 +92,22 @@ def test_fetch_exposures_multiple_pages(exposures_fetcher, mock_api_client):
                                     "freshnessStatus": "Unknown",
                                     "description": "Test exposure 1",
                                     "label": None,
-                                    "parents": []
+                                    "parents": [],
                                 }
                             }
-                        ]
+                        ],
                     }
                 }
             }
         }
     }
-    
+
     page2_response = {
         "data": {
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": False,
-                            "endCursor": "cursor456"
-                        },
+                        "pageInfo": {"hasNextPage": False, "endCursor": "cursor456"},
                         "edges": [
                             {
                                 "node": {
@@ -133,35 +124,35 @@ def test_fetch_exposures_multiple_pages(exposures_fetcher, mock_api_client):
                                     "label": "Label 2",
                                     "parents": [
                                         {"uniqueId": "model.test.parent_model2"}
-                                    ]
+                                    ],
                                 }
                             }
-                        ]
+                        ],
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.side_effect = [page1_response, page2_response]
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposures()
-    
+
     assert len(result) == 2
     assert result[0]["name"] == "exposure1"
     assert result[1]["name"] == "exposure2"
     assert result[1]["meta"] == {"key": "value"}
     assert result[1]["label"] == "Label 2"
-    
+
     assert mock_api_client.execute_query.call_count == 2
-    
+
     # Check first call (no cursor)
     first_call = mock_api_client.execute_query.call_args_list[0]
     assert first_call[0][1]["environmentId"] == 123
     assert first_call[0][1]["first"] == 100
     assert "after" not in first_call[0][1]
-    
+
     # Check second call (with cursor)
     second_call = mock_api_client.execute_query.call_args_list[1]
     assert second_call[0][1]["environmentId"] == 123
@@ -175,22 +166,19 @@ def test_fetch_exposures_empty_response(exposures_fetcher, mock_api_client):
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": False,
-                            "endCursor": None
-                        },
-                        "edges": []
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "edges": [],
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposures()
-    
+
     assert len(result) == 0
     assert isinstance(result, list)
 
@@ -201,10 +189,7 @@ def test_fetch_exposures_handles_malformed_edges(exposures_fetcher, mock_api_cli
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": False,
-                            "endCursor": None
-                        },
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
                         "edges": [
                             {
                                 "node": {
@@ -219,7 +204,7 @@ def test_fetch_exposures_handles_malformed_edges(exposures_fetcher, mock_api_cli
                                     "freshnessStatus": "Unknown",
                                     "description": "Valid exposure",
                                     "label": None,
-                                    "parents": []
+                                    "parents": [],
                                 }
                             },
                             {"invalid": "edge"},  # Missing "node" key
@@ -237,28 +222,30 @@ def test_fetch_exposures_handles_malformed_edges(exposures_fetcher, mock_api_cli
                                     "freshnessStatus": "Stale",
                                     "description": "Another valid exposure",
                                     "label": None,
-                                    "parents": []
+                                    "parents": [],
                                 }
-                            }
-                        ]
+                            },
+                        ],
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposures()
-    
+
     # Should only get the valid exposures (malformed edges should be filtered out)
     assert len(result) == 2
     assert result[0]["name"] == "valid_exposure"
     assert result[1]["name"] == "another_valid_exposure"
 
 
-def test_fetch_exposure_details_by_unique_ids_single(exposures_fetcher, mock_api_client):
+def test_fetch_exposure_details_by_unique_ids_single(
+    exposures_fetcher, mock_api_client
+):
     mock_response = {
         "data": {
             "environment": {
@@ -280,8 +267,10 @@ def test_fetch_exposure_details_by_unique_ids_single(exposures_fetcher, mock_api
                                     "label": "Customer Dashboard",
                                     "parents": [
                                         {"uniqueId": "model.analytics.customers"},
-                                        {"uniqueId": "model.analytics.customer_metrics"}
-                                    ]
+                                        {
+                                            "uniqueId": "model.analytics.customer_metrics"
+                                        },
+                                    ],
                                 }
                             }
                         ]
@@ -290,14 +279,14 @@ def test_fetch_exposure_details_by_unique_ids_single(exposures_fetcher, mock_api
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposure_details(
             unique_ids=["exposure.analytics.customer_dashboard"]
         )
-    
+
     assert isinstance(result, list)
     assert len(result) == 1
     exposure = result[0]
@@ -315,7 +304,7 @@ def test_fetch_exposure_details_by_unique_ids_single(exposures_fetcher, mock_api
     assert len(exposure["parents"]) == 2
     assert exposure["parents"][0]["uniqueId"] == "model.analytics.customers"
     assert exposure["parents"][1]["uniqueId"] == "model.analytics.customer_metrics"
-    
+
     mock_api_client.execute_query.assert_called_once()
     args, kwargs = mock_api_client.execute_query.call_args
     assert args[1]["environmentId"] == 123
@@ -323,7 +312,9 @@ def test_fetch_exposure_details_by_unique_ids_single(exposures_fetcher, mock_api
     assert args[1]["filter"] == {"uniqueIds": ["exposure.analytics.customer_dashboard"]}
 
 
-def test_fetch_exposure_details_by_unique_ids_multiple(exposures_fetcher, mock_api_client):
+def test_fetch_exposure_details_by_unique_ids_multiple(
+    exposures_fetcher, mock_api_client
+):
     mock_response = {
         "data": {
             "environment": {
@@ -343,7 +334,7 @@ def test_fetch_exposure_details_by_unique_ids_multiple(exposures_fetcher, mock_a
                                     "freshnessStatus": "Fresh",
                                     "description": "Customer analytics dashboard",
                                     "label": "Customer Dashboard",
-                                    "parents": []
+                                    "parents": [],
                                 }
                             },
                             {
@@ -359,45 +350,51 @@ def test_fetch_exposure_details_by_unique_ids_multiple(exposures_fetcher, mock_a
                                     "freshnessStatus": "Stale",
                                     "description": "Monthly sales analysis report",
                                     "label": None,
-                                    "parents": [
-                                        {"uniqueId": "model.sales.sales_data"}
-                                    ]
+                                    "parents": [{"uniqueId": "model.sales.sales_data"}],
                                 }
-                            }
+                            },
                         ]
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposure_details(
-            unique_ids=["exposure.analytics.customer_dashboard", "exposure.sales.sales_report"]
+            unique_ids=[
+                "exposure.analytics.customer_dashboard",
+                "exposure.sales.sales_report",
+            ]
         )
-    
+
     assert isinstance(result, list)
     assert len(result) == 2
-    
+
     # Check first exposure
     exposure1 = result[0]
     assert exposure1["name"] == "customer_dashboard"
     assert exposure1["uniqueId"] == "exposure.analytics.customer_dashboard"
     assert exposure1["exposureType"] == "dashboard"
-    
+
     # Check second exposure
     exposure2 = result[1]
     assert exposure2["name"] == "sales_report"
     assert exposure2["uniqueId"] == "exposure.sales.sales_report"
     assert exposure2["exposureType"] == "analysis"
-    
+
     mock_api_client.execute_query.assert_called_once()
     args, kwargs = mock_api_client.execute_query.call_args
     assert args[1]["environmentId"] == 123
     assert args[1]["first"] == 2
-    assert args[1]["filter"] == {"uniqueIds": ["exposure.analytics.customer_dashboard", "exposure.sales.sales_report"]}
+    assert args[1]["filter"] == {
+        "uniqueIds": [
+            "exposure.analytics.customer_dashboard",
+            "exposure.sales.sales_report",
+        ]
+    }
 
 
 def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
@@ -407,10 +404,7 @@ def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": False,
-                            "endCursor": None
-                        },
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
                         "edges": [
                             {
                                 "node": {
@@ -425,9 +419,7 @@ def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
                                     "freshnessStatus": "Stale",
                                     "description": "Monthly sales analysis report",
                                     "label": None,
-                                    "parents": [
-                                        {"uniqueId": "model.sales.sales_data"}
-                                    ]
+                                    "parents": [{"uniqueId": "model.sales.sales_data"}],
                                 }
                             },
                             {
@@ -443,21 +435,21 @@ def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
                                     "freshnessStatus": "Fresh",
                                     "description": "Other exposure",
                                     "label": None,
-                                    "parents": []
+                                    "parents": [],
                                 }
-                            }
-                        ]
+                            },
+                        ],
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_exposures_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposure_details(exposure_name="sales_report")
-    
+
     assert isinstance(result, list)
     assert len(result) == 1
     exposure = result[0]
@@ -469,7 +461,7 @@ def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
     assert exposure["meta"] == {}
     assert exposure["freshnessStatus"] == "Stale"
     assert exposure["label"] is None
-    
+
     # Should have called the GET_EXPOSURES query (not GET_EXPOSURE_DETAILS)
     mock_api_client.execute_query.assert_called_once()
     args, kwargs = mock_api_client.execute_query.call_args
@@ -479,24 +471,16 @@ def test_fetch_exposure_details_by_name(exposures_fetcher, mock_api_client):
 
 def test_fetch_exposure_details_not_found(exposures_fetcher, mock_api_client):
     mock_response = {
-        "data": {
-            "environment": {
-                "definition": {
-                    "exposures": {
-                        "edges": []
-                    }
-                }
-            }
-        }
+        "data": {"environment": {"definition": {"exposures": {"edges": []}}}}
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
         result = exposures_fetcher.fetch_exposure_details(
             unique_ids=["exposure.nonexistent.exposure"]
         )
-    
+
     assert result == []
 
 
@@ -520,7 +504,9 @@ def test_get_exposure_filters_name_raises_error(exposures_fetcher):
 
 
 def test_get_exposure_filters_no_params(exposures_fetcher):
-    with pytest.raises(ValueError, match="unique_ids must be provided for exposure filtering"):
+    with pytest.raises(
+        ValueError, match="unique_ids must be provided for exposure filtering"
+    ):
         exposures_fetcher._get_exposure_filters()
 
 
@@ -531,20 +517,19 @@ def test_fetch_exposure_details_by_name_not_found(exposures_fetcher, mock_api_cl
             "environment": {
                 "definition": {
                     "exposures": {
-                        "pageInfo": {
-                            "hasNextPage": False,
-                            "endCursor": None
-                        },
-                        "edges": []
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "edges": [],
                     }
                 }
             }
         }
     }
-    
+
     mock_api_client.execute_query.return_value = mock_response
-    
-    with patch('dbt_mcp.discovery.client.raise_gql_error'):
-        result = exposures_fetcher.fetch_exposure_details(exposure_name="nonexistent_exposure")
-    
+
+    with patch("dbt_mcp.discovery.client.raise_gql_error"):
+        result = exposures_fetcher.fetch_exposure_details(
+            exposure_name="nonexistent_exposure"
+        )
+
     assert result == []


### PR DESCRIPTION
Requested by our internal analytics team

Adding tools to fetch exposures:
- get_exposures return all of them, with a subset of fields
- get_exposure_details accepts a list of IDs and return more information

I will raise a PR in the docs site when merged.