### PR TITLE
Simplify OAuth token refresh and extract credentials module

### DIFF
--- a/.changes/unreleased/Under the Hood-20260316-161230.yaml
+++ b/.changes/unreleased/Under the Hood-20260316-161230.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: 'Simplify OAuth token refresh: consolidate duplicate refresh logic, unify expiry constants, add JWKS caching, and extract credentials module from settings'
+time: 2026-03-16T16:12:30.736639-05:00

--- a/src/dbt_mcp/config/credentials.py
+++ b/src/dbt_mcp/config/credentials.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import logging
+import socket
+import time
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dbt_mcp.config.settings import DbtMcpSettings
+
+from filelock import FileLock
+
+from dbt_mcp.config.headers import TokenProvider
+from dbt_mcp.oauth.context_manager import DbtPlatformContextManager
+from dbt_mcp.oauth.dbt_platform import DbtPlatformContext
+from dbt_mcp.oauth.expiry import STARTUP_EXPIRY_BUFFER_SECONDS
+from dbt_mcp.oauth.login import login
+from dbt_mcp.oauth.refresh import refresh_oauth_token
+from dbt_mcp.oauth.token_provider import OAuthTokenProvider, StaticTokenProvider
+
+logger = logging.getLogger(__name__)
+
+OAUTH_REDIRECT_STARTING_PORT = 6785
+
+
+class AuthenticationMethod(Enum):
+    OAUTH = "oauth"
+    ENV_VAR = "env_var"
+
+
+def _find_available_port(*, start_port: int, max_attempts: int = 20) -> int:
+    """
+    Return the first available port on 127.0.0.1 starting at start_port.
+
+    Raises RuntimeError if no port is found within the attempted range.
+    """
+    for candidate_port in range(start_port, start_port + max_attempts):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("127.0.0.1", candidate_port))
+            except OSError:
+                continue
+            return candidate_port
+    raise RuntimeError(
+        "No available port found starting at "
+        f"{start_port} after {max_attempts} attempts."
+    )
+
+
+def get_dbt_profiles_path(dbt_profiles_dir: str | None = None) -> Path:
+    # Respect DBT_PROFILES_DIR if set; otherwise default to ~/.dbt/mcp.yml
+    if dbt_profiles_dir:
+        return Path(dbt_profiles_dir).expanduser()
+    else:
+        return Path.home() / ".dbt"
+
+
+def _is_context_complete(dbt_ctx: DbtPlatformContext | None) -> bool:
+    """Check if the context has all required fields (regardless of token expiry).
+
+    Note: dev_environment is optional since not all projects have a development
+    environment configured. prod_environment is required for semantic layer
+    and other core features.
+    """
+    return bool(
+        dbt_ctx
+        and dbt_ctx.account_id
+        and dbt_ctx.host_prefix
+        and dbt_ctx.prod_environment
+        and dbt_ctx.decoded_access_token
+    )
+
+
+def _is_token_valid(dbt_ctx: DbtPlatformContext) -> bool:
+    """Check if the access token is still valid (not expired)."""
+    if not dbt_ctx.decoded_access_token:
+        return False
+    expires_at = dbt_ctx.decoded_access_token.access_token_response.expires_at
+    return expires_at > time.time() + STARTUP_EXPIRY_BUFFER_SECONDS
+
+
+def _try_refresh_token(
+    dbt_ctx: DbtPlatformContext,
+    dbt_platform_url: str,
+    dbt_platform_context_manager: DbtPlatformContextManager,
+) -> DbtPlatformContext | None:
+    """
+    Attempt to refresh the access token using the refresh token.
+    Returns the updated context if successful, None otherwise.
+    """
+    if not dbt_ctx.decoded_access_token:
+        return None
+
+    refresh_token_value = dbt_ctx.decoded_access_token.access_token_response.refresh_token
+    if not refresh_token_value:
+        return None
+
+    try:
+        logger.info("Access token expired, attempting refresh using refresh token")
+        token_url = f"{dbt_platform_url}/oauth/token"
+        new_context = refresh_oauth_token(
+            refresh_token=refresh_token_value,
+            token_url=token_url,
+            dbt_platform_url=dbt_platform_url,
+        )
+        # Merge the new token with the existing context (preserves account/env info)
+        updated_context = dbt_ctx.override(new_context)
+        dbt_platform_context_manager.write_context_to_file(updated_context)
+        logger.info("Successfully refreshed access token at startup")
+        return updated_context
+    except Exception as e:
+        logger.warning(f"Failed to refresh token at startup: {e}")
+        return None
+
+
+async def get_dbt_platform_context(
+    *,
+    dbt_user_dir: Path,
+    dbt_platform_url: str,
+    dbt_platform_context_manager: DbtPlatformContextManager,
+) -> DbtPlatformContext:
+    # Some MCP hosts (Claude Desktop) tend to run multiple MCP servers instances.
+    # We need to lock so that only one can run the oauth flow.
+    with FileLock(dbt_user_dir / "mcp.lock"):
+        dbt_ctx = dbt_platform_context_manager.read_context()
+
+        # If context is complete, check token validity
+        if _is_context_complete(dbt_ctx):
+            assert dbt_ctx is not None  # for type checker
+            # If token is still valid, use context directly
+            if _is_token_valid(dbt_ctx):
+                return dbt_ctx
+            # Token expired, try to refresh
+            refreshed_ctx = _try_refresh_token(
+                dbt_ctx, dbt_platform_url, dbt_platform_context_manager
+            )
+            if refreshed_ctx:
+                return refreshed_ctx
+
+        # Fall back to full OAuth login flow
+        selected_port = _find_available_port(start_port=OAUTH_REDIRECT_STARTING_PORT)
+        return await login(
+            dbt_platform_url=dbt_platform_url,
+            port=selected_port,
+            dbt_platform_context_manager=dbt_platform_context_manager,
+        )
+
+
+def get_dbt_host(
+    settings: DbtMcpSettings,
+    dbt_platform_context: DbtPlatformContext,
+) -> str:
+    actual_host = settings.actual_host
+    if not actual_host:
+        raise ValueError("DBT_HOST is a required environment variable")
+    host_prefix_with_period = f"{dbt_platform_context.host_prefix}."
+    if not actual_host.startswith(host_prefix_with_period):
+        raise ValueError(
+            f"The DBT_HOST environment variable is expected to start with the {dbt_platform_context.host_prefix} custom subdomain."
+        )
+    # We have to remove the custom subdomain prefix
+    # so that the metadata and semantic-layer URLs can be constructed correctly.
+    return actual_host.removeprefix(host_prefix_with_period)
+
+
+class CredentialsProvider:
+    def __init__(self, settings: DbtMcpSettings):
+        self.settings = settings
+        self.token_provider: TokenProvider | None = None
+        self.authentication_method: AuthenticationMethod | None = None
+
+    def _log_settings(self) -> None:
+        settings = self.settings.model_dump()
+        if settings.get("dbt_token") is not None:
+            settings["dbt_token"] = "***redacted***"
+        logger.info(f"Settings: {settings}")
+
+    async def get_credentials(self) -> tuple[DbtMcpSettings, TokenProvider]:
+        from dbt_mcp.config.settings import (
+            validate_dbt_cli_settings,
+            validate_dbt_platform_settings,
+            validate_settings,
+        )
+
+        if self.token_provider is not None:
+            # If token provider is already set, just return the cached values
+            return self.settings, self.token_provider
+        # Load settings from environment variables using pydantic_settings
+        dbt_platform_errors = validate_dbt_platform_settings(self.settings)
+        if dbt_platform_errors:
+            dbt_user_dir = get_dbt_profiles_path(
+                dbt_profiles_dir=self.settings.dbt_profiles_dir
+            )
+            config_location = dbt_user_dir / "mcp.yml"
+            dbt_platform_url = f"https://{self.settings.actual_host}"
+            dbt_platform_context_manager = DbtPlatformContextManager(config_location)
+            dbt_platform_context = await get_dbt_platform_context(
+                dbt_platform_context_manager=dbt_platform_context_manager,
+                dbt_user_dir=dbt_user_dir,
+                dbt_platform_url=dbt_platform_url,
+            )
+
+            # Override settings with settings attained from login or mcp.yml
+            self.settings.dbt_user_id = dbt_platform_context.user_id
+            self.settings.dbt_dev_env_id = (
+                dbt_platform_context.dev_environment.id
+                if dbt_platform_context.dev_environment
+                else None
+            )
+            self.settings.dbt_prod_env_id = (
+                dbt_platform_context.prod_environment.id
+                if dbt_platform_context.prod_environment
+                else None
+            )
+            self.settings.dbt_account_id = dbt_platform_context.account_id
+            self.settings.host_prefix = dbt_platform_context.host_prefix
+            self.settings.dbt_host = get_dbt_host(self.settings, dbt_platform_context)
+            if not dbt_platform_context.decoded_access_token:
+                raise ValueError("No decoded access token found in OAuth context")
+
+            token_provider = await OAuthTokenProvider.create(
+                access_token_response=dbt_platform_context.decoded_access_token.access_token_response,
+                dbt_platform_url=dbt_platform_url,
+                context_manager=dbt_platform_context_manager,
+            )
+            self.token_provider = token_provider
+
+            # Only validate CLI settings here — platform settings were already
+            # checked at the top of get_credentials() and the OAuth flow has
+            # populated the remaining fields (host, env ids, account id).
+            # dbt_token stays None in the OAuth path since the OAuthTokenProvider
+            # supplies the token instead.
+            cli_errors = validate_dbt_cli_settings(self.settings)
+            if cli_errors:
+                raise ValueError(
+                    "Errors found in configuration:\n\n" + "\n".join(cli_errors)
+                )
+            self.authentication_method = AuthenticationMethod.OAUTH
+            self._log_settings()
+            return self.settings, self.token_provider
+        self.token_provider = StaticTokenProvider(token=self.settings.dbt_token)
+        validate_settings(self.settings)
+        self.authentication_method = AuthenticationMethod.ENV_VAR
+        self._log_settings()
+        return self.settings, self.token_provider

--- a/src/dbt_mcp/config/settings.py
+++ b/src/dbt_mcp/config/settings.py
@@ -1,44 +1,33 @@
 import logging
 import shutil
-import socket
-import time
-from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
-from authlib.integrations.requests_client import OAuth2Session
-from filelock import FileLock
 from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from dbt_mcp.config.dbt_project import DbtProjectYaml
 from dbt_mcp.config.dbt_yaml import try_read_yaml
-from dbt_mcp.config.headers import (
-    TokenProvider,
-)
-from dbt_mcp.oauth.client_id import OAUTH_CLIENT_ID
-from dbt_mcp.oauth.context_manager import DbtPlatformContextManager
-from dbt_mcp.oauth.dbt_platform import (
-    DbtPlatformContext,
-    dbt_platform_context_from_token_response,
-)
-from dbt_mcp.oauth.login import login
-from dbt_mcp.oauth.token_provider import (
-    OAuthTokenProvider,
-    StaticTokenProvider,
-)
 from dbt_mcp.tools.tool_names import ToolName
+
+# Re-exports for backward compatibility — existing code imports these from settings.
+from dbt_mcp.config.credentials import (  # noqa: F401
+    AuthenticationMethod,
+    CredentialsProvider,
+    get_dbt_host,
+    get_dbt_platform_context,
+    get_dbt_profiles_path,
+    _find_available_port,
+    _is_context_complete,
+    _is_token_valid,
+    _try_refresh_token,
+)
+from dbt_mcp.config.credentials import OAUTH_REDIRECT_STARTING_PORT  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
-OAUTH_REDIRECT_STARTING_PORT = 6785
 DEFAULT_DBT_CLI_TIMEOUT = 60
