### PR TITLE
 Add dbt-codegen MCP toolset 

### DIFF
--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -46,6 +46,13 @@ class DbtCliConfig(BaseModel):
     dbt_cli_timeout: int
     binary_type: BinaryType
 
+class DbtCodegenConfig(BaseModel):
+    project_dir: str
+    dbt_path: str
+    dbt_cli_timeout: int
+    binary_type: BinaryType
+
+
 
 class SqlConfig(BaseModel):
     host_prefix: str | None = None
@@ -93,6 +100,7 @@ class DbtMcpSettings(BaseSettings):
 
     # Disable tool settings
     disable_dbt_cli: bool = Field(False, alias="DISABLE_DBT_CLI")
+    disable_dbt_codegen: bool = Field(False, alias="DISABLE_DBT_CODEGEN")
     disable_semantic_layer: bool = Field(False, alias="DISABLE_SEMANTIC_LAYER")
     disable_discovery: bool = Field(False, alias="DISABLE_DISCOVERY")
     disable_remote: bool | None = Field(None, alias="DISABLE_REMOTE")
@@ -156,6 +164,7 @@ class Config(BaseModel):
     tracking_config: TrackingConfig
     sql_config: SqlConfig | None = None
     dbt_cli_config: DbtCliConfig | None = None
+    dbt_codegen_config: DbtCodegenConfig | None = None
     discovery_config: DiscoveryConfig | None = None
     semantic_layer_config: SemanticLayerConfig | None = None
     admin_api_config: AdminApiConfig | None = None
@@ -380,6 +389,16 @@ def create_config(settings: DbtMcpSettings) -> Config:
             binary_type=binary_type,
         )
 
+    dbt_codegen_config = None
+    if not settings.disable_dbt_codegen and settings.dbt_project_dir and settings.dbt_path:
+        binary_type = detect_binary_type(settings.dbt_path)
+        dbt_codegen_config = DbtCodegenConfig(
+            project_dir=settings.dbt_project_dir,
+            dbt_path=settings.dbt_path,
+            dbt_cli_timeout=settings.dbt_cli_timeout,
+            binary_type=binary_type,
+        )
+        
     discovery_config = None
     if (
         not settings.disable_discovery
@@ -451,6 +470,7 @@ def create_config(settings: DbtMcpSettings) -> Config:
         ),
         sql_config=sql_config,
         dbt_cli_config=dbt_cli_config,
+        dbt_codegen_config=dbt_codegen_config,
         discovery_config=discovery_config,
         semantic_layer_config=semantic_layer_config,
         admin_api_config=admin_api_config,

--- a/src/dbt_mcp/dbt_codegen/__init__.py
+++ b/src/dbt_mcp/dbt_codegen/__init__.py
@@ -1,0 +1,1 @@
+"""dbt-codegen MCP tools for automated dbt code generation."""

