### PR TITLE
Fix .user.yml "id" parsing to handle both string and dict formats

### DIFF
--- a/.changes/unreleased/Bug Fix-20250929-221653.yaml
+++ b/.changes/unreleased/Bug Fix-20250929-221653.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix .user.yml "id" parsing to handle both string and dict formats
+time: 2025-09-29T22:16:53.566697-07:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -119,7 +119,7 @@ def load_config() -> Config:
     user_dir = get_dbt_profiles_path(settings.dbt_profiles_dir)
     user_yaml = try_read_yaml(user_dir / ".user.yml")
     if user_yaml:
-        local_user_id = user_yaml.get("id")
+        local_user_id = user_yaml if isinstance(user_yaml, str) else user_yaml.get("id")
 
     return Config(
         tracking_config=TrackingConfig(


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->

**NOTE:** Want to preface by saying that this PR may be more of an observation that leads to greater discussion and that the "fix" here may be more of a downstream bandaid than a solution (or neither) for what I believe is an edge case. 

Unit tests that call  `load_config()` within `src/dbt_mcp/config/config.py` are failing locally on my machine even with the latest changes from [main](https://github.com/dbt-labs/dbt-mcp/commit/509811aab9eca9c1ed2aa73fa98bd21cf2264897):

<img width="1242" height="311" alt="Screenshot 2025-09-29 at 9 36 11 PM" src="https://github.com/user-attachments/assets/d5f679f9-0ea1-4ca0-9427-40efc73bb54e" />


All of the errors are `AttributeError: 'str' object has no attribute 'get'` when trying to extract the `local_user_id` from a user's local `~/.dbt/.user.yml` file. 

The problem seems to be that the failing tests are expecting the `.user.yml` file to have the following structure:

```yml
id: <local_user_id>
```

which gets read in and treated as a dict when the config is loaded. 

However, locally, my personal `~/.dbt/.user.yml` file contains a straight up string:

```yml
<local_user_id>
```

When this string gets loaded, the line `local_user_id = user_yaml.get("id")` fails.

I'm not sure if the format of `~/.dbt/.user.yml` that I have locally is an anomaly or more widespread, but do believe this is the root cause.

Lastly, I want to note that I think the helper method `_load_config_with_env` in the `TestLoadConfig` class within `tests/unit/config/test_config.py` actually calls `load_config()` directly (not mocked) which may explain why unit tests may pass in other dev environments/CI, but then fails on my machine:

```python
   def _load_config_with_env(self, env_vars):
        """Helper method to load config with test environment variables, avoiding .env file interference"""
        with (
            patch.dict(os.environ, env_vars),
            patch("dbt_mcp.config.config.DbtMcpSettings") as mock_settings_class,
            patch(
                "dbt_mcp.config.config.detect_binary_type",
                return_value=BinaryType.DBT_CORE,
            ),
        ):
            # Create a real instance with test values, but without .env file loading
            with patch.dict(os.environ, env_vars, clear=True):
                settings_instance = DbtMcpSettings(_env_file=None)
            mock_settings_class.return_value = settings_instance
            return load_config() # <-- direct call
```

## What Changed
<!-- Describe the changes made in this PR -->
  - Updated `load_config()` in `src/dbt_mcp/config/config.py` to handle both YAML formats:
    - Dict format: `{"id": "<local_user_id>"}` to extract via`.get("id")`
    - String format: `"<local_user_id>"` to be used directly


## Why
<!-- Explain the motivation for these changes -->
- Fix failing unit test from in my local dev environment

## Related Issues
<!-- Link any related issues using #issue_number -->
Closes #
Related to #


## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->