### PR TITLE
Improved logging for development

### DIFF
--- a/.changes/unreleased/Under the Hood-20251002-155957.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-155957.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Improved logging for development
+time: 2025-10-02T15:59:57.117686-05:00

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.egg-info/
 .idea/
 vortex_dev_mode_output.jsonl
+dbt-mcp.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ Or, if you would like to test with Oauth, use a configuration like this:
 }
 ```
 
+For improved debugging, you can set the `FILE_LOGGING=true` environment variable to log to a `./dbt-mcp.log` file.
+
 ## Signed Commits
 
 Before committing changes, ensure that you have set up [signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

--- a/src/dbt_mcp/main.py
+++ b/src/dbt_mcp/main.py
@@ -2,9 +2,11 @@ import asyncio
 
 from dbt_mcp.config.config import load_config
 from dbt_mcp.mcp.server import create_dbt_mcp
+from dbt_mcp.telemetry.logging import configure_file_logging
 
 
 def main() -> None:
+    configure_file_logging()
     config = load_config()
     asyncio.run(create_dbt_mcp(config)).run()
 

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -44,7 +44,7 @@ class DbtMCP(FastMCP):
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
     ) -> Sequence[ContentBlock] | dict[str, Any]:
-        logger.info(f"Calling tool: {name}")
+        logger.info(f"Calling tool: {name} with arguments: {arguments}")
         result = None
         start_time = int(time.time() * 1000)
         try:

--- a/src/dbt_mcp/telemetry/logging.py
+++ b/src/dbt_mcp/telemetry/logging.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+FILE_LOGGING_ENV_VAR = "FILE_LOGGING"
+LOG_FILENAME = "dbt-mcp.log"
+
+
+def _find_repo_root() -> Path:
+    module_path = Path(__file__).resolve().parent
+    home = Path.home().resolve()
+    for candidate in [module_path, *module_path.parents]:
+        if (
+            (candidate / ".git").exists()
+            or (candidate / "pyproject.toml").exists()
+            or candidate == home
+        ):
+            return candidate
+    return module_path
+
+
+def configure_file_logging() -> None:
+    if os.environ.get(FILE_LOGGING_ENV_VAR, "").lower() != "true":
+        return
+
+    repo_root = _find_repo_root()
+    log_path = repo_root / LOG_FILENAME
+
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if (
+            isinstance(handler, logging.FileHandler)
+            and Path(handler.baseFilename) == log_path
+        ):
+            return
+
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s")
+    )
+
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary

This PR adds the ability to configure logging to a file. This can make it easier to debug certain clients that don't readily display MCP logs. I tested this in Claude Desktop.

## Checklist
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes