### PR TITLE
Avoid double counting in usage tracking proxied tools

### DIFF
--- a/.changes/unreleased/Under the Hood-20251008-134723.yaml
+++ b/.changes/unreleased/Under the Hood-20251008-134723.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Avoid double counting in usage tracking proxied tools
+time: 2025-10-08T13:47:23.624854-05:00

--- a/src/dbt_mcp/tools/toolsets.py
+++ b/src/dbt_mcp/tools/toolsets.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 from dbt_mcp.tools.tool_names import ToolName
 
@@ -11,6 +12,13 @@ class Toolset(Enum):
     ADMIN_API = "admin_api"
     DBT_CODEGEN = "dbt_codegen"
 
+
+proxied_tools: set[Literal[ToolName.TEXT_TO_SQL, ToolName.EXECUTE_SQL]] = set(
+    [
+        ToolName.TEXT_TO_SQL,
+        ToolName.EXECUTE_SQL,
+    ]
+)
 
 toolsets = {
     Toolset.SQL: {

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -22,7 +22,7 @@ from dbt_mcp.config.settings import (
     DbtMcpSettings,
     get_dbt_profiles_path,
 )
-from dbt_mcp.tools.toolsets import Toolset
+from dbt_mcp.tools.toolsets import Toolset, proxied_tools
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +116,10 @@ class DefaultUsageTracker:
     ) -> None:
         settings = await self._get_settings()
         if not settings.usage_tracking_enabled:
+            return
+        # Proxied tools are tracked on our backend, so we don't want
+        # to double count them here.
+        if tool_called_event.tool_name in [tool.value for tool in proxied_tools]:
             return
         try:
             arguments_mapping: Mapping[str, str] = {

--- a/tests/unit/tools/test_tool_names.py
+++ b/tests/unit/tools/test_tool_names.py
@@ -1,18 +1,18 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from dbt_mcp.config.config import load_config
 from dbt_mcp.dbt_cli.binary_type import BinaryType
 from dbt_mcp.mcp.server import create_dbt_mcp
 from dbt_mcp.tools.tool_names import ToolName
+from dbt_mcp.tools.toolsets import proxied_tools
 from tests.env_vars import default_env_vars_context
 
 
 @pytest.mark.asyncio
 async def test_tool_names_match_server_tools():
     """Test that the ToolName enum matches the tools registered in the server."""
-    sql_tool_names = {"text_to_sql", "execute_sql"}
-
     with (
         default_env_vars_context(),
         patch(
@@ -26,7 +26,9 @@ async def test_tool_names_match_server_tools():
         server_tools = await dbt_mcp.list_tools()
         # Manually adding SQL tools here because the server doesn't get them
         # in this unit test.
-        server_tool_names = {tool.name for tool in server_tools} | sql_tool_names
+        server_tool_names = {tool.name for tool in server_tools} | {
+            p.value for p in proxied_tools
+        }
         enum_names = {n for n in ToolName.get_all_tool_names()}
 
         # This should not raise any errors if the enum is in sync

--- a/tests/unit/tools/test_tool_policies.py
+++ b/tests/unit/tools/test_tool_policies.py
@@ -5,13 +5,12 @@ from dbt_mcp.dbt_cli.binary_type import BinaryType
 from dbt_mcp.mcp.server import create_dbt_mcp
 from dbt_mcp.tools.policy import tool_policies
 from dbt_mcp.tools.tool_names import ToolName
+from dbt_mcp.tools.toolsets import proxied_tools
 from tests.env_vars import default_env_vars_context
 
 
 async def test_tool_policies_match_server_tools():
     """Test that the ToolPolicy enum matches the tools registered in the server."""
-    sql_tool_names = {"text_to_sql", "execute_sql"}
-
     with (
         default_env_vars_context(),
         patch(
@@ -25,7 +24,9 @@ async def test_tool_policies_match_server_tools():
         server_tools = await dbt_mcp.list_tools()
         # Manually adding SQL tools here because the server doesn't get them
         # in this unit test.
-        server_tool_names = {tool.name for tool in server_tools} | sql_tool_names
+        server_tool_names = {tool.name for tool in server_tools} | {
+            p.value for p in proxied_tools
+        }
         policy_names = {policy_name for policy_name in tool_policies}
 
         if server_tool_names != policy_names:

--- a/tests/unit/tools/test_toolsets.py
+++ b/tests/unit/tools/test_toolsets.py
@@ -3,14 +3,12 @@ from unittest.mock import patch
 from dbt_mcp.config.config import load_config
 from dbt_mcp.dbt_cli.binary_type import BinaryType
 from dbt_mcp.mcp.server import create_dbt_mcp
-from dbt_mcp.tools.toolsets import toolsets
+from dbt_mcp.tools.toolsets import proxied_tools, toolsets
 from tests.env_vars import default_env_vars_context
 
 
 async def test_toolsets_match_server_tools():
     """Test that the defined toolsets match the tools registered in the server."""
-    sql_tool_names = {"text_to_sql", "execute_sql"}
-
     with (
         default_env_vars_context(),
         patch(
@@ -24,7 +22,9 @@ async def test_toolsets_match_server_tools():
         server_tools = await dbt_mcp.list_tools()
         # Manually adding SQL tools here because the server doesn't get them
         # in this unit test.
-        server_tool_names = {tool.name for tool in server_tools} | sql_tool_names
+        server_tool_names = {tool.name for tool in server_tools} | {
+            p.value for p in proxied_tools
+        }
         defined_tools = set()
         for toolset_tools in toolsets.values():
             defined_tools.update({t.value for t in toolset_tools})


### PR DESCRIPTION
## Summary

We are now counting remote tool calls on our backend, so we shouldn't double-count them here as well.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes