### PR TITLE
fix: expand tilde (~) in path environment variables

### DIFF
--- a/.changes/unreleased/Bug Fix-20260126-expand-tilde-paths.yaml
+++ b/.changes/unreleased/Bug Fix-20260126-expand-tilde-paths.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Expand tilde (~) in DBT_PATH, DBT_PROJECT_DIR, and DBT_PROFILES_DIR environment variables to support paths like ~/.local/bin/dbt
+time: 2026-01-26T21:00:00.000000+01:00

--- a/src/dbt_mcp/config/settings.py
+++ b/src/dbt_mcp/config/settings.py
@@ -227,9 +227,9 @@ class DbtMcpSettings(BaseSettings):
         if v in ["dbt", "dbtf"]:
             return v
         if v:
-            p = Path(v)
+            p = Path(v).expanduser()
             if p.exists():
-                return v
+                return str(p)
 
             field_name = (
                 getattr(info, "field_name", "None") if info is not None else "None"
@@ -242,12 +242,13 @@ class DbtMcpSettings(BaseSettings):
     def validate_dir_exists(cls, v: str | None, info: ValidationInfo) -> str | None:
         """Validate a directory path exists in the system."""
         if v:
-            path = Path(v)
+            path = Path(v).expanduser()
             if not path.is_dir():
                 field_name = (
                     getattr(info, "field_name", "None") if info is not None else "None"
                 ).upper()
                 raise ValueError(f"{field_name} directory does not exist: {v}")
+            return str(path)
         return v
 
     @field_validator("disable_tools", mode="before")


### PR DESCRIPTION
## Summary
- Add `expanduser()` to path validators so that `DBT_PATH`, `DBT_PROJECT_DIR`, and `DBT_PROFILES_DIR` can use tilde notation (e.g., `~/.local/bin/dbt`)
- This allows `.env` files to be shared across different developers without hardcoding absolute paths

## Problem
When using `DBT_PATH=~/.local/bin/dbt` in a `.env` file, pydantic's path validation fails because `Path("~/.local/bin/dbt").exists()` returns `False` - the tilde is not expanded.

## Solution
Call `Path(v).expanduser()` in both `validate_file_exists` and `validate_dir_exists` validators, and return the expanded path so downstream code doesn't need to handle tilde expansion.

## Test plan
- [x] Tested locally with `DBT_PATH=~/.local/bin/dbt` - MCP server starts successfully