### PR TITLE
Add ruff linting config for Python 3.9+ style

### DIFF
--- a/.changes/unreleased/Under the Hood-20250924-155624.yaml
+++ b/.changes/unreleased/Under the Hood-20250924-155624.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Add ruff lint config to enforce Python 3.9+ coding style
+time: 2025-09-24T15:56:24.277308-07:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,6 @@ source = "vcs"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 pythonpath = [".", "src"]
+
+[tool.ruff.lint]
+extend-select = ["UP"] # UP=pyupgrade


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Adding a simple `pyproject.toml` config to add automated checks for Python 3.9+ coding style in pre-commits and CI via `ruff`. 

## What Changed
<!-- Describe the changes made in this PR -->
Extends the default `ruff` lint checks to use [pyupgrade](https://docs.astral.sh/ruff/rules/#pyupgrade-up) ("UP") in order to automatically flag and upgrade obsolete syntax.

## Why
<!-- Explain the motivation for these changes -->
This PR was catalyzed by a [comment](https://github.com/dbt-labs/dbt-mcp/pull/335#discussion_r2359212277) made by @b-per on another ongoing PR that touched on this coding style topic.

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->
To validate, staged a file with "old" Python 3.9 syntax, ran `pre-commit run`, verified that the `ruff` steps failed, and that the linting errors were automatically fixed:

<img width="1467" height="907" alt="Screenshot 2025-09-24 at 3 41 06 PM" src="https://github.com/user-attachments/assets/24478bfe-1138-4bf0-ab3a-e907029a838c" />

