### PR TITLE
Opt-out of usage tracking with standard dbt methods

### DIFF
--- a/.changes/unreleased/Under the Hood-20250926-161930.yaml
+++ b/.changes/unreleased/Under the Hood-20250926-161930.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Opt-out of usage tracking with standard dbt methods
+time: 2025-09-26T16:19:30.465991-05:00

--- a/src/dbt_mcp/config/dbt_project.py
+++ b/src/dbt_mcp/config/dbt_project.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class DbtProjectFlags(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    send_anonymous_usage_stats: bool | None = None
+
+
+class DbtProjectYaml(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    flags: None | DbtProjectFlags = None

--- a/src/dbt_mcp/config/yaml.py
+++ b/src/dbt_mcp/config/yaml.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import yaml
+
+
+def try_read_yaml(file_path: Path) -> dict | None:
+    try:
+        suffix = file_path.suffix.lower()
+        if suffix not in {".yml", ".yaml"}:
+            return None
+        alternate_suffix = ".yaml" if suffix == ".yml" else ".yml"
+        alternate_path = file_path.with_suffix(alternate_suffix)
+        if file_path.exists():
+            return yaml.safe_load(file_path.read_text())
+        if alternate_path.exists():
+            return yaml.safe_load(alternate_path.read_text())
+    except Exception:
+        return None
+    return None

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -33,7 +33,9 @@ class UsageTracker:
         start_time_ms: int,
         end_time_ms: int,
         error_message: str | None = None,
-    ):
+    ) -> None:
+        if not config.usage_tracking_enabled:
+            return
         try:
             arguments_mapping: Mapping[str, str] = {
                 k: json.dumps(v) for k, v in arguments.items()

--- a/tests/unit/tracking/test_tracking.py
+++ b/tests/unit/tracking/test_tracking.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from dbt_mcp.config.config import TrackingConfig
+from dbt_mcp.tracking.tracking import UsageTracker
+
+
+@pytest.fixture
+def tracking_config() -> TrackingConfig:
+    return TrackingConfig(
+        host="test.dbt.com",
+        host_prefix="prefix",
+        prod_environment_id=1,
+        dev_environment_id=2,
+        dbt_cloud_user_id=3,
+        local_user_id="local-user",
+    )
+
+
+class TestUsageTracker:
+    def test_emit_tool_called_event_disabled(self, tracking_config):
+        tracking_config.usage_tracking_enabled = False
+
+        tracker = UsageTracker()
+
+        with patch("dbt_mcp.tracking.tracking.log_proto") as mock_log_proto:
+            tracker.emit_tool_called_event(
+                config=tracking_config,
+                tool_name="list_metrics",
+                arguments={"foo": "bar"},
+                start_time_ms=0,
+                end_time_ms=1,
+            )
+
+        mock_log_proto.assert_not_called()
+
+    def test_emit_tool_called_event_enabled(self, tracking_config):
+        tracking_config.usage_tracking_enabled = True
+
+        tracker = UsageTracker()
+
+        with patch("uuid.uuid4", return_value="event-1"):
+            with patch("dbt_mcp.tracking.tracking.log_proto") as mock_log_proto:
+                tracker.emit_tool_called_event(
+                    config=tracking_config,
+                    tool_name="list_metrics",
+                    arguments={"foo": "bar"},
+                    start_time_ms=0,
+                    end_time_ms=1,
+                    error_message=None,
+                )
+
+        mock_log_proto.assert_called_once()
+        tool_called = mock_log_proto.call_args.args[0]
+        assert tool_called.tool_name == "list_metrics"
+        assert json.loads(tool_called.arguments["foo"]) == "bar"
+        assert tool_called.dbt_cloud_environment_id_dev == "2"
+        assert tool_called.dbt_cloud_environment_id_prod == "1"
+        assert tool_called.dbt_cloud_user_id == "3"
+        assert tool_called.local_user_id == "local-user"


### PR DESCRIPTION
## Summary

This PR allows disabling usage tracking with standard dbt methods defined [here](https://docs.getdbt.com/reference/global-configs/usage-stats). I have tested this with `task client`, including editing `dbt_project.yml` and utilizing environment variables.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com): https://github.com/dbt-labs/docs.getdbt.com/pull/7959
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes