### PR TITLE
Check that host doesn't contain prefix

### DIFF
--- a/.changes/unreleased/Under the Hood-20251028-144531.yaml
+++ b/.changes/unreleased/Under the Hood-20251028-144531.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Update validation logic to raise errors when users add multicell prefix to host
+time: 2025-10-28T14:45:31.648687+01:00

--- a/src/dbt_mcp/config/settings.py
+++ b/src/dbt_mcp/config/settings.py
@@ -278,6 +278,16 @@ def validate_dbt_platform_settings(
             errors.append(
                 "DBT_HOST must not start with 'metadata' or 'semantic-layer'."
             )
+        if settings.actual_host and not settings.actual_host.startswith("localhost"):
+            # Count dots in the hostname (excluding port if present)
+            hostname_without_port = settings.actual_host.split(":")[0]
+            dot_count = hostname_without_port.count(".")
+            if dot_count > 2:
+                errors.append(
+                    f"DBT_HOST appears to include a multi-cell account prefix (found {dot_count} dots, expected 2 or fewer). "
+                    "If you're using Multi-cell, please set DBT_HOST to the base hostname (e.g., 'us1.dbt.com') "
+                    "and set MULTICELL_ACCOUNT_PREFIX or DBT_HOST_PREFIX separately (e.g., 'tj155')."
+                )
     if (
         not settings.actual_disable_sql
         and ToolName.TEXT_TO_SQL not in (settings.disable_tools or [])


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Add a check to provide an error message if the host value contains the mult-icell prefix

## What Changed
<!-- Describe the changes made in this PR -->
Extra check in the config

## Why
<!-- Explain the motivation for these changes -->
People got confused in how to set the host sometimes which led to the MCP server starting correctly but then not being able to connect to the dbt platform