-
-
-class AuthenticationMethod(Enum):
-    OAUTH = "oauth"
-    ENV_VAR = "env_var"
 
 
 class DbtMcpLogSettings(BaseSettings):
@@ -344,147 +333,6 @@ def _parse_tool_list(env_var: str | None, field_name: str) -> list[ToolName] | N
     return tool_names
 
 
-def _find_available_port(*, start_port: int, max_attempts: int = 20) -> int:
-    """
-    Return the first available port on 127.0.0.1 starting at start_port.
-
-    Raises RuntimeError if no port is found within the attempted range.
-    """
-    for candidate_port in range(start_port, start_port + max_attempts):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            try:
-                sock.bind(("127.0.0.1", candidate_port))
-            except OSError:
-                continue
-            return candidate_port
-    raise RuntimeError(
-        "No available port found starting at "
-        f"{start_port} after {max_attempts} attempts."
-    )
-
-
-def get_dbt_profiles_path(dbt_profiles_dir: str | None = None) -> Path:
-    # Respect DBT_PROFILES_DIR if set; otherwise default to ~/.dbt/mcp.yml
-    if dbt_profiles_dir:
-        return Path(dbt_profiles_dir).expanduser()
-    else:
-        return Path.home() / ".dbt"
-
-
-def _is_context_complete(dbt_ctx: DbtPlatformContext | None) -> bool:
-    """Check if the context has all required fields (regardless of token expiry).
-
-    Note: dev_environment is optional since not all projects have a development
-    environment configured. prod_environment is required for semantic layer
-    and other core features.
-    """
-    return bool(
-        dbt_ctx
-        and dbt_ctx.account_id
-        and dbt_ctx.host_prefix
-        and dbt_ctx.prod_environment
-        and dbt_ctx.decoded_access_token
-    )
-
-
-def _is_token_valid(dbt_ctx: DbtPlatformContext) -> bool:
-    """Check if the access token is still valid (not expired)."""
-    if not dbt_ctx.decoded_access_token:
-        return False
-    expires_at = dbt_ctx.decoded_access_token.access_token_response.expires_at
-    return expires_at > time.time() + 120  # 2 minutes buffer
-
-
-def _try_refresh_token(
-    dbt_ctx: DbtPlatformContext,
-    dbt_platform_url: str,
-    dbt_platform_context_manager: DbtPlatformContextManager,
-) -> DbtPlatformContext | None:
-    """
-    Attempt to refresh the access token using the refresh token.
-    Returns the updated context if successful, None otherwise.
-    """
-    if not dbt_ctx.decoded_access_token:
-        return None
-
-    refresh_token = dbt_ctx.decoded_access_token.access_token_response.refresh_token
-    if not refresh_token:
-        return None
-
-    try:
-        logger.info("Access token expired, attempting refresh using refresh token")
-        token_url = f"{dbt_platform_url}/oauth/token"
-        oauth_client = OAuth2Session(
-            client_id=OAUTH_CLIENT_ID,
-            token_endpoint=token_url,
-        )
-        token_response = oauth_client.refresh_token(
-            url=token_url,
-            refresh_token=refresh_token,
-        )
-        new_context = dbt_platform_context_from_token_response(
-            token_response, dbt_platform_url
-        )
-        # Merge the new token with the existing context (preserves account/env info)
-        updated_context = dbt_ctx.override(new_context)
-        dbt_platform_context_manager.write_context_to_file(updated_context)
-        logger.info("Successfully refreshed access token at startup")
-        return updated_context
-    except Exception as e:
-        logger.warning(f"Failed to refresh token at startup: {e}")
-        return None
-
-
-async def get_dbt_platform_context(
-    *,
-    dbt_user_dir: Path,
-    dbt_platform_url: str,
-    dbt_platform_context_manager: DbtPlatformContextManager,
-) -> DbtPlatformContext:
-    # Some MCP hosts (Claude Desktop) tend to run multiple MCP servers instances.
-    # We need to lock so that only one can run the oauth flow.
-    with FileLock(dbt_user_dir / "mcp.lock"):
-        dbt_ctx = dbt_platform_context_manager.read_context()
-
-        # If context is complete, check token validity
-        if _is_context_complete(dbt_ctx):
-            assert dbt_ctx is not None  # for type checker
-            # If token is still valid, use context directly
-            if _is_token_valid(dbt_ctx):
-                return dbt_ctx
-            # Token expired, try to refresh
-            refreshed_ctx = _try_refresh_token(
-                dbt_ctx, dbt_platform_url, dbt_platform_context_manager
-            )
-            if refreshed_ctx:
-                return refreshed_ctx
-
-        # Fall back to full OAuth login flow
-        selected_port = _find_available_port(start_port=OAUTH_REDIRECT_STARTING_PORT)
-        return await login(
-            dbt_platform_url=dbt_platform_url,
-            port=selected_port,
-            dbt_platform_context_manager=dbt_platform_context_manager,
-        )
-
-
-def get_dbt_host(
-    settings: DbtMcpSettings, dbt_platform_context: DbtPlatformContext
-) -> str:
-    actual_host = settings.actual_host
-    if not actual_host:
-        raise ValueError("DBT_HOST is a required environment variable")
-    host_prefix_with_period = f"{dbt_platform_context.host_prefix}."
-    if not actual_host.startswith(host_prefix_with_period):
-        raise ValueError(
-            f"The DBT_HOST environment variable is expected to start with the {dbt_platform_context.host_prefix} custom subdomain."
-        )
-    # We have to remove the custom subdomain prefix
-    # so that the metadata and semantic-layer URLs can be constructed correctly.
-    return actual_host.removeprefix(host_prefix_with_period)
-
-
 def validate_settings(settings: DbtMcpSettings) -> None:
     errors: list[str] = []
     errors.extend(validate_dbt_platform_settings(settings))
