### PR TITLE
Exclude Python 3.14 until pyarrow wheels are out

### DIFF
--- a/.changes/unreleased/Bug Fix-20251020-132553.yaml
+++ b/.changes/unreleased/Bug Fix-20251020-132553.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Exclude Python 3.14 for now as pyarrow hasn't released wheels yet
+time: 2025-10-20T13:25:53.59341+02:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ description = "A MCP (Model Context Protocol) server for interacting with dbt re
 authors = [{ name = "dbt Labs" }]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.12"
+# until pyarrow releases wheels for 3.14 https://github.com/apache/arrow/issues/47438
+requires-python = ">=3.12,<3.14"
 dynamic = ["version"]
 keywords = [
   "dbt",


### PR DESCRIPTION
Excluding 3.14 for now as pyarrow hasn't released wheels: https://github.com/apache/arrow/issues/47438

People on 3.14 had issues during the hackathon.