### PR TITLE
fix: make development environment optional for OAuth context reuse

### DIFF
--- a/.changes/unreleased/Bug Fix-20260126-oauth-dev-env-optional.yaml
+++ b/.changes/unreleased/Bug Fix-20260126-oauth-dev-env-optional.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Make development environment optional when reusing OAuth context, fixing re-auth loop for projects without a dev environment
+time: 2026-01-26T12:00:00.000000+01:00

--- a/src/dbt_mcp/config/settings.py
+++ b/src/dbt_mcp/config/settings.py
@@ -359,11 +359,13 @@ async def get_dbt_platform_context(
     # We need to lock so that only one can run the oauth flow.
     with FileLock(dbt_user_dir / "mcp.lock"):
         dbt_ctx = dbt_platform_context_manager.read_context()
+        # Note: dev_environment is optional since not all projects have a development
+        # environment configured. prod_environment is required for semantic layer
+        # and other core features.
         if (
             dbt_ctx
             and dbt_ctx.account_id
             and dbt_ctx.host_prefix
-            and dbt_ctx.dev_environment
             and dbt_ctx.prod_environment
             and dbt_ctx.decoded_access_token
             and dbt_ctx.decoded_access_token.access_token_response.expires_at


### PR DESCRIPTION
## Summary
- Makes `dev_environment` optional when validating OAuth context for reuse
- Fixes re-authentication loop for projects without a development environment configured

## Problem
Projects without an environment with `deployment_type="development"` would trigger a full OAuth re-authentication on every restart, even though the saved credentials were valid.

## Solution
Remove `dev_environment` from the required fields check since it's not used for semantic layer or other core features. Only `prod_environment` is required.

## Test plan
- [x] Existing unit tests pass