@@ -561,79 +409,3 @@ def validate_dbt_cli_settings(settings: DbtMcpSettings) -> list[str]:
                     f"DBT_PATH executable can't be found: {settings.dbt_path}"
                 )
     return errors
-
-
-class CredentialsProvider:
-    def __init__(self, settings: DbtMcpSettings):
-        self.settings = settings
-        self.token_provider: TokenProvider | None = None
-        self.authentication_method: AuthenticationMethod | None = None
-
-    def _log_settings(self) -> None:
-        settings = self.settings.model_dump()
-        if settings.get("dbt_token") is not None:
-            settings["dbt_token"] = "***redacted***"
-        logger.info(f"Settings: {settings}")
-
-    async def get_credentials(self) -> tuple[DbtMcpSettings, TokenProvider]:
-        if self.token_provider is not None:
-            # If token provider is already set, just return the cached values
-            return self.settings, self.token_provider
-        # Load settings from environment variables using pydantic_settings
-        dbt_platform_errors = validate_dbt_platform_settings(self.settings)
-        if dbt_platform_errors:
-            dbt_user_dir = get_dbt_profiles_path(
-                dbt_profiles_dir=self.settings.dbt_profiles_dir
-            )
-            config_location = dbt_user_dir / "mcp.yml"
-            dbt_platform_url = f"https://{self.settings.actual_host}"
-            dbt_platform_context_manager = DbtPlatformContextManager(config_location)
-            dbt_platform_context = await get_dbt_platform_context(
-                dbt_platform_context_manager=dbt_platform_context_manager,
-                dbt_user_dir=dbt_user_dir,
-                dbt_platform_url=dbt_platform_url,
-            )
-
-            # Override settings with settings attained from login or mcp.yml
-            self.settings.dbt_user_id = dbt_platform_context.user_id
-            self.settings.dbt_dev_env_id = (
-                dbt_platform_context.dev_environment.id
-                if dbt_platform_context.dev_environment
-                else None
-            )
-            self.settings.dbt_prod_env_id = (
-                dbt_platform_context.prod_environment.id
-                if dbt_platform_context.prod_environment
-                else None
-            )
-            self.settings.dbt_account_id = dbt_platform_context.account_id
-            self.settings.host_prefix = dbt_platform_context.host_prefix
-            self.settings.dbt_host = get_dbt_host(self.settings, dbt_platform_context)
-            if not dbt_platform_context.decoded_access_token:
-                raise ValueError("No decoded access token found in OAuth context")
-
-            token_provider = await OAuthTokenProvider.create(
-                access_token_response=dbt_platform_context.decoded_access_token.access_token_response,
-                dbt_platform_url=dbt_platform_url,
-                context_manager=dbt_platform_context_manager,
-            )
-            self.token_provider = token_provider
-
-            # Only validate CLI settings here — platform settings were already
-            # checked at the top of get_credentials() and the OAuth flow has
-            # populated the remaining fields (host, env ids, account id).
-            # dbt_token stays None in the OAuth path since the OAuthTokenProvider
-            # supplies the token instead.
-            cli_errors = validate_dbt_cli_settings(self.settings)
-            if cli_errors:
-                raise ValueError(
-                    "Errors found in configuration:\n\n" + "\n".join(cli_errors)
-                )
-            self.authentication_method = AuthenticationMethod.OAUTH
-            self._log_settings()
-            return self.settings, self.token_provider
-        self.token_provider = StaticTokenProvider(token=self.settings.dbt_token)
-        validate_settings(self.settings)
-        self.authentication_method = AuthenticationMethod.ENV_VAR
-        self._log_settings()
-        return self.settings, self.token_provider

--- a/src/dbt_mcp/oauth/expiry.py
+++ b/src/dbt_mcp/oauth/expiry.py
@@ -1,0 +1,7 @@
+# How far before expiry each layer triggers a refresh.
+# Background > Startup > Inline so that background refresh handles most cases,
+# startup catches tokens that expired while the process was down, and
+# inline is the last-resort safety net.
+BACKGROUND_REFRESH_BUFFER_SECONDS = 300
+STARTUP_EXPIRY_BUFFER_SECONDS = 120
+INLINE_REFRESH_BUFFER_SECONDS = 30