--- a/src/dbt_mcp/dbt_codegen/tools.py
+++ b/src/dbt_mcp/dbt_codegen/tools.py
@@ -1,0 +1,216 @@
+import json
+import os
+import subprocess
+from collections.abc import Sequence
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from dbt_mcp.config.config import DbtCodegenConfig
+from dbt_mcp.dbt_cli.binary_type import get_color_disable_flag
+from dbt_mcp.prompts.prompts import get_prompt
+from dbt_mcp.tools.definitions import ToolDefinition
+from dbt_mcp.tools.register import register_tools
+from dbt_mcp.tools.tool_names import ToolName
+from dbt_mcp.tools.annotations import create_tool_annotations
+
+
+def create_dbt_codegen_tool_definitions(config: DbtCodegenConfig) -> list[ToolDefinition]:
+    def _run_codegen_operation(
+        macro_name: str,
+        args: dict[str, any] | None = None,
+    ) -> str:
+        """Execute a dbt-codegen macro using dbt run-operation."""
+        try:
+            # Build the dbt run-operation command
+            command = ["run-operation", macro_name]
+            
+            # Add arguments if provided
+            if args:
+                # Convert args to JSON string for dbt
+                args_json = json.dumps(args)
+                command.extend(["--args", args_json])
+            
+            full_command = command.copy()
+            # Add --quiet flag to reduce output verbosity
+            main_command = full_command[0]
+            command_args = full_command[1:] if len(full_command) > 1 else []
+            full_command = [main_command, "--quiet", *command_args]
+            
+            # We change the path only if this is an absolute path, otherwise we can have
+            # problems with relative paths applied multiple times as DBT_PROJECT_DIR
+            # is applied to dbt Core and Fusion as well (but not the dbt Cloud CLI)
+            cwd_path = config.project_dir if os.path.isabs(config.project_dir) else None
+            
+            # Add appropriate color disable flag based on binary type
+            color_flag = get_color_disable_flag(config.binary_type)
+            args_list = [config.dbt_path, color_flag, *full_command]
+            
+            process = subprocess.Popen(
+                args=args_list,
+                cwd=cwd_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+            )
+            output, _ = process.communicate(timeout=config.dbt_cli_timeout)
+            
+            # Return the output directly or handle errors
+            if process.returncode != 0:
+                if "dbt found" in output and "resource" in output:
+                    return f"Error: dbt-codegen package may not be installed. Run 'dbt deps' to install it.\n{output}"
+                return f"Error running dbt-codegen macro: {output}"
+            
+            return output or "OK"
+            
+        except subprocess.TimeoutExpired:
+            return f"Timeout: dbt-codegen operation took longer than {config.dbt_cli_timeout} seconds."
+        except Exception as e:
+            return str(e)
+
+    def generate_source(
+        schema_name: str = Field(
+            description=get_prompt("dbt_codegen/args/schema_name")
+        ),
+        database_name: str | None = Field(
+            default=None, description=get_prompt("dbt_codegen/args/database_name")
+        ),
+        table_names: list[str] | None = Field(
+            default=None, description=get_prompt("dbt_codegen/args/table_names")
+        ),
+        generate_columns: bool = Field(
+            default=False, description=get_prompt("dbt_codegen/args/generate_columns")
+        ),
+        include_descriptions: bool = Field(
+            default=False, description=get_prompt("dbt_codegen/args/include_descriptions")
+        ),
+    ) -> str:
+        args = {"schema_name": schema_name}
+        if database_name:
+            args["database_name"] = database_name
+        if table_names:
+            args["table_names"] = table_names
+        if generate_columns:
+            args["generate_columns"] = generate_columns
+        if include_descriptions:
+            args["include_descriptions"] = include_descriptions
+        
+        return _run_codegen_operation("generate_source", args)
+
+    def generate_model_yaml(
+        model_names: list[str] = Field(
+            description=get_prompt("dbt_codegen/args/model_names")
+        ),
+        upstream_descriptions: bool = Field(
+            default=False, description=get_prompt("dbt_codegen/args/upstream_descriptions")
+        ),
+        include_data_types: bool = Field(
+            default=True, description=get_prompt("dbt_codegen/args/include_data_types")
+        ),
+    ) -> str:
+        args = {
+            "model_names": model_names,
+            "upstream_descriptions": upstream_descriptions,
+            "include_data_types": include_data_types,
+        }
+        
+        return _run_codegen_operation("generate_model_yaml", args)
+
+    def generate_base_model(
+        source_name: str = Field(
+            description=get_prompt("dbt_codegen/args/source_name")
+        ),
+        table_name: str = Field(
+            description=get_prompt("dbt_codegen/args/table_name")
+        ),
+        leading_commas: bool = Field(
+            default=False, description=get_prompt("dbt_codegen/args/leading_commas")
+        ),
+        case_sensitive_cols: bool = Field(
+            default=False, description=get_prompt("dbt_codegen/args/case_sensitive_cols")
+        ),
+        materialized: str | None = Field(
+            default=None, description=get_prompt("dbt_codegen/args/materialized")
+        ),
+    ) -> str:
+        args = {
+            "source_name": source_name,
+            "table_name": table_name,
+            "leading_commas": leading_commas,
+            "case_sensitive_cols": case_sensitive_cols,
+        }
+        if materialized:
+            args["materialized"] = materialized
+        
+        return _run_codegen_operation("generate_base_model", args)
+
+    def generate_model_import_ctes(
+        model_name: str = Field(
+            description=get_prompt("dbt_codegen/args/model_name")
+        ),
+        leading_commas: bool = Field(
+            default=False, description=get_prompt("dbt_codegen/args/leading_commas")
+        ),
+    ) -> str:
+        args = {
+            "model_name": model_name,
+            "leading_commas": leading_commas,
+        }
+        
+        return _run_codegen_operation("generate_model_import_ctes", args)
+
+    return [
+        ToolDefinition(
+            fn=generate_source,
+            description=get_prompt("dbt_codegen/generate_source"),
+            annotations=create_tool_annotations(
+                title="dbt-codegen generate_source",
+                read_only_hint=True,
+                destructive_hint=False,
+                idempotent_hint=True,
+            ),
+        ),
+        ToolDefinition(
+            fn=generate_model_yaml,
+            description=get_prompt("dbt_codegen/generate_model_yaml"),
+            annotations=create_tool_annotations(
+                title="dbt-codegen generate_model_yaml",
+                read_only_hint=True,
+                destructive_hint=False,
+                idempotent_hint=True,
+            ),
+        ),
+        ToolDefinition(
+            fn=generate_base_model,
+            description=get_prompt("dbt_codegen/generate_base_model"),
+            annotations=create_tool_annotations(
+                title="dbt-codegen generate_base_model",
+                read_only_hint=True,
+                destructive_hint=False,
+                idempotent_hint=True,
+            ),
+        ),
+        ToolDefinition(
+            fn=generate_model_import_ctes,
+            description=get_prompt("dbt_codegen/generate_model_import_ctes"),
+            annotations=create_tool_annotations(
+                title="dbt-codegen generate_model_import_ctes",
+                read_only_hint=True,
+                destructive_hint=False,
+                idempotent_hint=True,
+            ),
+        ),
+    ]
+
+
+def register_dbt_codegen_tools(
+    dbt_mcp: FastMCP,
+    config: DbtCodegenConfig,
+    exclude_tools: Sequence[ToolName] = [],
+) -> None:
+    register_tools(
+        dbt_mcp,
+        create_dbt_codegen_tool_definitions(config),
+        exclude_tools,
+    )

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -16,6 +16,7 @@ from mcp.types import (
 from dbt_mcp.config.config import Config
 from dbt_mcp.dbt_admin.tools import register_admin_api_tools
 from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
+from dbt_mcp.dbt_codegen.tools import register_dbt_codegen_tools
 from dbt_mcp.discovery.tools import register_discovery_tools
 from dbt_mcp.semantic_layer.tools import register_sl_tools
 from dbt_mcp.sql.tools import SqlToolsManager, register_sql_tools
@@ -119,6 +120,10 @@ async def create_dbt_mcp(config: Config) -> DbtMCP:
     if config.dbt_cli_config:
         logger.info("Registering dbt cli tools")
         register_dbt_cli_tools(dbt_mcp, config.dbt_cli_config, config.disable_tools)
+        
+    if config.dbt_codegen_config:
+        logger.info("Registering dbt codegen tools")
+        register_dbt_codegen_tools(dbt_mcp, config.dbt_codegen_config, config.disable_tools)
 
     if config.admin_api_config:
         logger.info("Registering dbt admin API tools")

--- a/src/dbt_mcp/prompts/dbt_codegen/args/case_sensitive_cols.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/case_sensitive_cols.md
@@ -1,0 +1,1 @@
+Whether to quote column names to preserve case sensitivity (optional, default false)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/database_name.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/database_name.md
@@ -1,0 +1,1 @@
+The database that contains your source data (optional, defaults to target database)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/generate_columns.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/generate_columns.md
@@ -1,0 +1,1 @@
+Whether to include column definitions in the generated source YAML (optional, default false)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/include_data_types.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/include_data_types.md
@@ -1,0 +1,1 @@
+Whether to include data types in the model column definitions (optional, default true)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/include_descriptions.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/include_descriptions.md
@@ -1,0 +1,1 @@
+Whether to include placeholder descriptions in the generated YAML (optional, default false)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/leading_commas.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/leading_commas.md
@@ -1,0 +1,1 @@
+Whether to use leading commas instead of trailing commas in SQL (optional, default false)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/materialized.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/materialized.md
@@ -1,0 +1,1 @@
+The materialization type for the model config block (optional, e.g., 'view', 'table')

--- a/src/dbt_mcp/prompts/dbt_codegen/args/model_name.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/model_name.md
@@ -1,0 +1,1 @@
+The name of the model to generate import CTEs for (required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/model_name.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/model_name.md
@@ -1,1 +1,1 @@
-The name of the model to generate import CTEs for (required)
+The name of the model to generate import CTEs for, search for the model name provided with and without extension provided by users(required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/model_names.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/model_names.md
@@ -1,1 +1,1 @@
-List of model names to generate YAML documentation for (required)
+List of model names to generate YAML documentation for, search for the model names provided with and without extension provided by users(required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/model_names.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/model_names.md
@@ -1,0 +1,1 @@
+List of model names to generate YAML documentation for (required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/schema_name.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/schema_name.md
@@ -1,0 +1,1 @@
+The schema name in your database that contains the source tables (required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/source_name.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/source_name.md
@@ -1,0 +1,1 @@
+The source name as defined in your sources.yml file (required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/table_name.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/table_name.md
@@ -1,0 +1,1 @@
+The source table name to generate a base model for (required)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/table_names.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/table_names.md
@@ -1,0 +1,1 @@
+List of specific table names to generate source definitions for (optional, generates all tables if not specified)

--- a/src/dbt_mcp/prompts/dbt_codegen/args/upstream_descriptions.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/args/upstream_descriptions.md
@@ -1,0 +1,1 @@
+Whether to include descriptions from upstream models for matching column names (optional, default false)

--- a/src/dbt_mcp/prompts/dbt_codegen/generate_base_model.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/generate_base_model.md
@@ -1,0 +1,1 @@
+Generate SQL for a base/staging model from a source table. This creates a standardized SQL select statement with all columns from the source, following best practices for staging models. The generated SQL can be saved as a new model file.

--- a/src/dbt_mcp/prompts/dbt_codegen/generate_model_import_ctes.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/generate_model_import_ctes.md
@@ -1,0 +1,1 @@
+Generate import CTEs for a model based on its dependencies. This creates the 'with' statements that import all referenced models at the beginning of a SQL file, following dbt best practices for model structure and readability.

--- a/src/dbt_mcp/prompts/dbt_codegen/generate_model_yaml.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/generate_model_yaml.md
@@ -1,0 +1,1 @@
+Generate YAML documentation for dbt models including column names, data types, and optionally descriptions from upstream models. This tool introspects compiled models to create comprehensive documentation that can be added to schema.yml files.

--- a/src/dbt_mcp/prompts/dbt_codegen/generate_source.md
+++ b/src/dbt_mcp/prompts/dbt_codegen/generate_source.md
@@ -1,0 +1,1 @@
+Generate YAML for dbt sources by introspecting database schemas. This tool queries the actual database to create accurate source definitions with all tables and optionally their columns. Use this for initial source setup or when adding new tables to your project.

--- a/src/dbt_mcp/tools/tool_names.py
+++ b/src/dbt_mcp/tools/tool_names.py
@@ -51,6 +51,12 @@ class ToolName(Enum):
     LIST_JOB_RUN_ARTIFACTS = "list_job_run_artifacts"
     GET_JOB_RUN_ARTIFACT = "get_job_run_artifact"
 
+    # dbt-codegen tools
+    GENERATE_SOURCE = "generate_source"
+    GENERATE_MODEL_YAML = "generate_model_yaml"
+    GENERATE_BASE_MODEL = "generate_base_model"
+    GENERATE_MODEL_IMPORT_CTES = "generate_model_import_ctes"
+    
     @classmethod
     def get_all_tool_names(cls) -> set[str]:
         """Returns a set of all tool names as strings."""

--- a/src/dbt_mcp/tools/toolsets.py
+++ b/src/dbt_mcp/tools/toolsets.py
@@ -9,7 +9,7 @@ class Toolset(Enum):
     DISCOVERY = "discovery"
     DBT_CLI = "dbt_cli"
     ADMIN_API = "admin_api"
-
+    DBT_CODEGEN = "dbt_codegen"
 
 toolsets = {
     Toolset.SQL: {
@@ -54,4 +54,11 @@ toolsets = {
         ToolName.LIST_JOB_RUN_ARTIFACTS,
         ToolName.GET_JOB_RUN_ARTIFACT,
     },
+    Toolset.DBT_CODEGEN: {
+        ToolName.GENERATE_SOURCE,
+        ToolName.GENERATE_MODEL_YAML,
+        ToolName.GENERATE_BASE_MODEL,
+        ToolName.GENERATE_MODEL_IMPORT_CTES,
+    },
+    
 }

--- a/tests/integration/dbt_codegen/test_dbt_codegen.py
+++ b/tests/integration/dbt_codegen/test_dbt_codegen.py
@@ -1,0 +1,255 @@
+"""Integration tests for dbt-codegen MCP tools.
+
+These tests require a dbt project with dbt-codegen package installed.
+They test the end-to-end functionality of the dbt-codegen tools.
+"""
+
+import os
+import pytest
+
+from dbt_mcp.config.config import DbtCodegenConfig, load_config
+from dbt_mcp.dbt_cli.binary_type import BinaryType
+from dbt_mcp.dbt_codegen.tools import create_dbt_codegen_tool_definitions
+
+
+@pytest.fixture
+def dbt_codegen_config():
+    """Fixture for dbt-codegen configuration."""
+    # Try to load from full config first
+    try:
+        config = load_config()
+        if config.dbt_codegen_config:
+            return config.dbt_codegen_config
+    except:
+        pass
+    
+    # Fall back to environment variables
+    project_dir = os.getenv("DBT_PROJECT_DIR")
+    dbt_path = os.getenv("DBT_PATH", "dbt")
+    dbt_cli_timeout = os.getenv("DBT_CLI_TIMEOUT", "30")
+    
+    if not project_dir:
+        pytest.skip("DBT_PROJECT_DIR environment variable is required for integration tests")
+    
+    return DbtCodegenConfig(
+        project_dir=project_dir,
+        dbt_path=dbt_path,
+        dbt_cli_timeout=int(dbt_cli_timeout),
+        binary_type=BinaryType.DBT_CORE,
+    )
+
+
+@pytest.fixture
+def generate_source_tool(dbt_codegen_config):
+    """Fixture for generate_source tool."""
+    tools = create_dbt_codegen_tool_definitions(dbt_codegen_config)
+    for tool in tools:
+        if tool.fn.__name__ == "generate_source":
+            return tool.fn
+    raise ValueError("generate_source tool not found")
+
+
+@pytest.fixture
+def generate_model_yaml_tool(dbt_codegen_config):
+    """Fixture for generate_model_yaml tool."""
+    tools = create_dbt_codegen_tool_definitions(dbt_codegen_config)
+    for tool in tools:
+        if tool.fn.__name__ == "generate_model_yaml":
+            return tool.fn
+    raise ValueError("generate_model_yaml tool not found")
+
+
+@pytest.fixture
+def generate_base_model_tool(dbt_codegen_config):
+    """Fixture for generate_base_model tool."""
+    tools = create_dbt_codegen_tool_definitions(dbt_codegen_config)
+    for tool in tools:
+        if tool.fn.__name__ == "generate_base_model":
+            return tool.fn
+    raise ValueError("generate_base_model tool not found")
+
+
+@pytest.fixture
+def generate_model_import_ctes_tool(dbt_codegen_config):
+    """Fixture for generate_model_import_ctes tool."""
+    tools = create_dbt_codegen_tool_definitions(dbt_codegen_config)
+    for tool in tools:
+        if tool.fn.__name__ == "generate_model_import_ctes":
+            return tool.fn
+    raise ValueError("generate_model_import_ctes tool not found")
+
+
+def test_generate_source_basic(generate_source_tool):
+    """Test basic source generation with minimal parameters."""
+    # This will fail if dbt-codegen is not installed
+    result = generate_source_tool(schema_name="public")
+    
+    # Check for error conditions
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        else:
+            pytest.fail(f"Unexpected error: {result}")
+    
+    # Basic validation - should return YAML-like content
+    assert result is not None
+    assert len(result) > 0
+
+
+def test_generate_source_with_columns(generate_source_tool):
+    """Test source generation with column definitions."""
+    result = generate_source_tool(
+        schema_name="public",
+        generate_columns=True,
+        include_descriptions=True
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        else:
+            pytest.fail(f"Unexpected error: {result}")
+    
+    assert result is not None
+
+
+def test_generate_source_with_specific_tables(generate_source_tool):
+    """Test source generation for specific tables."""
+    result = generate_source_tool(
+        schema_name="public",
+        table_names=["users", "orders"],
+        generate_columns=True
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+    
+    assert result is not None
+
+
+def test_generate_model_yaml(generate_model_yaml_tool):
+    """Test model YAML generation."""
+    # This assumes there's at least one model in the project
+    result = generate_model_yaml_tool(
+        model_names=["stg_customers"],  # Common example model
+        include_data_types=True
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        elif "Model" in result and "not found" in result:
+            pytest.skip("Test model not found in project")
+    
+    assert result is not None
+
+
+def test_generate_model_yaml_with_upstream(generate_model_yaml_tool):
+    """Test model YAML generation with upstream descriptions."""
+    result = generate_model_yaml_tool(
+        model_names=["stg_customers"],
+        upstream_descriptions=True,
+        include_data_types=True
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        elif "Model" in result and "not found" in result:
+            pytest.skip("Test model not found in project")
+    
+    assert result is not None
+
+
+def test_generate_base_model(generate_base_model_tool):
+    """Test base model SQL generation."""
+    # This assumes a source is defined
+    result = generate_base_model_tool(
+        source_name="raw",  # Common source name
+        table_name="customers",
+        leading_commas=False,
+        materialized="view"
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        elif "Source" in result and "not found" in result:
+            pytest.skip("Test source not found in project")
+    
+    # Should generate SQL with SELECT statement
+    assert result is not None
+
+
+def test_generate_base_model_with_case_sensitive(generate_base_model_tool):
+    """Test base model generation with case-sensitive columns."""
+    result = generate_base_model_tool(
+        source_name="raw",
+        table_name="customers",
+        case_sensitive_cols=True,
+        leading_commas=True
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        elif "Source" in result and "not found" in result:
+            pytest.skip("Test source not found in project")
+    
+    assert result is not None
+
+
+def test_generate_model_import_ctes(generate_model_import_ctes_tool):
+    """Test import CTE generation."""
+    result = generate_model_import_ctes_tool(
+        model_name="fct_orders",  # Common fact model
+        leading_commas=False
+    )
+    
+    if "Error:" in result:
+        if "dbt-codegen package may not be installed" in result:
+            pytest.skip("dbt-codegen package not installed")
+        elif "Model" in result and "not found" in result:
+            pytest.skip("Test model not found in project")
+    
+    assert result is not None
+
+
+def test_error_handling_invalid_schema(generate_source_tool):
+    """Test handling of invalid schema names."""
+    # Use a schema that definitely doesn't exist
+    result = generate_source_tool(schema_name="definitely_nonexistent_schema_12345")
+    
+    if "dbt-codegen package may not be installed" in result:
+        pytest.skip("dbt-codegen package not installed")
+    
+    # Should return an error but not crash
+    assert result is not None
+
+
+def test_error_handling_invalid_model(generate_model_yaml_tool):
+    """Test handling of non-existent model names."""
+    result = generate_model_yaml_tool(
+        model_names=["definitely_nonexistent_model_12345"]
+    )
+    
+    if "dbt-codegen package may not be installed" in result:
+        pytest.skip("dbt-codegen package not installed")
+    
+    # Should handle gracefully
+    assert result is not None
+
+
+def test_error_handling_invalid_source(generate_base_model_tool):
+    """Test handling of invalid source references."""
+    result = generate_base_model_tool(
+        source_name="nonexistent_source",
+        table_name="nonexistent_table"
+    )
+    
+    if "dbt-codegen package may not be installed" in result:
+        pytest.skip("dbt-codegen package not installed")
+    
+    # Should return an error message
+    assert result is not None

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -2,6 +2,7 @@ from dbt_mcp.config.config import (
     AdminApiConfig,
     Config,
     DbtCliConfig,
+    DbtCodegenConfig,
     DiscoveryConfig,
     SemanticLayerConfig,
     SqlConfig,
@@ -28,6 +29,13 @@ mock_sql_config = SqlConfig(
 )
 
 mock_dbt_cli_config = DbtCliConfig(
+    project_dir="/test/project",
+    dbt_path="/path/to/dbt",
+    dbt_cli_timeout=10,
+    binary_type=BinaryType.DBT_CORE,
+)
+
+mock_dbt_codegen_config = DbtCodegenConfig(
     project_dir="/test/project",
     dbt_path="/path/to/dbt",
     dbt_cli_timeout=10,
@@ -65,6 +73,7 @@ mock_config = Config(
     tracking_config=mock_tracking_config,
     sql_config=mock_sql_config,
     dbt_cli_config=mock_dbt_cli_config,
+    dbt_codegen_config=mock_dbt_codegen_config,
     discovery_config=mock_discovery_config,
     semantic_layer_config=mock_semantic_layer_config,
     admin_api_config=mock_admin_api_config,

--- a/tests/unit/dbt_codegen/test_tools.py
+++ b/tests/unit/dbt_codegen/test_tools.py
@@ -1,0 +1,378 @@
+import json
+import subprocess
+
+import pytest
+from pytest import MonkeyPatch
+
+from dbt_mcp.dbt_codegen.tools import register_dbt_codegen_tools
+from tests.mocks.config import mock_dbt_codegen_config
+
+
+@pytest.fixture
+def mock_process():
+    class MockProcess:
+        def __init__(self, returncode=0, output="command output"):
+            self.returncode = returncode
+            self._output = output
+
+        def communicate(self, timeout=None):
+            return self._output, None
+
+    return MockProcess
+
+
+@pytest.fixture
+def mock_fastmcp():
+    class MockFastMCP:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self, **kwargs):
+            def decorator(func):
+                self.tools[func.__name__] = func
+                return func
+
+            return decorator
+
+    fastmcp = MockFastMCP()
+    return fastmcp, fastmcp.tools
+
+
+def test_generate_source_basic_schema(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test generate_source with just schema_name parameter."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Call with just schema_name
+    result = generate_source_tool(schema_name="raw_data")
+
+    # Verify the command was called correctly
+    assert mock_calls
+    args_list = mock_calls[0]
+    
+    # Check basic command structure
+    assert args_list[0] == "/path/to/dbt"
+    assert "--no-use-colors" in args_list
+    assert "run-operation" in args_list
+    assert "--quiet" in args_list
+    assert "generate_source" in args_list
+    
+    # Check that args were passed correctly
+    assert "--args" in args_list
+    args_index = args_list.index("--args")
+    args_json = json.loads(args_list[args_index + 1])
+    assert args_json["schema_name"] == "raw_data"
+
+
+def test_generate_source_with_all_parameters(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test generate_source with all parameters."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Call with all parameters
+    result = generate_source_tool(
+        schema_name="raw_data",
+        database_name="analytics",
+        table_names=["users", "orders"],
+        generate_columns=True,
+        include_descriptions=True,
+    )
+
+    # Verify the args were passed correctly
+    assert mock_calls
+    args_list = mock_calls[0]
+    args_index = args_list.index("--args")
+    args_json = json.loads(args_list[args_index + 1])
+    
+    assert args_json["schema_name"] == "raw_data"
+    assert args_json["database_name"] == "analytics"
+    assert args_json["table_names"] == ["users", "orders"]
+    assert args_json["generate_columns"] is True
+    assert args_json["include_descriptions"] is True
+
+
+def test_generate_model_yaml(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test generate_model_yaml function."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_model_yaml_tool = tools["generate_model_yaml"]
+
+    # Call the tool
+    result = generate_model_yaml_tool(
+        model_names=["stg_users", "stg_orders"],
+        upstream_descriptions=True,
+        include_data_types=False,
+    )
+
+    # Verify the command
+    assert mock_calls
+    args_list = mock_calls[0]
+    assert "generate_model_yaml" in args_list
+    
+    args_index = args_list.index("--args")
+    args_json = json.loads(args_list[args_index + 1])
+    assert args_json["model_names"] == ["stg_users", "stg_orders"]
+    assert args_json["upstream_descriptions"] is True
+    assert args_json["include_data_types"] is False
+
+
+def test_generate_base_model(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test generate_base_model function."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_base_model_tool = tools["generate_base_model"]
+
+    # Call the tool
+    result = generate_base_model_tool(
+        source_name="raw_data",
+        table_name="users",
+        leading_commas=True,
+        case_sensitive_cols=False,
+        materialized="view",
+    )
+
+    # Verify the command
+    assert mock_calls
+    args_list = mock_calls[0]
+    assert "generate_base_model" in args_list
+    
+    args_index = args_list.index("--args")
+    args_json = json.loads(args_list[args_index + 1])
+    assert args_json["source_name"] == "raw_data"
+    assert args_json["table_name"] == "users"
+    assert args_json["leading_commas"] is True
+    assert args_json["case_sensitive_cols"] is False
+    assert args_json["materialized"] == "view"
+
+
+def test_generate_model_import_ctes(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test generate_model_import_ctes function."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_model_import_ctes_tool = tools["generate_model_import_ctes"]
+
+    # Call the tool
+    result = generate_model_import_ctes_tool(
+        model_name="fct_orders",
+        leading_commas=False,
+    )
+
+    # Verify the command
+    assert mock_calls
+    args_list = mock_calls[0]
+    assert "generate_model_import_ctes" in args_list
+    
+    args_index = args_list.index("--args")
+    args_json = json.loads(args_list[args_index + 1])
+    assert args_json["model_name"] == "fct_orders"
+    assert args_json["leading_commas"] is False
+
+
+def test_codegen_error_handling_missing_package(
+    monkeypatch: MonkeyPatch, mock_fastmcp
+):
+    """Test error handling when dbt-codegen package is not installed."""
+    mock_calls = []
+    
+    class MockProcessWithError:
+        def __init__(self):
+            self.returncode = 1
+        
+        def communicate(self, timeout=None):
+            return "dbt found 1 resource of type macro", None
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return MockProcessWithError()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Call should return error message about missing package
+    result = generate_source_tool(schema_name="test_schema")
+    
+    assert "dbt-codegen package may not be installed" in result
+    assert "Run 'dbt deps'" in result
+
+
+def test_codegen_error_handling_general_error(
+    monkeypatch: MonkeyPatch, mock_fastmcp
+):
+    """Test general error handling."""
+    mock_calls = []
+    
+    class MockProcessWithError:
+        def __init__(self):
+            self.returncode = 1
+        
+        def communicate(self, timeout=None):
+            return "Some other error occurred", None
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return MockProcessWithError()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Call should return the error
+    result = generate_source_tool(schema_name="test_schema")
+    
+    assert "Error running dbt-codegen macro" in result
+    assert "Some other error occurred" in result
+
+
+def test_codegen_timeout_handling(
+    monkeypatch: MonkeyPatch, mock_fastmcp
+):
+    """Test timeout handling for long-running operations."""
+    
+    class MockProcessWithTimeout:
+        def communicate(self, timeout=None):
+            raise subprocess.TimeoutExpired(
+                cmd=["dbt", "run-operation"], timeout=10
+            )
+
+    def mock_popen(*args, **kwargs):
+        return MockProcessWithTimeout()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Test timeout case
+    result = generate_source_tool(schema_name="large_schema")
+    assert "Timeout: dbt-codegen operation took longer than" in result
+    assert "10 seconds" in result
+
+
+def test_quiet_flag_placement(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test that --quiet flag is placed correctly in the command."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Call the tool
+    result = generate_source_tool(schema_name="test")
+
+    # Verify --quiet is placed after run-operation
+    assert mock_calls
+    args_list = mock_calls[0]
+    
+    run_op_index = args_list.index("run-operation")
+    quiet_index = args_list.index("--quiet")
+    
+    # --quiet should come right after run-operation
+    assert quiet_index == run_op_index + 1
+
+
+def test_absolute_path_handling(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Test that absolute paths are handled correctly."""
+    mock_calls = []
+    captured_kwargs = {}
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        captured_kwargs.update(kwargs)
+        return mock_process()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    generate_source_tool = tools["generate_source"]
+
+    # Call the tool (mock config has /test/project which is absolute)
+    result = generate_source_tool(schema_name="test")
+
+    # Verify cwd was set for absolute path
+    assert "cwd" in captured_kwargs
+    assert captured_kwargs["cwd"] == "/test/project"
+
+
+def test_all_tools_registered(mock_fastmcp):
+    """Test that all expected tools are registered."""
+    fastmcp, tools = mock_fastmcp
+    register_dbt_codegen_tools(fastmcp, mock_dbt_codegen_config)
+    
+    expected_tools = [
+        "generate_source",
+        "generate_model_yaml", 
+        "generate_base_model",
+        "generate_model_import_ctes",
+    ]
+    
+    for tool_name in expected_tools:
+        assert tool_name in tools, f"Tool {tool_name} not registered"


### PR DESCRIPTION
This PR adds support for dbt-codegen package operations through the MCP protocol, enabling AI assistants to automatically generate dbt boilerplate code.

  What we are adding
  ***4 new MCP tools for dbt-codegen operations:***

    - generate_source: Creates source YAML definitions from database schemas
    - generate_model_yaml: Generates documentation for existing dbt models
    - generate_base_model: Creates staging SQL models from sources
    - generate_model_import_ctes: Generates CTE imports for model dependencies