### PR TITLE
feat: eager warehouse auth check for browser-based authentication

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260309-browser-auth-check.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260309-browser-auth-check.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add eager warehouse auth check for browser-based authentication (e.g., Snowflake externalbrowser)
+time: 2026-03-09T10:00:00.000000-08:00

--- a/docs/plans/2026-03-09-browser-auth-check-design.md
+++ b/docs/plans/2026-03-09-browser-auth-check-design.md
@@ -1,0 +1,57 @@
+# Browser-Based Warehouse Authentication Check
+
+## Problem
+
+When dbt is configured to use browser-based warehouse authentication (e.g., Snowflake `authenticator: externalbrowser`), the dbt CLI commands invoked by dbt-mcp fail because:
+
+1. `subprocess.Popen` uses `stdin=subprocess.DEVNULL`, which may block interactive auth flows
+2. The default 60-second timeout may be too short for a user to complete browser SSO
+3. The user gets no feedback that browser authentication is needed
+
+This affects dbt Core and Fusion users with local `profiles.yml` using browser-based SSO for their data warehouse. dbt Cloud CLI is not affected (warehouse auth is handled server-side).
+
+## Solution
+
+Run `dbt debug` as an eager background task during MCP server lifespan (matching the existing pattern used for LSP connection). This:
+
+1. Triggers the browser auth flow early, before the user invokes any CLI tool
+2. Caches the token in the OS keychain (via the dbt adapter)
+3. Makes subsequent CLI commands work without re-authentication
+
+### Architecture
+
+```
+app_lifespan()
+├── register proxied tools (existing)
+├── eager LSP connection (existing)
+└── NEW: eager warehouse auth check
+    └── asyncio.create_task(warehouse_auth_check())
+        └── runs `dbt debug` (no stdin=DEVNULL, longer timeout)
+            ├── success → auth_status = AUTHENTICATED
+            ├── timeout → auth_status = TIMEOUT (with guidance)
+            └── error → auth_status = FAILED (with error message)
+```
+
+### Auth Status Flow
+
+CLI tools check auth status before executing:
+- `AUTHENTICATED` or `NOT_STARTED` (no CLI config): proceed normally
+- `IN_PROGRESS`: wait briefly, then proceed (the auth may complete during the command)
+- `TIMEOUT` / `FAILED`: return actionable error message to the user
+
+### Key Design Decisions
+
+1. **No profile parsing** — We don't try to detect the auth method. We just run `dbt debug` for all CLI users. It's fast when no browser auth is needed, and triggers the flow when it is.
+
+2. **Non-blocking startup** — The check runs as `asyncio.create_task()`, matching the LSP eager-start pattern. Server starts immediately; the check runs in parallel.
+
+3. **Generous timeout** — The auth check uses a longer timeout (120s) than normal CLI commands (60s) to give users time to complete browser SSO.
+
+4. **No stdin=DEVNULL** — The `dbt debug` subprocess is allowed to interact with the environment so browser auth can work.
+
+## Files to Change
+
+- `src/dbt_mcp/dbt_cli/auth_check.py` (new) — Auth check logic and status tracking
+- `src/dbt_mcp/mcp/server.py` — Launch auth check in `app_lifespan()`
+- `src/dbt_mcp/dbt_cli/tools.py` — Check auth status before running CLI commands
+- `tests/unit/dbt_cli/test_auth_check.py` (new) — Tests

