### PR TITLE
Implement SemanticLayerClientProvider

### DIFF
--- a/.changes/unreleased/Under the Hood-20250923-132830.yaml
+++ b/.changes/unreleased/Under the Hood-20250923-132830.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Implement SemanticLayerClientProvider
+time: 2025-09-23T13:28:30.302597-05:00

--- a/evals/semantic_layer/test_eval_semantic_layer.py
+++ b/evals/semantic_layer/test_eval_semantic_layer.py
@@ -15,7 +15,10 @@ from openai.types.responses.response_input_param import FunctionCallOutput
 from client.tools import get_tools
 from dbt_mcp.config.config import load_config
 from dbt_mcp.mcp.server import create_dbt_mcp
-from dbt_mcp.semantic_layer.client import SemanticLayerFetcher
+from dbt_mcp.semantic_layer.client import (
+    DefaultSemanticLayerClientProvider,
+    SemanticLayerFetcher,
+)
 from dbt_mcp.semantic_layer.types import OrderByParam, QueryMetricsSuccess
 
 LLM_MODEL = "gpt-4o-mini"
@@ -112,6 +115,9 @@ async def expect_query_metrics_tool_call(
     assert config.semantic_layer_config_provider is not None
     semantic_layer_fetcher = SemanticLayerFetcher(
         config_provider=config.semantic_layer_config_provider,
+        client_provider=DefaultSemanticLayerClientProvider(
+            config_provider=config.semantic_layer_config_provider,
+        ),
     )
     tool_response = await semantic_layer_fetcher.query_metrics(
         metrics=args_dict["metrics"],

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -19,6 +19,7 @@ from dbt_mcp.config.config import Config
 from dbt_mcp.dbt_admin.tools import register_admin_api_tools
 from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
 from dbt_mcp.discovery.tools import register_discovery_tools
+from dbt_mcp.semantic_layer.client import DefaultSemanticLayerClientProvider
 from dbt_mcp.semantic_layer.tools import register_sl_tools
 from dbt_mcp.sql.tools import SqlToolsManager, register_sql_tools
 from dbt_mcp.tracking.tracking import UsageTracker
@@ -115,8 +116,11 @@ async def create_dbt_mcp(config: Config) -> DbtMCP:
         logger.info("Registering semantic layer tools")
         register_sl_tools(
             dbt_mcp,
-            config.semantic_layer_config_provider,
-            config.disable_tools,
+            config_provider=config.semantic_layer_config_provider,
+            client_provider=DefaultSemanticLayerClientProvider(
+                config_provider=config.semantic_layer_config_provider,
+            ),
+            exclude_tools=config.disable_tools,
         )
 
     if config.discovery_config_provider:

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -10,6 +10,7 @@ from dbt_mcp.config.config_providers import (
 )
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.semantic_layer.client import (
+    SemanticLayerClientProvider,
     SemanticLayerFetcher,
 )
 from dbt_mcp.semantic_layer.types import (
@@ -30,9 +31,11 @@ logger = logging.getLogger(__name__)
 
 def create_sl_tool_definitions(
     config_provider: ConfigProvider[SemanticLayerConfig],
+    client_provider: SemanticLayerClientProvider,
 ) -> list[ToolDefinition]:
     semantic_layer_fetcher = SemanticLayerFetcher(
         config_provider=config_provider,
+        client_provider=client_provider,
     )
 
     async def list_metrics(search: str | None = None) -> list[MetricToolResponse] | str:
@@ -162,10 +165,11 @@ def create_sl_tool_definitions(
 def register_sl_tools(
     dbt_mcp: FastMCP,
     config_provider: ConfigProvider[SemanticLayerConfig],
+    client_provider: SemanticLayerClientProvider,
     exclude_tools: Sequence[ToolName] = [],
 ) -> None:
     register_tools(
         dbt_mcp,
-        create_sl_tool_definitions(config_provider),
+        create_sl_tool_definitions(config_provider, client_provider),
         exclude_tools,
     )

--- a/tests/integration/semantic_layer/test_semantic_layer.py
+++ b/tests/integration/semantic_layer/test_semantic_layer.py
@@ -2,7 +2,10 @@ import pytest
 from dbtsl.api.shared.query_params import GroupByParam, GroupByType
 
 from dbt_mcp.config.config import load_config
-from dbt_mcp.semantic_layer.client import SemanticLayerFetcher
+from dbt_mcp.semantic_layer.client import (
+    DefaultSemanticLayerClientProvider,
+    SemanticLayerFetcher,
+)
 from dbt_mcp.semantic_layer.types import OrderByParam
 
 config = load_config()
@@ -13,6 +16,9 @@ def semantic_layer_fetcher() -> SemanticLayerFetcher:
     assert config.semantic_layer_config_provider is not None
     return SemanticLayerFetcher(
         config_provider=config.semantic_layer_config_provider,
+        client_provider=DefaultSemanticLayerClientProvider(
+            config_provider=config.semantic_layer_config_provider,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

In [this](https://github.com/dbt-labs/dbt-mcp/pull/340) PR, I changed how configuration worked to be lazily evaluated. In other words, the configuration is fetched just before the API request is made.

This is problematic for our internal usage of dbt MCP, where we still want to configure the tools when they are created rather than when they are called. This PR adds a `SemanticLayerClientProvider` protocol such that the behavior remains the same in this OSS repo, but we can implement a separate `SemanticLayerClientProvider` to create the SL client ahead of time, not lazily, as was done before PR #340. I tested this change with `task client`.