### PR TITLE
Switch dependencies to compatible release (~=) specifiers

### DIFF
--- a/.changes/unreleased/Under the Hood-20260316-113257.yaml
+++ b/.changes/unreleased/Under the Hood-20260316-113257.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Switch dependencies to compatible release (~=) specifiers
+time: 2026-03-16T11:32:57.668349-05:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,23 +28,23 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "authlib==1.6.7",
-  "dbt-protos>=1.0.431",
-  "dbt-sl-sdk[sync]>=0.13.2",
-  "dbtlabs-vortex==0.2.0",
-  "fastapi>=0.116.1",
-  "uvicorn>=0.31.1",
+  "authlib~=1.6.7",
+  "dbt-protos~=1.0.431",
+  "dbt-sl-sdk[sync]~=0.13.2",
+  "dbtlabs-vortex~=0.2.0",
+  "fastapi~=0.128.0",
+  "uvicorn~=0.38.0",
   # Pinned to a patch range because src/dbt_mcp/proxy/tools.py accesses private
   # MCP SDK internals (_tool_manager._tools, mcp.server.fastmcp.utilities.func_metadata).
   # When upgrading, verify those APIs are unchanged and update this pin accordingly.
   "mcp[cli]==1.26.0",
-  "pydantic-settings==2.10.1",
-  "pyjwt==2.12.0",
-  "pyyaml==6.0.2",
-  "requests==2.32.4",
-  "httpx==0.28.1",
-  "filelock>=3.18.0",
-  "starlette>=0.49.1",
+  "pydantic-settings~=2.10.1",
+  "pyjwt~=2.12.0",
+  "pyyaml~=6.0.2",
+  "requests~=2.32.4",
+  "httpx~=0.28.1",
+  "filelock~=3.20.3",
+  "starlette~=0.50.0",
 ]
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -290,20 +290,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "authlib", specifier = "==1.6.7" },
-    { name = "dbt-protos", specifier = ">=1.0.431" },
-    { name = "dbt-sl-sdk", extras = ["sync"], specifier = ">=0.13.2" },
-    { name = "dbtlabs-vortex", specifier = "==0.2.0" },
-    { name = "fastapi", specifier = ">=0.116.1" },
-    { name = "filelock", specifier = ">=3.18.0" },
-    { name = "httpx", specifier = "==0.28.1" },
+    { name = "authlib", specifier = "~=1.6.7" },
+    { name = "dbt-protos", specifier = "~=1.0.431" },
+    { name = "dbt-sl-sdk", extras = ["sync"], specifier = "~=0.13.2" },
+    { name = "dbtlabs-vortex", specifier = "~=0.2.0" },
+    { name = "fastapi", specifier = "~=0.128.0" },
+    { name = "filelock", specifier = "~=3.20.3" },
+    { name = "httpx", specifier = "~=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
-    { name = "pydantic-settings", specifier = "==2.10.1" },
-    { name = "pyjwt", specifier = "==2.12.0" },
-    { name = "pyyaml", specifier = "==6.0.2" },
-    { name = "requests", specifier = "==2.32.4" },
-    { name = "starlette", specifier = ">=0.49.1" },
-    { name = "uvicorn", specifier = ">=0.31.1" },
+    { name = "pydantic-settings", specifier = "~=2.10.1" },
+    { name = "pyjwt", specifier = "~=2.12.0" },
+    { name = "pyyaml", specifier = "~=6.0.2" },
+    { name = "requests", specifier = "~=2.32.4" },
+    { name = "starlette", specifier = "~=0.50.0" },
+    { name = "uvicorn", specifier = "~=0.38.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Replace `==` and `>=` version specifiers with `~=` (compatible release) for all dependencies except `mcp[cli]`, which must remain exact-pinned due to reliance on private SDK internals.
- Bumps minimum versions for `fastapi`, `uvicorn`, `starlette`, and `filelock` to match currently resolved versions, avoiding conflicts with `~=` constraints.

## Test plan
- [ ] `task check` passes
- [ ] `task test:unit` passes
- [ ] Verify `uv lock` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)