--- a/src/dbt_mcp/dbt_cli/auth_check.py
+++ b/src/dbt_mcp/dbt_cli/auth_check.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+import os
+from enum import Enum
+
+from dbt_mcp.config.config import DbtCliConfig
+from dbt_mcp.dbt_cli.binary_type import get_color_disable_flag
+
+logger = logging.getLogger(__name__)
+
+AUTH_CHECK_TIMEOUT = 120  # Generous timeout for browser SSO
+
+
+class AuthStatus(Enum):
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    AUTHENTICATED = "authenticated"
+    TIMEOUT = "timeout"
+    FAILED = "failed"
+
+
+class WarehouseAuthChecker:
+    """Runs `dbt debug` eagerly to trigger and cache warehouse authentication.
+
+    When dbt uses browser-based warehouse auth (e.g., Snowflake externalbrowser),
+    the token gets cached in the OS keychain after a successful auth. This checker
+    triggers that flow during server startup so subsequent CLI commands work.
+    """
+
+    def __init__(self, config: DbtCliConfig) -> None:
+        self._config = config
+        self._status = AuthStatus.NOT_STARTED
+        self._error_message: str | None = None
+
+    @property
+    def status(self) -> AuthStatus:
+        return self._status
+
+    @property
+    def error_message(self) -> str | None:
+        return self._error_message
+
+    async def run_auth_check(self) -> None:
+        """Run `dbt debug` to trigger warehouse authentication."""
+        self._status = AuthStatus.IN_PROGRESS
+        logger.info("Starting warehouse auth check via dbt debug")
+
+        try:
+            cwd_path = (
+                self._config.project_dir
+                if os.path.isabs(self._config.project_dir)
+                else None
+            )
+            color_flag = get_color_disable_flag(self._config.binary_type)
+            args = [self._config.dbt_path, color_flag, "debug"]
+
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                cwd=cwd_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+
+            stdout, _ = await asyncio.wait_for(
+                process.communicate(),
+                timeout=AUTH_CHECK_TIMEOUT,
+            )
+            output = stdout.decode() if stdout else ""
+
+            if process.returncode == 0:
+                self._status = AuthStatus.AUTHENTICATED
+                logger.info("Warehouse auth check succeeded")
+            else:
+                self._status = AuthStatus.FAILED
+                self._error_message = output
+                logger.warning(f"Warehouse auth check failed: {output}")
+
+        except TimeoutError:
+            self._status = AuthStatus.TIMEOUT
+            self._error_message = (
+                "Warehouse authentication timed out. "
+                "If your dbt profile uses browser-based authentication "
+                "(e.g., Snowflake externalbrowser), please run "
+                "'dbt debug' in your terminal to authenticate, then restart the MCP server."
+            )
+            logger.warning("Warehouse auth check timed out")
+        except Exception as e:
+            self._status = AuthStatus.FAILED
+            self._error_message = str(e)
+            logger.warning(f"Warehouse auth check error: {e}")
+
+    def get_status_message(self) -> str | None:
+        """Return an actionable message if auth is not ready, or None if OK."""
+        if self._status in (AuthStatus.AUTHENTICATED, AuthStatus.NOT_STARTED):
+            return None
+        if self._status == AuthStatus.IN_PROGRESS:
+            return None  # Let the command proceed; auth may complete during execution
+        if self._status == AuthStatus.TIMEOUT:
+            return self._error_message
+        if self._status == AuthStatus.FAILED:
+            return (
+                f"Warehouse connection check failed during startup. "
+                f"dbt debug output:\n{self._error_message}"
+            )
+        return None

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from dbt_mcp.config.config import DbtCliConfig
+from dbt_mcp.dbt_cli.auth_check import WarehouseAuthChecker
 from dbt_mcp.dbt_cli.binary_type import get_color_disable_flag
 from dbt_mcp.dbt_cli.models.lineage_types import ModelLineage
 from dbt_mcp.dbt_cli.models.manifest import Manifest
@@ -25,7 +26,10 @@ from dbt_mcp.tools.tool_names import ToolName
 from dbt_mcp.tools.toolsets import Toolset
 
 
-def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition]:
+def create_dbt_cli_tool_definitions(
+    config: DbtCliConfig,
+    auth_checker: WarehouseAuthChecker | None = None,
+) -> list[ToolDefinition]:
     def _run_dbt_command(
         command: list[str],
         selector: str | None = None,
@@ -34,6 +38,12 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         is_full_refresh: bool | None = False,
         vars: str | None = None,
     ) -> str:
+        # Check warehouse auth status before running commands that connect to the warehouse
+        if auth_checker:
+            status_message = auth_checker.get_status_message()
+            if status_message:
+                return status_message
+
         try:
             # Commands that should always be quiet to reduce output verbosity
             verbose_commands = [
@@ -406,10 +416,11 @@ def register_dbt_cli_tools(
     enabled_tools: set[ToolName] | None,
     enabled_toolsets: set[Toolset],
     disabled_toolsets: set[Toolset],
+    auth_checker: WarehouseAuthChecker | None = None,
 ) -> None:
     register_tools(
         dbt_mcp,
-        tool_definitions=create_dbt_cli_tool_definitions(config),
+        tool_definitions=create_dbt_cli_tool_definitions(config, auth_checker),
         disabled_tools=disabled_tools,
         enabled_tools=enabled_tools,
         enabled_toolsets=enabled_toolsets,

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -13,6 +13,7 @@ from mcp.types import ContentBlock, TextContent
 
 from dbt_mcp.config.config import Config
 from dbt_mcp.dbt_admin.tools import register_admin_api_tools
+from dbt_mcp.dbt_cli.auth_check import WarehouseAuthChecker
 from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
 from dbt_mcp.dbt_codegen.tools import register_dbt_codegen_tools
 from dbt_mcp.discovery.tools import register_discovery_tools
@@ -50,6 +51,7 @@ class DbtMCP(FastMCP):
         self.usage_tracker = usage_tracker
         self.config = config
         self.lsp_connection_provider = lsp_connection_provider
+        self.warehouse_auth_checker: WarehouseAuthChecker | None = None
         self._lsp_connection_task: (
             asyncio.Task[LSPConnectionProviderProtocol] | None
         ) = None
@@ -127,6 +129,11 @@ async def app_lifespan(server: FastMCP[Any]) -> AsyncIterator[bool | None]:
         # eager start and initialize the LSP connection
         if server.lsp_connection_provider:
             asyncio.create_task(server.lsp_connection_provider.get_connection())
+
+        # eager warehouse auth check via dbt debug
+        if server.warehouse_auth_checker:
+            asyncio.create_task(server.warehouse_auth_checker.run_auth_check())
+
         yield None
     except Exception as e:
         logger.error(f"Error in MCP server: {e}")
@@ -203,6 +210,7 @@ async def create_dbt_mcp(config: Config) -> DbtMCP:
 
     if config.dbt_cli_config:
         logger.info("Registering dbt cli tools")
+        dbt_mcp.warehouse_auth_checker = WarehouseAuthChecker(config.dbt_cli_config)
         register_dbt_cli_tools(
             dbt_mcp,
             config=config.dbt_cli_config,
@@ -210,6 +218,7 @@ async def create_dbt_mcp(config: Config) -> DbtMCP:
             enabled_tools=enabled_tools,
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
+            auth_checker=dbt_mcp.warehouse_auth_checker,
         )
 
     if config.dbt_codegen_config:

--- a/tests/unit/dbt_cli/test_auth_check.py
+++ b/tests/unit/dbt_cli/test_auth_check.py
@@ -1,0 +1,123 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dbt_mcp.config.config import DbtCliConfig
+from dbt_mcp.dbt_cli.auth_check import AuthStatus, WarehouseAuthChecker
+from dbt_mcp.dbt_cli.binary_type import BinaryType
+
+
+@pytest.fixture
+def cli_config() -> DbtCliConfig:
+    return DbtCliConfig(
+        project_dir="/tmp/test_project",
+        dbt_path="/usr/local/bin/dbt",
+        dbt_cli_timeout=60,
+        binary_type=BinaryType.DBT_CORE,
+    )
+
+
+@pytest.fixture
+def auth_checker(cli_config: DbtCliConfig) -> WarehouseAuthChecker:
+    return WarehouseAuthChecker(cli_config)
+
+
+class TestWarehouseAuthChecker:
+    def test_initial_status_is_not_started(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        assert auth_checker.status == AuthStatus.NOT_STARTED
+        assert auth_checker.error_message is None
+
+    def test_get_status_message_when_not_started(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        assert auth_checker.get_status_message() is None
+
+    def test_get_status_message_when_authenticated(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        auth_checker._status = AuthStatus.AUTHENTICATED
+        assert auth_checker.get_status_message() is None
+
+    def test_get_status_message_when_in_progress(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        auth_checker._status = AuthStatus.IN_PROGRESS
+        assert auth_checker.get_status_message() is None
+
+    def test_get_status_message_when_timeout(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        auth_checker._status = AuthStatus.TIMEOUT
+        auth_checker._error_message = "timed out"
+        message = auth_checker.get_status_message()
+        assert message == "timed out"
+
+    def test_get_status_message_when_failed(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        auth_checker._status = AuthStatus.FAILED
+        auth_checker._error_message = "connection refused"
+        message = auth_checker.get_status_message()
+        assert message is not None
+        assert "connection refused" in message
+
+    @pytest.mark.asyncio
+    async def test_successful_auth_check(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.communicate.return_value = (b"All checks passed!", None)
+        mock_process.returncode = 0
+
+        with patch(
+            "dbt_mcp.dbt_cli.auth_check.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ):
+            await auth_checker.run_auth_check()
+
+        assert auth_checker.status == AuthStatus.AUTHENTICATED
+        assert auth_checker.error_message is None
+
+    @pytest.mark.asyncio
+    async def test_failed_auth_check(self, auth_checker: WarehouseAuthChecker) -> None:
+        mock_process = AsyncMock()
+        mock_process.communicate.return_value = (b"Connection failed", None)
+        mock_process.returncode = 1
+
+        with patch(
+            "dbt_mcp.dbt_cli.auth_check.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ):
+            await auth_checker.run_auth_check()
+
+        assert auth_checker.status == AuthStatus.FAILED
+        assert "Connection failed" in (auth_checker.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_timeout_auth_check(self, auth_checker: WarehouseAuthChecker) -> None:
+        mock_process = AsyncMock()
+        mock_process.communicate.side_effect = TimeoutError()
+
+        with patch(
+            "dbt_mcp.dbt_cli.auth_check.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ):
+            await auth_checker.run_auth_check()
+
+        assert auth_checker.status == AuthStatus.TIMEOUT
+        assert "browser-based authentication" in (auth_checker.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_exception_auth_check(
+        self, auth_checker: WarehouseAuthChecker
+    ) -> None:
+        with patch(
+            "dbt_mcp.dbt_cli.auth_check.asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("dbt not found"),
+        ):
+            await auth_checker.run_auth_check()
+
+        assert auth_checker.status == AuthStatus.FAILED
+        assert "dbt not found" in (auth_checker.error_message or "")


### PR DESCRIPTION
## Summary

- Runs `dbt debug` as an eager background task during MCP server startup to trigger and cache browser-based warehouse auth (e.g., Snowflake `externalbrowser`)
- If the cached warehouse token has expired, the browser SSO flow completes before any CLI tool is invoked
- If auth times out or fails, CLI tools return an actionable error message instead of a cryptic timeout

Closes #628

## How it works

1. `WarehouseAuthChecker` is created during `create_dbt_mcp()` when CLI tools are configured
2. In `app_lifespan()`, `dbt debug` runs as `asyncio.create_task()` (same pattern as LSP eager start)
3. The subprocess runs without `stdin=subprocess.DEVNULL` and with a 120s timeout to allow browser SSO
4. On success, the adapter caches the token in the OS keychain; subsequent CLI commands work normally
5. On failure/timeout, `_run_dbt_command()` checks auth status and returns guidance to the user

## Test plan

- [x] Unit tests for all `AuthStatus` transitions (10 tests)
- [x] All existing 396 unit tests still pass
- [x] ruff check, ruff format, mypy all pass
- [ ] Manual test with Snowflake `externalbrowser` profile with expired token