### PR TITLE
Update instructions LSP tool

### DIFF
--- a/.changes/unreleased/Bug Fix-20251028-143835.yaml
+++ b/.changes/unreleased/Bug Fix-20251028-143835.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Minor update to the instruction for LSP tool
+time: 2025-10-28T14:38:35.729371+01:00

--- a/src/dbt_mcp/prompts/lsp/args/model_id.md
+++ b/src/dbt_mcp/prompts/lsp/args/model_id.md
@@ -1,1 +1,3 @@
-The fully qualified dbt model identifier (e.g., "model.my_project.my_model").
+The fully qualified dbt model identifier (e.g., "model.my_project_name.my_model").
+
+Do not use just the model name, always use the model full identifier. If you don't have the full identifier, the project name is the field `name:` in the `dbt_project.yml` file at the root of the dbt project.


### PR DESCRIPTION
Very minor update to the LSP tool instructions for getting column level lineage.
I couldn't get it to works at first because it was just using the model name instead of its ID.

I am suggesting to get the project name from `dbt_project.yml` but I am open to other suggestions.

- we could also get it from running the list tool but in that case we would need the list tool to accept the JSON output so that we can request the `unique_id`
- or we could accept a model name in addition to its unique ID and build the unique ID ourselves in the logic of the tool