### PR TITLE
Filter triggers based on internal/external PRs

### DIFF
--- a/.changes/unreleased/Under the Hood-20260113-122520.yaml
+++ b/.changes/unreleased/Under the Hood-20260113-122520.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Prevent duplicate flows for internal/external PRs
+time: 2026-01-13T12:25:20.588949+01:00

--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -4,7 +4,7 @@ name: Integration tests
 # 1. Internal PRs (same repo): Runs automatically via pull_request trigger
 # 2. Fork PRs: Requires 'ok-to-test' label added by maintainer (pull_request_target)
 #
-# Fork PRs without the label will fail the check with instructions.
+# Fork PRs via pull_request are skipped (not failed) to avoid confusing status checks.
 # This protects secrets from being exfiltrated by malicious fork PRs.
 on:
   pull_request:
@@ -18,12 +18,19 @@ permissions:
 
 jobs:
   integration:
+    # Only run for:
+    # 1. pull_request_target from fork PRs (with ok-to-test label)
+    # 2. pull_request from internal PRs (not forks)
+    if: |
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     environment: integration
     permissions:
       contents: read
     steps:
       # Gate: Block fork PRs that come through pull_request (no secrets, no label check)
+      # This is a safety net - the job-level `if` should skip these, but this ensures they fail if reached
       - name: Check fork PR authorization
         if: |
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Remove duplicate integration tests flows like we see here: https://github.com/dbt-labs/dbt-mcp/pull/515
We now have 2 different cases, internal PRs vs external PRs

With the new env created, does it mean that we could also change the following setting in the repo?

> **Require approval for all external contributors**
> All users that are not a member or owner of this repository and not a member of the dbt-labs organization will require approval to run workflows.

## What Changed
<!-- Describe the changes made in this PR -->
Trigger integration tests only once, for internal and for external PRs

## Why
<!-- Explain the motivation for these changes -->
We are running extra checks today (see https://github.com/dbt-labs/dbt-mcp/pull/515)
