### PR TITLE
Make DbtMCP lifespan optional

### DIFF
--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -34,7 +34,8 @@ class DbtMCP(FastMCP):
         self,
         config: Config,
         usage_tracker: UsageTracker,
-        lifespan: Callable[["DbtMCP"], AbstractAsyncContextManager[LifespanResultT]],
+        lifespan: Callable[["DbtMCP"], AbstractAsyncContextManager[LifespanResultT]]
+        | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
## Summary

When we use `DbtMCP` internally, we don't necessarily need to change the lifespan.