### PR TITLE
Add hatchling build hook to build UI during package installation

### DIFF
--- a/.changes/unreleased/Bug Fix-20260128-104532.yaml
+++ b/.changes/unreleased/Bug Fix-20260128-104532.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix installing dbt-mcp from GitHub by adding a hatchling build hook to build UI assets during package installation
+time: 2026-01-28T10:45:32.214336+01:00

--- a/.github/actions/setup-python-and-pnpm/action.yml
+++ b/.github/actions/setup-python-and-pnpm/action.yml
@@ -1,5 +1,5 @@
-name: Setup Python
-description: Setup Python for ai-codegen-api
+name: Setup Python and pnpm
+description: Setup Python, uv, and pnpm for dbt-mcp
 
 runs:
   using: "composite"
@@ -15,6 +15,11 @@ runs:
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      with:
+        version: 10
 
     - name: Install the project
       shell: bash

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup python
-        uses: ./.github/actions/setup-python
+        uses: ./.github/actions/setup-python-and-pnpm
         id: setup-python
       - name: Check for changes
         run: |

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
 
-      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-python-and-pnpm
 
       - name: Compute next dir for bump
         id: changie-next

--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
       - name: Setup Python
-        uses: ./.github/actions/setup-python
+        uses: ./.github/actions/setup-python-and-pnpm
         id: setup-python
 
       - name: Install go-task

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'version:')"
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
-      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-python-and-pnpm
       - name: Get the latest version
         id: changie-latest
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
@@ -50,12 +50,8 @@ jobs:
           fetch-tags: true
 
       - name: setup python
-        uses: ./.github/actions/setup-python
+        uses: ./.github/actions/setup-python-and-pnpm
         id: setup-python
-
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
-        with:
-          version: 10
 
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
@@ -121,11 +117,7 @@ jobs:
         uses: ./.github/actions/setup-mcpb          
 
       - name: Setup python
-        uses: ./.github/actions/setup-python
-
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
-        with:
-          version: 10
+        uses: ./.github/actions/setup-python-and-pnpm
 
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin

--- a/.github/workflows/run-checks-pr.yaml
+++ b/.github/workflows/run-checks-pr.yaml
@@ -16,11 +16,8 @@ jobs:
       - name: checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: setup python
-        uses: ./.github/actions/setup-python
+        uses: ./.github/actions/setup-python-and-pnpm
         id: setup-python
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
-        with:
-          version: 10
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
       - name: Install dependencies
@@ -41,11 +38,8 @@ jobs:
       - name: checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: setup python
-        uses: ./.github/actions/setup-python
+        uses: ./.github/actions/setup-python-and-pnpm
         id: setup-python
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
-        with:
-          version: 10
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
       - name: Run tests
@@ -64,7 +58,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: setup python
-        uses: ./.github/actions/setup-python
+        uses: ./.github/actions/setup-python-and-pnpm
         id: setup-python
       - name: Install go-task
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -102,7 +102,6 @@ tasks:
   build:
     desc: "Build the package"
     cmds:
-      - (cd ui && pnpm install && pnpm build)
       - uv build
 
   client:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,66 @@
+"""Hatchling build hook to build the UI before packaging."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface  # type: ignore[import-not-found]
+
+
+class UIBuildHook(BuildHookInterface):
+    """Build hook that builds the UI assets before packaging."""
+
+    PLUGIN_NAME = "ui-build"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        """Build the UI assets before the package is built."""
+        if self.target_name not in ("wheel", "sdist"):
+            return
+
+        root = Path(self.root)
+        ui_dir = root / "ui"
+
+        if not ui_dir.exists():
+            self.app.display_warning(f"UI directory not found: {ui_dir}")
+            return
+
+        # Check if pnpm is available
+        pnpm_cmd = shutil.which("pnpm")
+        if not pnpm_cmd:
+            self.app.display_error(
+                "pnpm is not installed. Please install pnpm to build the UI. "
+                "You can install it with: npm install -g pnpm"
+            )
+            sys.exit(1)
+
+        self.app.display_info("Building UI assets...")
+
+        try:
+            # Run pnpm install
+            self.app.display_info("Running pnpm install...")
+            subprocess.run(
+                [pnpm_cmd, "install"],
+                cwd=ui_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            # Run pnpm build
+            self.app.display_info("Running pnpm build...")
+            subprocess.run(
+                [pnpm_cmd, "build"],
+                cwd=ui_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            self.app.display_success("UI assets built successfully")
+        except subprocess.CalledProcessError as e:
+            self.app.display_error(f"Failed to build UI: {e.stderr}")
+            sys.exit(1)
+        except FileNotFoundError as e:
+            self.app.display_error(f"Command not found: {e}")
+            sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,14 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-include = ["src/dbt_mcp/**/*", "README.md", "LICENSE"]
+include = ["src/dbt_mcp/**/*", "README.md", "LICENSE", "ui/**/*"]
+exclude = ["ui/node_modules/**/*"]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.targets.sdist.hooks.custom]
+path = "hatch_build.py"
 
 [tool.hatch.version]
 source = "vcs"

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
+packages: []
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary

Fixes #560

This PR adds a hatchling build hook that automatically builds the UI assets during package installation, enabling users to install dbt-mcp directly from GitHub:

```bash
uvx git+https://github.com/dbt-labs/dbt-mcp@main
```

## Changes

- Add `hatch_build.py` with `UIBuildHook` that runs `pnpm install` and `pnpm build`
- Configure the hook in `pyproject.toml` for both wheel and sdist targets
- Include `ui/` source files in sdist (excluding `node_modules`)
- Remove manual UI build from Taskfile `build` task (hook handles it now)
- Fix `pnpm-workspace.yaml` to include `packages` field required by pnpm v10

## Notes

- Users installing from GitHub will need `pnpm` installed (as discussed in the issue, this is an acceptable tradeoff)
- GitHub Actions already has pnpm setup via `pnpm/action-setup`
- The hook provides clear error messages if pnpm is not available

## Test plan

- [x] Verified `uv build` works and triggers the hook
- [x] Verified sdist includes UI source files but excludes `node_modules`