--- a/src/dbt_mcp/oauth/refresh.py
+++ b/src/dbt_mcp/oauth/refresh.py
@@ -1,0 +1,33 @@
+import logging
+
+from authlib.integrations.requests_client import OAuth2Session
+
+from dbt_mcp.oauth.client_id import OAUTH_CLIENT_ID
+from dbt_mcp.oauth.dbt_platform import (
+    DbtPlatformContext,
+    dbt_platform_context_from_token_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_oauth_token(
+    *,
+    refresh_token: str,
+    token_url: str,
+    dbt_platform_url: str,
+) -> DbtPlatformContext:
+    """Perform an OAuth token refresh and return the new context.
+
+    This is the single implementation used by both the startup refresh
+    path and the OAuthTokenProvider's inline/background refresh.
+    """
+    oauth_client = OAuth2Session(
+        client_id=OAUTH_CLIENT_ID,
+        token_endpoint=token_url,
+    )
+    token_response = oauth_client.refresh_token(
+        url=token_url,
+        refresh_token=refresh_token,
+    )
+    return dbt_platform_context_from_token_response(token_response, dbt_platform_url)

--- a/src/dbt_mcp/oauth/refresh_strategy.py
+++ b/src/dbt_mcp/oauth/refresh_strategy.py
@@ -2,6 +2,8 @@ import asyncio
 import time
 from typing import Protocol
 
+from dbt_mcp.oauth.expiry import BACKGROUND_REFRESH_BUFFER_SECONDS
+
 
 class RefreshStrategy(Protocol):
     """Protocol for handling token refresh timing and waiting."""
@@ -25,7 +27,11 @@ class RefreshStrategy(Protocol):
 class DefaultRefreshStrategy:
     """Default strategy that refreshes tokens with a buffer before expiry."""
 
-    def __init__(self, buffer_seconds: int = 300, error_retry_delay: float = 5.0):
+    def __init__(
+        self,
+        buffer_seconds: int = BACKGROUND_REFRESH_BUFFER_SECONDS,
+        error_retry_delay: float = 5.0,
+    ):
         """
         Initialize with timing configuration.
 

--- a/src/dbt_mcp/oauth/token.py
+++ b/src/dbt_mcp/oauth/token.py
@@ -19,11 +19,25 @@ class DecodedAccessToken(BaseModel):
     decoded_claims: dict[str, Any]
 
 
+_jwks_clients: dict[str, PyJWKClient] = {}
+
+
+def _get_jwks_client(jwks_url: str) -> PyJWKClient:
+    if jwks_url not in _jwks_clients:
+        _jwks_clients[jwks_url] = PyJWKClient(jwks_url)
+    return _jwks_clients[jwks_url]
+
+
+def _clear_jwks_cache() -> None:
+    """Clear the cached JWKS clients. Intended for test teardown."""
+    _jwks_clients.clear()
+
+
 def fetch_jwks_and_verify_token(
     access_token: str, dbt_platform_url: str
 ) -> dict[str, Any]:
     jwks_url = f"{dbt_platform_url}/.well-known/jwks.json"
-    jwks_client = PyJWKClient(jwks_url)
+    jwks_client = _get_jwks_client(jwks_url)
     signing_key = jwks_client.get_signing_key_from_jwt(access_token)
     claims = jwt.decode(
         access_token,

--- a/src/dbt_mcp/oauth/token_provider.py
+++ b/src/dbt_mcp/oauth/token_provider.py
@@ -3,19 +3,16 @@ import logging
 import time
 from typing import Protocol
 
-from authlib.integrations.requests_client import OAuth2Session
-
-from dbt_mcp.oauth.client_id import OAUTH_CLIENT_ID
 from dbt_mcp.oauth.context_manager import DbtPlatformContextManager
-from dbt_mcp.oauth.dbt_platform import dbt_platform_context_from_token_response
+from dbt_mcp.oauth.expiry import INLINE_REFRESH_BUFFER_SECONDS
+from dbt_mcp.oauth.refresh import refresh_oauth_token
 from dbt_mcp.oauth.refresh_strategy import DefaultRefreshStrategy, RefreshStrategy
 from dbt_mcp.oauth.token import AccessTokenResponse
 
 logger = logging.getLogger(__name__)
 
-# Buffer in seconds before expiry at which get_token() considers the token expired
-# and triggers an inline refresh.
-TOKEN_EXPIRY_BUFFER_SECONDS = 30
+# Re-export for backward compatibility with tests that import this name.
+TOKEN_EXPIRY_BUFFER_SECONDS = INLINE_REFRESH_BUFFER_SECONDS
 
 
 class TokenProvider(Protocol):
@@ -47,10 +44,6 @@ class OAuthTokenProvider:
         self.dbt_platform_url = dbt_platform_url
         self.refresh_strategy = refresh_strategy or DefaultRefreshStrategy()
         self.token_url = f"{self.dbt_platform_url}/oauth/token"
-        self.oauth_client = OAuth2Session(
-            client_id=OAUTH_CLIENT_ID,
-            token_endpoint=self.token_url,
-        )
 
     @classmethod
     async def create(
@@ -70,12 +63,6 @@ class OAuthTokenProvider:
         provider.start_background_refresh()
         return provider
 
-    def _get_access_token_response(self) -> AccessTokenResponse:
-        dbt_platform_context = self.context_manager.read_context()
-        if not dbt_platform_context or not dbt_platform_context.decoded_access_token:
-            raise ValueError("No decoded access token found in context")
-        return dbt_platform_context.decoded_access_token.access_token_response
-
     def _is_token_expired(self) -> bool:
         """Check whether the current access token is expired or about to expire."""
         return (
@@ -87,16 +74,13 @@ class OAuthTokenProvider:
         """Refresh the OAuth access token using the refresh token.
 
         Used by both the background worker and the inline safety-net in
-        ``get_token()``.  All operations (authlib's ``refresh_token``, context
-        persistence) are synchronous, so a plain ``def`` is sufficient.
+        ``get_token()``.
         """
         logger.info("Refreshing OAuth access token")
-        token_response = self.oauth_client.refresh_token(
-            url=self.token_url,
+        dbt_platform_context = refresh_oauth_token(
             refresh_token=self.access_token_response.refresh_token,
-        )
-        dbt_platform_context = dbt_platform_context_from_token_response(
-            token_response, self.dbt_platform_url
+            token_url=self.token_url,
+            dbt_platform_url=self.dbt_platform_url,
         )
         self.context_manager.update_context(dbt_platform_context)
         if not dbt_platform_context.decoded_access_token:

--- a/tests/unit/oauth/test_credentials_provider.py
+++ b/tests/unit/oauth/test_credentials_provider.py
@@ -37,13 +37,13 @@ class TestCredentialsProviderAuthenticationMethod:
 
         with (
             patch(
-                "dbt_mcp.config.settings.get_dbt_platform_context",
+                "dbt_mcp.config.credentials.get_dbt_platform_context",
                 return_value=mock_dbt_context,
             ),
             patch(
-                "dbt_mcp.config.settings.get_dbt_host", return_value="cloud.getdbt.com"
+                "dbt_mcp.config.credentials.get_dbt_host", return_value="cloud.getdbt.com"
             ),
-            patch("dbt_mcp.config.settings.OAuthTokenProvider") as mock_token_provider,
+            patch("dbt_mcp.config.credentials.OAuthTokenProvider") as mock_token_provider,
             patch("dbt_mcp.config.settings.validate_dbt_cli_settings", return_value=[]),
         ):
             mock_provider_instance = MagicMock()
@@ -141,13 +141,13 @@ class TestCredentialsProviderOAuthDoesNotSetDbtToken:
 
         with (
             patch(
-                "dbt_mcp.config.settings.get_dbt_platform_context",
+                "dbt_mcp.config.credentials.get_dbt_platform_context",
                 return_value=mock_dbt_context,
             ),
             patch(
-                "dbt_mcp.config.settings.get_dbt_host", return_value="cloud.getdbt.com"
+                "dbt_mcp.config.credentials.get_dbt_host", return_value="cloud.getdbt.com"
             ),
-            patch("dbt_mcp.config.settings.OAuthTokenProvider") as mock_tp_cls,
+            patch("dbt_mcp.config.credentials.OAuthTokenProvider") as mock_tp_cls,
             patch("dbt_mcp.config.settings.validate_dbt_cli_settings", return_value=[]),
         ):
             mock_tp_cls.create = AsyncMock(return_value=MagicMock())
@@ -181,13 +181,13 @@ class TestCredentialsProviderOAuthDoesNotSetDbtToken:
 
         with (
             patch(
-                "dbt_mcp.config.settings.get_dbt_platform_context",
+                "dbt_mcp.config.credentials.get_dbt_platform_context",
                 return_value=mock_dbt_context,
             ),
             patch(
-                "dbt_mcp.config.settings.get_dbt_host", return_value="cloud.getdbt.com"
+                "dbt_mcp.config.credentials.get_dbt_host", return_value="cloud.getdbt.com"
             ),
-            patch("dbt_mcp.config.settings.OAuthTokenProvider") as mock_tp_cls,
+            patch("dbt_mcp.config.credentials.OAuthTokenProvider") as mock_tp_cls,
             patch("dbt_mcp.config.settings.validate_dbt_cli_settings", return_value=[]),
         ):
             mock_provider_instance = MagicMock()
@@ -225,13 +225,13 @@ class TestCredentialsProviderOAuthDoesNotSetDbtToken:
 
         with (
             patch(
-                "dbt_mcp.config.settings.get_dbt_platform_context",
+                "dbt_mcp.config.credentials.get_dbt_platform_context",
                 return_value=mock_dbt_context,
             ),
             patch(
-                "dbt_mcp.config.settings.get_dbt_host", return_value="cloud.getdbt.com"
+                "dbt_mcp.config.credentials.get_dbt_host", return_value="cloud.getdbt.com"
             ),
-            patch("dbt_mcp.config.settings.OAuthTokenProvider") as mock_tp_cls,
+            patch("dbt_mcp.config.credentials.OAuthTokenProvider") as mock_tp_cls,
             patch("dbt_mcp.config.settings.validate_settings") as mock_validate,
             patch("dbt_mcp.config.settings.validate_dbt_cli_settings", return_value=[]),
         ):

--- a/tests/unit/oauth/test_refresh.py
+++ b/tests/unit/oauth/test_refresh.py
@@ -1,0 +1,72 @@
+"""Tests for the shared refresh_oauth_token function."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dbt_mcp.oauth.dbt_platform import DbtPlatformContext
+from dbt_mcp.oauth.refresh import refresh_oauth_token
+from dbt_mcp.oauth.token import AccessTokenResponse, DecodedAccessToken
+
+
+def _mock_token_response(*, expires_at: int | None = None) -> dict:
+    return {
+        "access_token": "new_access_token",
+        "refresh_token": "new_refresh_token",
+        "expires_in": 3600,
+        "scope": "user_access offline_access",
+        "token_type": "Bearer",
+        "expires_at": expires_at or int(time.time()) + 3600,
+    }
+
+
+class TestRefreshOauthToken:
+    def test_returns_context_on_success(self):
+        """Successful refresh returns a DbtPlatformContext with a decoded token."""
+        mock_response = _mock_token_response()
+        expected_context = DbtPlatformContext(
+            decoded_access_token=DecodedAccessToken(
+                access_token_response=AccessTokenResponse(**mock_response),
+                decoded_claims={"sub": "123"},
+            )
+        )
+
+        with (
+            patch("dbt_mcp.oauth.refresh.OAuth2Session") as mock_session_cls,
+            patch(
+                "dbt_mcp.oauth.refresh.dbt_platform_context_from_token_response"
+            ) as mock_from_token,
+        ):
+            mock_session = MagicMock()
+            mock_session.refresh_token.return_value = mock_response
+            mock_session_cls.return_value = mock_session
+
+            mock_from_token.return_value = expected_context
+
+            result = refresh_oauth_token(
+                refresh_token="old_refresh",
+                token_url="https://cloud.getdbt.com/oauth/token",
+                dbt_platform_url="https://cloud.getdbt.com",
+            )
+
+        assert result == expected_context
+        mock_session.refresh_token.assert_called_once_with(
+            url="https://cloud.getdbt.com/oauth/token",
+            refresh_token="old_refresh",
+        )
+        mock_from_token.assert_called_once_with(mock_response, "https://cloud.getdbt.com")
+
+    def test_propagates_exceptions(self):
+        """Network or auth errors propagate without being swallowed."""
+        with patch("dbt_mcp.oauth.refresh.OAuth2Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session.refresh_token.side_effect = Exception("network error")
+            mock_session_cls.return_value = mock_session
+
+            with pytest.raises(Exception, match="network error"):
+                refresh_oauth_token(
+                    refresh_token="old_refresh",
+                    token_url="https://cloud.getdbt.com/oauth/token",
+                    dbt_platform_url="https://cloud.getdbt.com",
+                )

--- a/tests/unit/oauth/test_token.py
+++ b/tests/unit/oauth/test_token.py
@@ -1,11 +1,18 @@
 """
-Tests for OAuth token models.
+Tests for OAuth token models and JWKS verification.
 """
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
-from dbt_mcp.oauth.token import AccessTokenResponse, DecodedAccessToken
+from dbt_mcp.oauth.token import (
+    AccessTokenResponse,
+    DecodedAccessToken,
+    _clear_jwks_cache,
+    fetch_jwks_and_verify_token,
+)
 
 
 class TestAccessTokenResponse:
@@ -221,3 +228,40 @@ class TestDecodedAccessToken:
             decoded_token.decoded_claims["metadata"]["created_at"]
             == "2021-01-01T00:00:00Z"
         )
+
+
+class TestFetchJwksAndVerifyTokenCaching:
+    """JWKS client should be cached per platform URL to avoid redundant HTTP fetches."""
+
+    def setup_method(self):
+        _clear_jwks_cache()
+
+    def teardown_method(self):
+        _clear_jwks_cache()
+
+    @patch("dbt_mcp.oauth.token.jwt.decode", return_value={"sub": "123"})
+    @patch("dbt_mcp.oauth.token.PyJWKClient")
+    def test_jwks_client_reused_across_calls(self, mock_client_cls, _mock_decode):
+        """Same platform URL should reuse the PyJWKClient instance."""
+        mock_instance = MagicMock()
+        mock_client_cls.return_value = mock_instance
+        mock_instance.get_signing_key_from_jwt.return_value = MagicMock(key="key")
+
+        fetch_jwks_and_verify_token("token1", "https://cloud.getdbt.com")
+        fetch_jwks_and_verify_token("token2", "https://cloud.getdbt.com")
+
+        # PyJWKClient should only be constructed once for the same URL
+        assert mock_client_cls.call_count == 1
+
+    @patch("dbt_mcp.oauth.token.jwt.decode", return_value={"sub": "123"})
+    @patch("dbt_mcp.oauth.token.PyJWKClient")
+    def test_different_urls_get_different_clients(self, mock_client_cls, _mock_decode):
+        """Different platform URLs should get separate cached clients."""
+        mock_instance = MagicMock()
+        mock_client_cls.return_value = mock_instance
+        mock_instance.get_signing_key_from_jwt.return_value = MagicMock(key="key")
+
+        fetch_jwks_and_verify_token("token1", "https://cloud.getdbt.com")
+        fetch_jwks_and_verify_token("token2", "https://emea.dbt.com")
+
+        assert mock_client_cls.call_count == 2

--- a/tests/unit/oauth/test_token_provider.py
+++ b/tests/unit/oauth/test_token_provider.py
@@ -74,31 +74,24 @@ class TestGetTokenValidatesExpiry:
         mock_context = MagicMock()
         mock_context.decoded_access_token.access_token_response = new_token_response
 
-        with patch.object(provider, "oauth_client") as mock_client:
-            mock_client.refresh_token.return_value = {
-                "access_token": "fresh",
-                "refresh_token": "new_refresh",
-                "expires_in": 3600,
-                "scope": "user_access offline_access",
-                "token_type": "Bearer",
-                "expires_at": int(time.time()) + 3600,
-            }
-            with patch(
-                "dbt_mcp.oauth.token_provider.dbt_platform_context_from_token_response"
-            ) as mock_from_token:
-                mock_from_token.return_value = mock_context
-                token = provider.get_token()
+        with patch(
+            "dbt_mcp.oauth.token_provider.refresh_oauth_token"
+        ) as mock_refresh:
+            mock_refresh.return_value = mock_context
+            token = provider.get_token()
 
         assert token == "fresh"
-        mock_client.refresh_token.assert_called_once()
+        mock_refresh.assert_called_once()
 
     def test_raises_when_refresh_fails(self):
         """If inline refresh fails, a clear error is raised (not a stale token)."""
         expired_at = int(time.time()) - 100
         provider = _make_provider(expires_at=expired_at, access_token="stale")
 
-        with patch.object(provider, "oauth_client") as mock_client:
-            mock_client.refresh_token.side_effect = Exception("network error")
+        with patch(
+            "dbt_mcp.oauth.token_provider.refresh_oauth_token"
+        ) as mock_refresh:
+            mock_refresh.side_effect = Exception("network error")
             with pytest.raises(ValueError, match="expired and inline refresh failed"):
                 provider.get_token()
 
@@ -113,13 +106,11 @@ class TestGetTokenValidatesExpiry:
         mock_context = MagicMock()
         mock_context.decoded_access_token.access_token_response = new_token_response
 
-        with patch.object(provider, "oauth_client") as mock_client:
-            mock_client.refresh_token.return_value = {}
-            with patch(
-                "dbt_mcp.oauth.token_provider.dbt_platform_context_from_token_response"
-            ) as mock_from_token:
-                mock_from_token.return_value = mock_context
-                token = provider.get_token()
+        with patch(
+            "dbt_mcp.oauth.token_provider.refresh_oauth_token"
+        ) as mock_refresh:
+            mock_refresh.return_value = mock_context
+            token = provider.get_token()
 
         assert token == "fresh"
 

--- a/tests/unit/oauth/test_token_refresh_at_startup.py
+++ b/tests/unit/oauth/test_token_refresh_at_startup.py
@@ -142,9 +142,9 @@ class TestTryRefreshToken:
         }
 
         with (
-            patch("dbt_mcp.config.settings.OAuth2Session") as mock_oauth_session_class,
+            patch("dbt_mcp.oauth.refresh.OAuth2Session") as mock_oauth_session_class,
             patch(
-                "dbt_mcp.config.settings.dbt_platform_context_from_token_response"
+                "dbt_mcp.oauth.refresh.dbt_platform_context_from_token_response"
             ) as mock_from_token,
         ):
             mock_oauth_session = MagicMock()
