### PR TITLE
Fix httpx ReadTimeout on semantic layer cold cache queries

### DIFF
--- a/src/dbt_mcp/semantic_layer/gql/gql_request.py
+++ b/src/dbt_mcp/semantic_layer/gql/gql_request.py
@@ -12,7 +12,7 @@ async def submit_request(
         payload["variables"] = {}
     payload["variables"]["environmentId"] = sl_config.prod_environment_id
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(
             sl_config.url,
             json=payload,


### PR DESCRIPTION
## Summary
- Increases the httpx client timeout from the default 5s to 30s for semantic layer GraphQL requests to metricflow-server
- Fixes intermittent `ReadTimeout` errors on `query_metrics` tool calls

## Test plan
- [ ] Verify unit tests pass (`uv run pytest tests/unit`)
- [ ] Verify semantic layer queries succeed on cold cache scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)