### PR TITLE
Add prereleases to the Create release PR action

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250918-125659.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250918-125659.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Allow creating pre-releases
+time: 2025-09-18T12:56:59.745803+02:00

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,10 @@ on:
           - major
           - minor
           - patch
+      prerelease:
+        type: string
+        description: Optional pre-release tag (e.g. alpha.1, beta.1, rc.1). Leave empty for stable.
+        default: ""
 
 jobs:
   create-release-pr:
@@ -22,11 +26,40 @@ jobs:
 
       - uses: ./.github/actions/setup-python
 
+      - name: Compute next dir for bump
+        id: changie-next
+        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        with:
+          version: latest
+          args: next ${{ inputs.bump }}
+
+      - name: Prepare batch args
+        id: prepare-batch
+        shell: bash
+        run: |
+          PR="${{ inputs.prerelease }}"
+          BUMP="${{ inputs.bump }}"
+          NEXT_DIR="${{ steps.changie-next.outputs.output }}"
+
+          if [[ -n "$PR" ]]; then
+            if [[ ! "$PR" =~ ^(alpha|beta|rc)\.[0-9]+$ ]]; then
+              echo "Invalid prerelease format: $PR (expected alpha.N, beta.N, rc.N)" >&2
+              exit 1
+            fi
+            echo "args=batch $BUMP --move-dir $NEXT_DIR --prerelease $PR" >> "$GITHUB_OUTPUT"
+          else
+            if [[ -d "$NEXT_DIR" ]]; then
+              echo "args=batch $BUMP --include $NEXT_DIR --remove-prereleases" >> "$GITHUB_OUTPUT"
+            else
+              echo "args=batch $BUMP" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
       - name: Batch changes
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
         with:
           version: latest
-          args: batch ${{ inputs.bump }}
+          args: ${{ steps.prepare-batch.outputs.args }}
 
       - name: Merge
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,5 +82,22 @@ If you encounter any problems. You can try running `task run` to see errors in y
 Only people in the `CODEOWNERS` file should trigger a new release with these steps:
 
 1. Trigger the [Create release PR Action](https://github.com/dbt-labs/dbt-mcp/actions/workflows/create-release-pr.yml).
-2. Get this PR approved & merged in.
+  - If the release is NOT a pre-release, just pick if the bump should be patch, minor or major
+  - If the release is a pre-release, set the bump and the pre-release suffix. We support alpha.N, beta.N and rc.N.
+    - use alpha for early releases of experimental features that specific people might want to test. Significant changes can be expected between alpha and the official release.
+    - use beta for releases that are mostly stable but still in development. It can be used to gather feedback from a group of peopleon how a specific feature should work.
+    - use rc for releases that are mostly stable and already feature complete. Only bugfixes and minor changes are expected between rc and the official release.
+  - Picking the prerelease suffix will depend on whether the last release was the stable release or a pre-release:
+
+| Last Stable | Last Pre-release | Bump  | Pre-release Suffix | Resulting Version |
+| ----------- | ---------------- | ----- | ------------------ | ----------------- |
+| 1.2.0       | -                | minor | beta.1             | 1.3.0-beta.1      |
+| 1.2.0       | 1.3.0-beta.1     | minor | beta.2             | 1.3.0-beta.2      |
+| 1.2.0       | 1.3.0-beta.2     | minor | rc.1               | 1.3.0-rc.1        |
+| 1.2.0       | 1.3.0-rc.1       | minor |                    | 1.3.0             |
+| 1.2.0       | 1.3.0-beta.2     | minor | -                  | 1.3.0             |
+| 1.2.0       | -                | major | rc.1               | 2.0.0-rc.1        |
+| 1.2.0       | 2.0.0-rc.1       | major | -                  | 2.0.0             |
+
+2. Get this PR approved & merged in (if the resulting release name is not the one expected in the PR, just close the PR and try again step 1)
 3. This will trigger the `Release dbt-mcp` Action. On the `Summary` page of this Action a member of the `CODEOWNERS` file will have to manually approve the release. The rest of the release process is automated.


### PR DESCRIPTION
Closes #325 

Allow setting pre-releases when triggering the release action

The design is the following:
- this flow allows adding alpha.x/beta.x/rc.x pre-releases
- when pre-releases are created, they are added to the changelog but the changie files are also saved to a specific folder
- when the final release is done, changie collects all the pre-release files for this version, merge them all and remove the original prereleases from the changelog
