### PR TITLE
Rename SemanticLayerConfig.service_token to SemanticLayerConfig.token

### DIFF
--- a/.changes/unreleased/Under the Hood-20250924-083009.yaml
+++ b/.changes/unreleased/Under the Hood-20250924-083009.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Rename SemanticLayerConfig.service_token to SemanticLayerConfig.token
+time: 2025-09-24T08:30:09.872818-05:00

--- a/src/dbt_mcp/config/config_providers.py
+++ b/src/dbt_mcp/config/config_providers.py
@@ -16,7 +16,7 @@ class SemanticLayerConfig:
     url: str
     host: str
     prod_environment_id: int
-    service_token: str
+    token: str
     headers_provider: HeadersProvider
 
 
@@ -75,7 +75,7 @@ class DefaultSemanticLayerConfigProvider(ConfigProvider[SemanticLayerConfig]):
             url=f"http://{host}" if is_local else f"https://{host}" + "/api/graphql",
             host=host,
             prod_environment_id=settings.actual_prod_environment_id,
-            service_token=settings.dbt_token,
+            token=settings.dbt_token,
             headers_provider=SemanticLayerHeadersProvider(
                 token_provider=token_provider
             ),

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -65,7 +65,7 @@ class DefaultSemanticLayerClientProvider:
         config = await self.config_provider.get_config()
         return SyncSemanticLayerClient(
             environment_id=config.prod_environment_id,
-            auth_token=config.service_token,
+            auth_token=config.token,
             host=config.host,
         )
 

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -58,7 +58,7 @@ mock_discovery_config = DiscoveryConfig(
 
 mock_semantic_layer_config = SemanticLayerConfig(
     host="localhost",
-    service_token="token",
+    token="token",
     url="http://localhost:8000",
     headers_provider=SemanticLayerHeadersProvider(
         token_provider=StaticTokenProvider(token="token")


### PR DESCRIPTION
## Summary

It was once the case that the SL was most commonly used with only service tokens. That is no longer the case. This helps clarify our code. I tested this with `tast client`.