### PR TITLE
Remove string union from output type

### DIFF
--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -63,7 +63,7 @@ def create_admin_api_tool_definitions(
             params["offset"] = offset
         return await admin_client.list_jobs(admin_api_config.account_id, **params)
 
-    async def get_job_details(job_id: int) -> dict[str, Any] | str:
+    async def get_job_details(job_id: int) -> dict[str, Any]:
         """Get details for a specific job."""
         admin_api_config = await admin_api_config_provider.get_config()
         return await admin_client.get_job_details(admin_api_config.account_id, job_id)
@@ -120,17 +120,17 @@ def create_admin_api_tool_definitions(
             admin_api_config.account_id, run_id
         )
 
-    async def cancel_job_run(run_id: int) -> dict[str, Any] | str:
+    async def cancel_job_run(run_id: int) -> dict[str, Any]:
         """Cancel a job run."""
         admin_api_config = await admin_api_config_provider.get_config()
         return await admin_client.cancel_job_run(admin_api_config.account_id, run_id)
 
-    async def retry_job_run(run_id: int) -> dict[str, Any] | str:
+    async def retry_job_run(run_id: int) -> dict[str, Any]:
         """Retry a failed job run."""
         admin_api_config = await admin_api_config_provider.get_config()
         return await admin_client.retry_job_run(admin_api_config.account_id, run_id)
 
-    async def list_job_run_artifacts(run_id: int) -> list[str] | str:
+    async def list_job_run_artifacts(run_id: int) -> list[str]:
         """List artifacts for a job run."""
         admin_api_config = await admin_api_config_provider.get_config()
         return await admin_client.list_job_run_artifacts(

--- a/src/dbt_mcp/discovery/tools.py
+++ b/src/dbt_mcp/discovery/tools.py
@@ -24,41 +24,41 @@ def create_discovery_tool_definitions(
     models_fetcher = ModelsFetcher(api_client=api_client)
     exposures_fetcher = ExposuresFetcher(api_client=api_client)
 
-    async def get_mart_models() -> list[dict] | str:
+    async def get_mart_models() -> list[dict]:
         mart_models = await models_fetcher.fetch_models(
             model_filter={"modelingLayer": "marts"}
         )
         return [m for m in mart_models if m["name"] != "metricflow_time_spine"]
 
-    async def get_all_models() -> list[dict] | str:
+    async def get_all_models() -> list[dict]:
         return await models_fetcher.fetch_models()
 
     async def get_model_details(
         model_name: str | None = None, unique_id: str | None = None
-    ) -> dict | str:
+    ) -> dict:
         return await models_fetcher.fetch_model_details(model_name, unique_id)
 
     async def get_model_parents(
         model_name: str | None = None, unique_id: str | None = None
-    ) -> list[dict] | str:
+    ) -> list[dict]:
         return await models_fetcher.fetch_model_parents(model_name, unique_id)
 
     async def get_model_children(
         model_name: str | None = None, unique_id: str | None = None
-    ) -> list[dict] | str:
+    ) -> list[dict]:
         return await models_fetcher.fetch_model_children(model_name, unique_id)
 
     async def get_model_health(
         model_name: str | None = None, unique_id: str | None = None
-    ) -> list[dict] | str:
+    ) -> list[dict]:
         return await models_fetcher.fetch_model_health(model_name, unique_id)
 
-    async def get_exposures() -> list[dict] | str:
+    async def get_exposures() -> list[dict]:
         return await exposures_fetcher.fetch_exposures()
 
     async def get_exposure_details(
         exposure_name: str | None = None, unique_ids: list[str] | None = None
-    ) -> list[dict] | str:
+    ) -> list[dict]:
         return await exposures_fetcher.fetch_exposure_details(exposure_name, unique_ids)
 
     return [

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -38,19 +38,19 @@ def create_sl_tool_definitions(
         client_provider=client_provider,
     )
 
-    async def list_metrics(search: str | None = None) -> list[MetricToolResponse] | str:
+    async def list_metrics(search: str | None = None) -> list[MetricToolResponse]:
         return await semantic_layer_fetcher.list_metrics(search=search)
 
     async def get_dimensions(
         metrics: list[str], search: str | None = None
-    ) -> list[DimensionToolResponse] | str:
+    ) -> list[DimensionToolResponse]:
         return await semantic_layer_fetcher.get_dimensions(
             metrics=metrics, search=search
         )
 
     async def get_entities(
         metrics: list[str], search: str | None = None
-    ) -> list[EntityToolResponse] | str:
+    ) -> list[EntityToolResponse]:
         return await semantic_layer_fetcher.get_entities(metrics=metrics, search=search)
 
     async def query_metrics(


### PR DESCRIPTION
## Summary

Since we are no longer surfacing errors as strings, we can remove this extra, unused type information.