### PR TITLE
Add env var to force no color flag

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20250922-151943.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20250922-151943.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Allow setting the "no color flag" when we can't detect the CLI type
+time: 2025-09-22T15:19:43.245974+02:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -60,6 +60,7 @@ class DbtCliConfig:
     dbt_path: str
     dbt_cli_timeout: int
     binary_type: BinaryType
+    dbt_no_color_flag: str | None = None
 
 
 @dataclass
@@ -106,6 +107,7 @@ class DbtMcpSettings(BaseSettings):
     dbt_cli_timeout: int = Field(10, alias="DBT_CLI_TIMEOUT")
     dbt_warn_error_options: str | None = Field(None, alias="DBT_WARN_ERROR_OPTIONS")
     dbt_profiles_dir: str | None = Field(None, alias="DBT_PROFILES_DIR")
+    dbt_color_disable_flag: str | None = Field(None, alias="DBT_COLOR_DISABLE_FLAG")
 
     # Disable tool settings
     disable_dbt_cli: bool = Field(False, alias="DISABLE_DBT_CLI")
@@ -438,6 +440,7 @@ def create_config(settings: DbtMcpSettings, token_provider: TokenProvider) -> Co
             dbt_path=settings.dbt_path,
             dbt_cli_timeout=settings.dbt_cli_timeout,
             binary_type=binary_type,
+            dbt_no_color_flag=settings.dbt_color_disable_flag,
         )
 
     discovery_config = None

--- a/src/dbt_mcp/dbt_cli/binary_type.py
+++ b/src/dbt_mcp/dbt_cli/binary_type.py
@@ -43,7 +43,9 @@ def detect_binary_type(file_path: str) -> BinaryType:
     return BinaryType.FUSION
 
 
-def get_color_disable_flag(binary_type: BinaryType) -> str:
+def get_color_disable_flag(
+    binary_type: BinaryType, no_color_flag: str | None = None
+) -> str:
     """
     Get the appropriate color disable flag for the given binary type.
 
@@ -53,6 +55,10 @@ def get_color_disable_flag(binary_type: BinaryType) -> str:
     Returns:
         str: The color disable flag to use
     """
+
+    if no_color_flag:
+        return no_color_flag
+
     if binary_type == BinaryType.DBT_CLOUD_CLI:
         return "--no-color"
     else:  # DBT_CORE or FUSION

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -61,7 +61,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             cwd_path = config.project_dir if os.path.isabs(config.project_dir) else None
 
             # Add appropriate color disable flag based on binary type
-            color_flag = get_color_disable_flag(config.binary_type)
+            color_flag = get_color_disable_flag(
+                config.binary_type, config.dbt_no_color_flag
+            )
             args = [config.dbt_path, color_flag, *full_command]
 
             process = subprocess.Popen(


### PR DESCRIPTION
When a person used the MCP server with the dbt Cloud CLI, for some reason the code didn't recognize that the executable was the dbt Cloud CLI and added the flag `--no-use-colors` instead of `--no-color` which raised issues.

I will dig further on why we didn't find the correct CLI type, but for now, the env var `DBT_COLOR_DISABLE_FLAG` could be used by anyone blocked by this behavior.

I don't think we need to document the env var `DBT_COLOR_DISABLE_FLAG` for now as it might be a temp workaround until I can understand the issue with recognizing the CLI type.