@@ -168,7 +168,7 @@ class TestTryRefreshToken:
         ctx = _create_mock_context(expires_at=int(time.time()) - 3600)
         mock_context_manager = MagicMock()
 
-        with patch("dbt_mcp.config.settings.OAuth2Session") as mock_oauth_session_class:
+        with patch("dbt_mcp.oauth.refresh.OAuth2Session") as mock_oauth_session_class:
             mock_oauth_session = MagicMock()
             mock_oauth_session.refresh_token.side_effect = Exception("Network error")
             mock_oauth_session_class.return_value = mock_oauth_session


### PR DESCRIPTION
## Why

The OAuth code had duplicate token refresh implementations, scattered magic numbers for expiry buffers, a new `PyJWKClient` created on every token verification, and a 600+ line `settings.py` mixing configuration with auth orchestration. This made the code harder to follow and maintain.

## What

1. **Delete dead code** — removed unused `_get_access_token_response()` from `OAuthTokenProvider`
2. **Unify expiry constants** — created `oauth/expiry.py` with three named constants (`BACKGROUND_REFRESH_BUFFER_SECONDS=300`, `STARTUP_EXPIRY_BUFFER_SECONDS=120`, `INLINE_REFRESH_BUFFER_SECONDS=30`) replacing scattered magic numbers
3. **Consolidate refresh logic** — created `oauth/refresh.py` with a single `refresh_oauth_token()` function used by both the startup path (`_try_refresh_token`) and runtime path (`OAuthTokenProvider._refresh_token`)
4. **Add JWKS caching** — `PyJWKClient` instances are now cached per platform URL, avoiding redundant HTTP fetches to `/.well-known/jwks.json` on every token refresh
5. **Extract `credentials.py`** — moved `CredentialsProvider`, `AuthenticationMethod`, `get_dbt_platform_context`, and related helpers from `settings.py` into `config/credentials.py`. Re-exports in `settings.py` maintain backward compatibility

All changes are behavior-preserving refactors. No public API changes.

## Test plan

- [x] All 455 unit tests pass
- [x] ruff and mypy clean on all modified files
- [x] New tests for `refresh_oauth_token()` (2 tests) and JWKS caching (2 tests)
- [x] Existing test patch targets updated for new module locations

Drafted by Claude Opus 4.6 under the direction of @DevonFulcher