### PR TITLE
Pin GitHub Actions to specific SHAs (8 actions in 5 files)

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -13,7 +13,7 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'Release: v')"
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup python

--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f
         with:
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -22,7 +22,7 @@ jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
 
       - uses: ./.github/actions/setup-python
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       changie-latest: ${{ steps.changie-latest.outputs.output }}
     if: "startsWith(github.event.head_commit.message, 'version:')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - uses: ./.github/actions/setup-python
       - name: Get the latest version
         id: changie-latest
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
         with:
           ref: ${{ needs.create-release-tag.outputs.changie-latest }}
           fetch-tags: true
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
         with:
           fetch-depth: 0 # Fetches all history for changie to work correctly
 

--- a/.github/workflows/run-checks-pr.yaml
+++ b/.github/workflows/run-checks-pr.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: setup python
         uses: ./.github/actions/setup-python
         id: setup-python
@@ -39,7 +39,7 @@ jobs:
       - check
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: setup python
         uses: ./.github/actions/setup-python
         id: setup-python


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 5
- **Actions pinned**: 8

### 📝 Changes by file

#### `.github/workflows/release.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

#### `.github/workflows/run-checks-pr.yaml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

#### `.github/workflows/create-release-pr.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

#### `.github/workflows/codeowners-check.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

#### `.github/workflows/changelog-check.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

