### PR TITLE
Recategorize user-caused errors as InvalidParameterError

### DIFF
--- a/.changes/unreleased/Bug Fix-20260209-recategorize-tool-errors.yaml
+++ b/.changes/unreleased/Bug Fix-20260209-recategorize-tool-errors.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Recategorize user-caused tool errors as InvalidParameterError so error messages are shown to users instead of being sanitized
+time: 2026-02-09T13:00:00.000000-06:00


### PR DESCRIPTION
## Summary

Inspects HTTP response status codes in the Admin API client to distinguish user-caused errors from server-side failures:

- **`_make_request`**: 4xx → `InvalidParameterError` (bad request, not found, forbidden), 5xx → `AdminAPIError` (server error)
- **`get_job_run_artifact`**: 4xx → `InvalidParameterError` (artifact/run not found), 5xx → `ArtifactRetrievalError` (server error)

Previously, all `httpx.HTTPStatusError` exceptions were wrapped as server-side errors regardless of status code. This meant user-caused errors (e.g., requesting a nonexistent artifact) were sanitized to "Internal tool error" in ai-codegen-api instead of showing the actual error message.

Companion to dbt-labs/ai-codegen-api#736 which changed `BadRequestErrors` to use `InvalidParameterError` instead of `ToolCallError`.

## Test plan

- [x] Added test: Admin API 4xx raises `InvalidParameterError`
- [x] Added test: Admin API 5xx raises `AdminAPIError`
- [x] Added test: Artifact retrieval 4xx raises `InvalidParameterError`
- [x] Added test: Artifact retrieval 5xx raises `ArtifactRetrievalError`
- [x] Full unit test suite passes (369 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)