### PR TITLE
Add search tool to ToolName enum

### DIFF
--- a/.changes/unreleased/Under the Hood-20251210-095908.yaml
+++ b/.changes/unreleased/Under the Hood-20251210-095908.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Add search tool to ToolName enum
+time: 2025-12-10T09:59:08.121821-06:00

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The dbt MCP server architecture allows for your agent to connect to a variety of
 - `get_snapshot_details`
 - `get_source_details`
 - `get_test_details`
+- `search`
 
 ### dbt CLI
 - `build`

--- a/src/dbt_mcp/tools/policy.py
+++ b/src/dbt_mcp/tools/policy.py
@@ -121,6 +121,9 @@ tool_policies = {
     ToolName.GET_SEMANTIC_MODEL_DETAILS.value: ToolPolicy(
         name=ToolName.GET_SEMANTIC_MODEL_DETAILS.value, behavior=ToolBehavior.METADATA
     ),
+    ToolName.SEARCH.value: ToolPolicy(
+        name=ToolName.SEARCH.value, behavior=ToolBehavior.METADATA
+    ),
     # SQL tools
     ToolName.TEXT_TO_SQL.value: ToolPolicy(
         name=ToolName.TEXT_TO_SQL.value, behavior=ToolBehavior.METADATA

--- a/src/dbt_mcp/tools/tool_names.py
+++ b/src/dbt_mcp/tools/tool_names.py
@@ -39,6 +39,7 @@ class ToolName(Enum):
     GET_SEMANTIC_MODEL_DETAILS = "get_semantic_model_details"
     GET_SNAPSHOT_DETAILS = "get_snapshot_details"
     GET_TEST_DETAILS = "get_test_details"
+    SEARCH = "search"  # The search tool is not generally available yet
 
     # SQL tools
     TEXT_TO_SQL = "text_to_sql"

--- a/src/dbt_mcp/tools/toolsets.py
+++ b/src/dbt_mcp/tools/toolsets.py
@@ -26,12 +26,14 @@ proxied_tools: set[
         ToolName.TEXT_TO_SQL,
         ToolName.EXECUTE_SQL,
         ToolName.GET_RELATED_MODELS,
+        ToolName.SEARCH,
     ]
 ] = set(
     [
         ToolName.TEXT_TO_SQL,
         ToolName.EXECUTE_SQL,
         ToolName.GET_RELATED_MODELS,
+        ToolName.SEARCH,
     ]
 )
 
@@ -65,6 +67,7 @@ toolsets = {
         ToolName.GET_SEMANTIC_MODEL_DETAILS,
         ToolName.GET_SNAPSHOT_DETAILS,
         ToolName.GET_TEST_DETAILS,
+        ToolName.SEARCH,
     },
     Toolset.DBT_CLI: {
         ToolName.BUILD,


### PR DESCRIPTION
## Summary

The search tool is not generally available yet, but we still need it to be part of the ToolName enum so we can develop it behind a feature flag.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes