### PR TITLE
Improved oauth error handling

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20251006-080008.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20251006-080008.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Improved oauth error handling
+time: 2025-10-06T08:00:08.635415-05:00

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -415,6 +415,69 @@ section {
   opacity: 0.8;
 }
 
+/* OAuth Error Section */
+.error-section {
+  background: #fff;
+  border: 1px solid #fecaca;
+}
+
+.error-details {
+  padding: 0 1.5rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.error-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.error-item strong {
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #991b1b;
+}
+
+.error-code {
+  display: inline-block;
+  padding: 0.5rem 0.75rem;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  font-size: 0.875rem;
+  color: #991b1b;
+  font-weight: 500;
+}
+
+.error-description {
+  margin: 0;
+  padding: 0.75rem;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  color: #991b1b;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.error-actions {
+  margin-top: 0.5rem;
+  padding: 1rem;
+  background-color: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+}
+
+.error-actions p {
+  margin: 0;
+  color: #92400e;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
 /* Context details */
 .context-details {
   padding: 0 1.5rem 1.5rem 1.5rem;
@@ -961,6 +1024,37 @@ section {
 
   .error-state p {
     color: #f6f6f6;
+  }
+
+  /* OAuth Error Section Dark Mode */
+  .error-section {
+    background: #1c1a19;
+    border-color: #991b1b;
+  }
+
+  .error-item strong {
+    color: #fca5a5;
+  }
+
+  .error-code {
+    background-color: #450a0a;
+    border-color: #7f1d1d;
+    color: #fca5a5;
+  }
+
+  .error-description {
+    background-color: #450a0a;
+    border-color: #7f1d1d;
+    color: #fca5a5;
+  }
+
+  .error-actions {
+    background-color: #422006;
+    border-color: #92400e;
+  }
+
+  .error-actions p {
+    color: #fde68a;
   }
 
   /* Context details */

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,10 +38,19 @@ function parseHash(): URLSearchParams {
   return new URLSearchParams(query);
 }
 
-function useOAuthResult(): string | null {
+type OAuthResult = {
+  status: string | null;
+  error: string | null;
+  errorDescription: string | null;
+};
+
+function useOAuthResult(): OAuthResult {
   const params = useMemo(() => parseHash(), []);
-  const status = params.get("status");
-  return status;
+  return {
+    status: params.get("status"),
+    error: params.get("error"),
+    errorDescription: params.get("error_description"),
+  };
 }
 
 type CustomDropdownProps = {
@@ -191,7 +200,7 @@ export default function App() {
 
   // Load available projects after OAuth success
   useEffect(() => {
-    if (oauthResult !== "success") return;
+    if (oauthResult.status !== "success") return;
     setLoadingProjects(true);
     setProjectsError(null);
     fetch("/projects")
@@ -207,11 +216,11 @@ export default function App() {
         setProjectsError(msg);
       })
       .finally(() => setLoadingProjects(false));
-  }, [oauthResult]);
+  }, [oauthResult.status]);
 
   // Fetch saved selected project on load after OAuth success
   useEffect(() => {
-    if (oauthResult !== "success") return;
+    if (oauthResult.status !== "success") return;
     (async () => {
       try {
         const res = await fetch("/dbt_platform_context");
@@ -222,7 +231,7 @@ export default function App() {
         // ignore
       }
     })();
-  }, [oauthResult]);
+  }, [oauthResult.status]);
 
   const onContinue = async () => {
     try {
@@ -278,7 +287,41 @@ export default function App() {
           <p>Configure your dbt Platform connection</p>
         </header>
 
-        {oauthResult === "success" && (
+        {oauthResult.status === "error" && (
+          <section className="error-section">
+            <div className="section-header">
+              <h2>Authentication Error</h2>
+              <p>There was a problem during authentication</p>
+            </div>
+
+            <div className="error-details">
+              {oauthResult.error && (
+                <div className="error-item">
+                  <strong>Error Code:</strong>
+                  <code className="error-code">{oauthResult.error}</code>
+                </div>
+              )}
+
+              {oauthResult.errorDescription && (
+                <div className="error-item">
+                  <strong>Description:</strong>
+                  <p className="error-description">
+                    {decodeURIComponent(oauthResult.errorDescription)}
+                  </p>
+                </div>
+              )}
+
+              <div className="error-actions">
+                <p>
+                  Please close this window and try again. If the problem
+                  persists, contact support.
+                </p>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {oauthResult.status === "success" && (
           <section className="project-selection-section">
             <div className="section-header">
               <h2>Select a Project</h2>


### PR DESCRIPTION
## Summary

The OAuth flow may error and provide a redirect that contains an error message. This PR reads and displays that message in the UI. I tested this with `task client`, both the success and error case. Here is what the error state looks like:

<img width="691" height="525" alt="image" src="https://github.com/user-attachments/assets/c7bed9fb-0b73-416b-affc-9f285b24cfe4" />

## Checklist
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes