### PR TITLE
Add PR guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ Tools can have associated UIs via the `meta` field:
 - `task inspector` — run with MCP Inspector
 - `uv run pytest tests/ --ignore=tests/integration -x -q` — quick unit test run
 
+## PRs
+
+- **This is an open-source repo.** Do not include internal links (Notion, Slack, Jira) or internal details in PR descriptions, commit messages, or code comments. Keep PR descriptions focused on the public-facing what and why.
+- Run `task check` before every PR push
+
 ## Style
 
 - See `.cursor/rules/python.mdc` for Python conventions


### PR DESCRIPTION
## Why

As an open-source repo, PR descriptions and commit messages should not contain internal links or details. Adding explicit guidelines prevents accidental leakage.

## What

Added a "PRs" section to CLAUDE.md with two rules:
- No internal links (Notion, Slack, Jira) or internal details in PR descriptions, commit messages, or code comments
- Run `task check` before every PR push

Drafted by Claude Opus 4.6 under the direction of @DevonFulcher