### PR TITLE
fix setup instructions for testing development server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ This repo has automated tests which can be run with `task test:unit`. Additional
 {
   "mcpServers": {
     "dbt": {
-      "command": "<path-to-this-uv>",
+      "command": "<path-to-uv>",
       "args": [
-        --directory,
+        "--directory",
         "<path-to-this-directory>/dbt-mcp",
         "run",
         "dbt-mcp",
@@ -50,9 +50,9 @@ Or, if you would like to test with Oauth, use a configuration like this:
 {
   "mcpServers": {
     "dbt": {
-      "command": "<path-to-this-uv>",
+      "command": "<path-to-uv>",
       "args": [
-        --directory,
+        "--directory",
         "<path-to-this-directory>/dbt-mcp",
         "run",
         "dbt-mcp",


### PR DESCRIPTION
## Summary
If you use current setup instructions you get.  

```
No server object found in /home/faller/repos/dbt-mcp/src/dbt_mcp/main.py. Please either:
1. Use a standard variable name (mcp, server, or app)
2. Specify the object name with file:object syntax3. If the server creates the FastMCP object within main()    or another function, refactor the FastMCP object to be a    global variable named mcp, server, or app.
```

## What Changed
Just the setup.  I _believe_ that it's correct for the oauth as well. 

## Why
So I don't have to take my dev branch out of an `if __name__ == "__main__":` block for it to run.  

## Related Issues

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional Info**
This is the same way that [mcp inspector](https://modelcontextprotocol.io/docs/tools/inspector#python) does it.  
