### PR TITLE
Create ConfigProvider ABC

### DIFF
--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import yaml
 
 from dbt_mcp.config.config_providers import (
-    AdminApiConfigProvider,
-    DiscoveryConfigProvider,
-    SemanticLayerConfigProvider,
-    SqlConfigProvider,
+    DefaultAdminApiConfigProvider,
+    DefaultDiscoveryConfigProvider,
+    DefaultSemanticLayerConfigProvider,
+    DefaultSqlConfigProvider,
 )
 from dbt_mcp.config.settings import CredentialsProvider, DbtMcpSettings
 from dbt_mcp.dbt_cli.binary_type import BinaryType, detect_binary_type
@@ -37,11 +37,11 @@ class DbtCliConfig:
 class Config:
     tracking_config: TrackingConfig
     disable_tools: list[ToolName]
-    sql_config_provider: SqlConfigProvider | None
+    sql_config_provider: DefaultSqlConfigProvider | None
     dbt_cli_config: DbtCliConfig | None
-    discovery_config_provider: DiscoveryConfigProvider | None
-    semantic_layer_config_provider: SemanticLayerConfigProvider | None
-    admin_api_config_provider: AdminApiConfigProvider | None
+    discovery_config_provider: DefaultDiscoveryConfigProvider | None
+    semantic_layer_config_provider: DefaultSemanticLayerConfigProvider | None
+    admin_api_config_provider: DefaultAdminApiConfigProvider | None
 
 
 def load_config() -> Config:
@@ -56,13 +56,13 @@ def load_config() -> Config:
     # Build configurations
     sql_config_provider = None
     if not settings.actual_disable_sql:
