### PR TITLE
Fix output of truncated logs

### DIFF
--- a/.changes/unreleased/Bug Fix-20251001-150131.yaml
+++ b/.changes/unreleased/Bug Fix-20251001-150131.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix get_job_run_error truncated log output
+time: 2025-10-01T15:01:31.006625-07:00

--- a/src/dbt_mcp/dbt_admin/run_results_errors/parser.py
+++ b/src/dbt_mcp/dbt_admin/run_results_errors/parser.py
@@ -183,7 +183,7 @@ class ErrorFetcher:
                 target=target,
             ).model_dump()
 
-        message = "No failures found in run_results"
+        message = "No failures found in run_results.json"
 
         return self._create_error_result(
             message=message,


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Two small bugs being addressed:
1. Truncated logs are missing an f string: `"Logs truncated to last {TRUNCATED_LOGS_LENGTH} lines...\` should be `"Logs truncated to last 50 lines...\`
2. When a job fails with no error found in the `run_results.json` (i.e due to a "Keyboard Interrupt" or something similar), the output returns null for the "truncated_logs" key. Like the following:

```bash
{
  "failed_steps": [
    {
      "target": "STAGING",
      "step_name": "Invoke dbt with `dbt build --select \"state:modified+2\" --fail-fast --full-refresh --exclude 
package:dbt_snowflake_monitoring --no-version-check --indirect-selection=cautious --log-level debug`",
      "finished_at": "2025-10-01 16:55:45.896077+00:00",
      "errors": [
        {
          "unique_id": null,
          "relation_name": null,
          "message": "No failures found in run_results",
          "compiled_code": null,
          "truncated_logs": null. # <-- this should return the truncated logs ( like _handle_artifact_error)
        }
      ]
    }
  ]
}
```

## What Changed
<!-- Describe the changes made in this PR -->
- Create `_truncated_logs` helper method to re-use in both `_handle_artifact_error` (existing use) and `_build_error_response` (new use)
- Add f string to TRUNCATED_LOGS_LENGTH  so integer (50) gets returned properly in output

## Why
<!-- Explain the motivation for these changes -->
- Address gap in `_build_error_response` where if no errors are found in `run_results.json`, no truncated logs were being returned (to add more useful/relevant context for the LLM)

## Related Issues
<!-- Link any related issues using #issue_number -->
Closes #
Related to #


## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->