-        sql_config_provider = SqlConfigProvider(
+        sql_config_provider = DefaultSqlConfigProvider(
             credentials_provider=credentials_provider,
         )
 
     admin_api_config_provider = None
     if not settings.disable_admin_api:
-        admin_api_config_provider = AdminApiConfigProvider(
+        admin_api_config_provider = DefaultAdminApiConfigProvider(
             credentials_provider=credentials_provider,
         )
 
@@ -78,13 +78,13 @@ def load_config() -> Config:
 
     discovery_config_provider = None
     if not settings.disable_discovery:
-        discovery_config_provider = DiscoveryConfigProvider(
+        discovery_config_provider = DefaultDiscoveryConfigProvider(
             credentials_provider=credentials_provider,
         )
 
     semantic_layer_config_provider = None
     if not settings.disable_semantic_layer:
-        semantic_layer_config_provider = SemanticLayerConfigProvider(
+        semantic_layer_config_provider = DefaultSemanticLayerConfigProvider(
             credentials_provider=credentials_provider,
         )
 

--- a/src/dbt_mcp/config/config_providers.py
+++ b/src/dbt_mcp/config/config_providers.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from dbt_mcp.config.headers import (
@@ -43,7 +44,12 @@ class SqlConfig:
     headers_provider: HeadersProvider
 
 
-class SemanticLayerConfigProvider:
+class ConfigProvider[ConfigType](ABC):
+    @abstractmethod
+    async def get_config(self) -> ConfigType: ...
+
+
+class DefaultSemanticLayerConfigProvider(ConfigProvider[SemanticLayerConfig]):
     def __init__(self, credentials_provider: CredentialsProvider):
         self.credentials_provider = credentials_provider
 
@@ -76,7 +82,7 @@ class SemanticLayerConfigProvider:
         )
 
 
-class DiscoveryConfigProvider:
+class DefaultDiscoveryConfigProvider(ConfigProvider[DiscoveryConfig]):
     def __init__(self, credentials_provider: CredentialsProvider):
         self.credentials_provider = credentials_provider
 
@@ -99,7 +105,7 @@ class DiscoveryConfigProvider:
         )
 
 
-class AdminApiConfigProvider:
+class DefaultAdminApiConfigProvider(ConfigProvider[AdminApiConfig]):
     def __init__(self, credentials_provider: CredentialsProvider):
         self.credentials_provider = credentials_provider
 
@@ -119,7 +125,7 @@ class AdminApiConfigProvider:
         )
 
 
-class SqlConfigProvider:
+class DefaultSqlConfigProvider(ConfigProvider[SqlConfig]):
     def __init__(self, credentials_provider: CredentialsProvider):
         self.credentials_provider = credentials_provider
 

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -4,7 +4,10 @@ from typing import Any
 
 import requests
 
-from dbt_mcp.config.config_providers import AdminApiConfig, AdminApiConfigProvider
+from dbt_mcp.config.config_providers import (
+    AdminApiConfig,
+    ConfigProvider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +21,7 @@ class AdminAPIError(Exception):
 class DbtAdminAPIClient:
     """Client for interacting with the dbt Admin API."""
 
-    def __init__(self, config_provider: AdminApiConfigProvider):
+    def __init__(self, config_provider: ConfigProvider[AdminApiConfig]):
         self.config_provider = config_provider
 
     async def get_config(self) -> AdminApiConfig:

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config_providers import AdminApiConfigProvider
+from dbt_mcp.config.config_providers import (
+    AdminApiConfig,
+    ConfigProvider,
+)
 from dbt_mcp.dbt_admin.client import DbtAdminAPIClient
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.tools.annotations import create_tool_annotations
@@ -38,7 +41,8 @@ STATUS_MAP = {
 
 
 def create_admin_api_tool_definitions(
-    admin_client: DbtAdminAPIClient, admin_api_config_provider: AdminApiConfigProvider
+    admin_client: DbtAdminAPIClient,
+    admin_api_config_provider: ConfigProvider[AdminApiConfig],
 ) -> list[ToolDefinition]:
     async def list_jobs(
         # TODO: add support for project_id in the future
@@ -286,7 +290,7 @@ def create_admin_api_tool_definitions(
 
 def register_admin_api_tools(
     dbt_mcp: FastMCP,
-    admin_config_provider: AdminApiConfigProvider,
+    admin_config_provider: ConfigProvider[AdminApiConfig],
     exclude_tools: Sequence[ToolName] = [],
 ) -> None:
     """Register dbt Admin API tools."""

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -3,7 +3,7 @@ from typing import Literal, TypedDict
 
 import requests
 
-from dbt_mcp.config.config_providers import DiscoveryConfigProvider
+from dbt_mcp.config.config_providers import ConfigProvider, DiscoveryConfig
 from dbt_mcp.gql.errors import raise_gql_error
 
 PAGE_SIZE = 100
@@ -322,7 +322,7 @@ class GraphQLQueries:
 
 
 class MetadataAPIClient:
-    def __init__(self, config_provider: DiscoveryConfigProvider):
+    def __init__(self, config_provider: ConfigProvider[DiscoveryConfig]):
         self.config_provider = config_provider
 
     async def execute_query(self, query: str, variables: dict) -> dict:

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -3,7 +3,10 @@ from collections.abc import Sequence
 
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config_providers import DiscoveryConfigProvider
+from dbt_mcp.config.config_providers import (
+    ConfigProvider,
+    DiscoveryConfig,
+)
 from dbt_mcp.discovery.client import ExposuresFetcher, MetadataAPIClient, ModelsFetcher
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.tools.annotations import create_tool_annotations
@@ -15,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_discovery_tool_definitions(
-    config_provider: DiscoveryConfigProvider,
+    config_provider: ConfigProvider[DiscoveryConfig],
 ) -> list[ToolDefinition]:
     api_client = MetadataAPIClient(config_provider=config_provider)
     models_fetcher = ModelsFetcher(api_client=api_client)
@@ -170,7 +173,7 @@ def create_discovery_tool_definitions(
 
 def register_discovery_tools(
     dbt_mcp: FastMCP,
-    config_provider: DiscoveryConfigProvider,
+    config_provider: ConfigProvider[DiscoveryConfig],
     exclude_tools: Sequence[ToolName] = [],
 ) -> None:
     register_tools(

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -11,7 +11,7 @@ from dbtsl.api.shared.query_params import (
 from dbtsl.client.sync import SyncSemanticLayerClient
 from dbtsl.error import QueryFailedError
 
-from dbt_mcp.config.config_providers import SemanticLayerConfigProvider
+from dbt_mcp.config.config_providers import ConfigProvider, SemanticLayerConfig
 from dbt_mcp.semantic_layer.gql.gql import GRAPHQL_QUERIES
 from dbt_mcp.semantic_layer.gql.gql_request import submit_request
 from dbt_mcp.semantic_layer.levenshtein import get_misspellings
@@ -56,7 +56,7 @@ class SemanticLayerClientProtocol(Protocol):
 class SemanticLayerFetcher:
     def __init__(
         self,
-        config_provider: SemanticLayerConfigProvider,
+        config_provider: ConfigProvider[SemanticLayerConfig],
     ):
         self.config_provider = config_provider
         self.entities_cache: dict[str, list[EntityToolResponse]] = {}

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -4,7 +4,10 @@ from collections.abc import Sequence
 from dbtsl.api.shared.query_params import GroupByParam
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config_providers import SemanticLayerConfigProvider
+from dbt_mcp.config.config_providers import (
+    ConfigProvider,
+    SemanticLayerConfig,
+)
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.semantic_layer.client import (
     SemanticLayerFetcher,
@@ -26,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_sl_tool_definitions(
-    config_provider: SemanticLayerConfigProvider,
+    config_provider: ConfigProvider[SemanticLayerConfig],
 ) -> list[ToolDefinition]:
     semantic_layer_fetcher = SemanticLayerFetcher(
         config_provider=config_provider,
@@ -158,7 +161,7 @@ def create_sl_tool_definitions(
 
 def register_sl_tools(
     dbt_mcp: FastMCP,
-    config_provider: SemanticLayerConfigProvider,
+    config_provider: ConfigProvider[SemanticLayerConfig],
     exclude_tools: Sequence[ToolName] = [],
 ) -> None:
     register_tools(

--- a/src/dbt_mcp/sql/tools.py
+++ b/src/dbt_mcp/sql/tools.py
@@ -26,7 +26,7 @@ from pydantic import Field, WithJsonSchema, create_model
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from dbt_mcp.config.config_providers import SqlConfigProvider
+from dbt_mcp.config.config_providers import ConfigProvider, SqlConfig
 from dbt_mcp.tools.tool_names import ToolName
 from dbt_mcp.tools.toolsets import Toolset, toolsets
 
@@ -99,7 +99,7 @@ class SqlToolsManager:
 
 async def register_sql_tools(
     dbt_mcp: FastMCP,
-    config_provider: SqlConfigProvider,
+    config_provider: ConfigProvider[SqlConfig],
     exclude_tools: Sequence[ToolName] = [],
 ) -> None:
     """

--- a/tests/integration/discovery/test_discovery.py
+++ b/tests/integration/discovery/test_discovery.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from dbt_mcp.config.config_providers import DiscoveryConfigProvider
+from dbt_mcp.config.config_providers import DefaultDiscoveryConfigProvider
 from dbt_mcp.config.settings import CredentialsProvider, DbtMcpSettings
 from dbt_mcp.discovery.client import (
     ExposuresFetcher,
@@ -28,7 +28,7 @@ def api_client() -> MetadataAPIClient:
     # DbtMcpSettings will automatically pick up from environment variables
     settings = DbtMcpSettings()  # type: ignore
     credentials_provider = CredentialsProvider(settings)
-    config_provider = DiscoveryConfigProvider(credentials_provider)
+    config_provider = DefaultDiscoveryConfigProvider(credentials_provider)
 
     return MetadataAPIClient(config_provider)
 

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -5,13 +5,13 @@ from dbt_mcp.config.config import (
 )
 from dbt_mcp.config.config_providers import (
     AdminApiConfig,
-    AdminApiConfigProvider,
+    DefaultAdminApiConfigProvider,
+    DefaultDiscoveryConfigProvider,
+    DefaultSemanticLayerConfigProvider,
+    DefaultSqlConfigProvider,
     DiscoveryConfig,
-    DiscoveryConfigProvider,
     SemanticLayerConfig,
-    SemanticLayerConfigProvider,
     SqlConfig,
-    SqlConfigProvider,
 )
 from dbt_mcp.config.headers import (
     AdminApiHeadersProvider,
@@ -76,7 +76,7 @@ mock_admin_api_config = AdminApiConfig(
 
 
 # Create mock config providers
-class MockSqlConfigProvider(SqlConfigProvider):
+class MockSqlConfigProvider(DefaultSqlConfigProvider):
     def __init__(self):
         pass  # Skip the base class __init__
 
@@ -84,7 +84,7 @@ class MockSqlConfigProvider(SqlConfigProvider):
         return mock_sql_config
 
 
-class MockDiscoveryConfigProvider(DiscoveryConfigProvider):
+class MockDiscoveryConfigProvider(DefaultDiscoveryConfigProvider):
     def __init__(self):
         pass  # Skip the base class __init__
 
@@ -92,7 +92,7 @@ class MockDiscoveryConfigProvider(DiscoveryConfigProvider):
         return mock_discovery_config
 
 
-class MockSemanticLayerConfigProvider(SemanticLayerConfigProvider):
+class MockSemanticLayerConfigProvider(DefaultSemanticLayerConfigProvider):
     def __init__(self):
         pass  # Skip the base class __init__
 
@@ -100,7 +100,7 @@ class MockSemanticLayerConfigProvider(SemanticLayerConfigProvider):
         return mock_semantic_layer_config
 
 
-class MockAdminApiConfigProvider(AdminApiConfigProvider):
+class MockAdminApiConfigProvider(DefaultAdminApiConfigProvider):
     def __init__(self):
         pass  # Skip the base class __init__
 


### PR DESCRIPTION
## Summary

This PR adds the `ConfigProvider` abstract base class, which all config providers inherit from. This allows us to create custom config providers for our internal usage.
