### PR TITLE
feat: migrate requests to httpx async for project resolvers

### DIFF
--- a/.changes/unreleased/Under the Hood-20260317-123544.yaml
+++ b/.changes/unreleased/Under the Hood-20260317-123544.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Migrate HTTP client from requests to httpx.AsyncClient for project and environment resolvers
+time: 2026-03-17T12:35:44.636156-05:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
   "pydantic-settings~=2.10.1",
   "pyjwt~=2.12.0",
   "pyyaml~=6.0.2",
-  "requests~=2.32.4",
   "httpx~=0.28.1",
   "filelock~=3.20.3",
   "starlette~=0.50.0",
@@ -49,7 +48,6 @@ dependencies = [
 [dependency-groups]
 dev = [
   "ruff>=0.11.2",
-  "types-requests>=2.32.0.20250328",
   "mypy>=1.12.1",
   "pre-commit>=4.2.0",
   "pytest-asyncio>=0.26.0",

--- a/src/dbt_mcp/oauth/fastapi_app.py
+++ b/src/dbt_mcp/oauth/fastapi_app.py
@@ -2,7 +2,7 @@ import logging
 from typing import cast
 from urllib.parse import quote
 
-import requests
+import httpx
 from authlib.integrations.requests_client import OAuth2Session
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
@@ -56,22 +56,22 @@ class NoCacheStaticFiles(StaticFiles):
         await super().__call__(scope, receive, send_wrapper)
 
 
-def _get_all_accounts(
+async def _get_all_accounts(
     *,
     dbt_platform_url: str,
     headers: dict[str, str],
 ) -> list[DbtPlatformAccount]:
-    accounts_response = requests.get(
-        url=f"{dbt_platform_url}/api/v3/accounts/",
-        headers=headers,
-    )
-    accounts_response.raise_for_status()
-    return [
-        DbtPlatformAccount(**account) for account in accounts_response.json()["data"]
-    ]
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            url=f"{dbt_platform_url}/api/v3/accounts/",
+            headers=headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+    return [DbtPlatformAccount(**account) for account in data["data"]]
 
 
-def _get_all_projects_for_account(
+async def _get_all_projects_for_account(
     *,
     dbt_platform_url: str,
     account: DbtPlatformAccount,
@@ -81,23 +81,25 @@ def _get_all_projects_for_account(
     """Fetch all projects for an account using offset/page_size pagination."""
     offset = 0
     projects: list[DbtPlatformProject] = []
-    while True:
-        projects_response = requests.get(
-            f"{dbt_platform_url}/api/v3/accounts/{account.id}/projects/?state=1&offset={offset}&limit={page_size}",
-            headers=headers,
-        )
-        projects_response.raise_for_status()
-        page = projects_response.json()["data"]
-        projects.extend(
-            DbtPlatformProject(**project, account_name=account.name) for project in page
-        )
-        if len(page) < page_size:
-            break
-        offset += page_size
+    async with httpx.AsyncClient() as client:
+        while True:
+            response = await client.get(
+                f"{dbt_platform_url}/api/v3/accounts/{account.id}/projects/?state=1&offset={offset}&limit={page_size}",
+                headers=headers,
+            )
+            response.raise_for_status()
+            page = response.json()["data"]
+            projects.extend(
+                DbtPlatformProject(**project, account_name=account.name)
+                for project in page
+            )
+            if len(page) < page_size:
+                break
+            offset += page_size
     return projects
 
 
-def _get_all_environments_for_project(
+async def _get_all_environments_for_project(
     *,
     dbt_platform_url: str,
     account_id: int,
@@ -108,19 +110,20 @@ def _get_all_environments_for_project(
     """Fetch all environments for a project using offset/page_size pagination."""
     offset = 0
     environments: list[DbtPlatformEnvironmentResponse] = []
-    while True:
-        environments_response = requests.get(
-            f"{dbt_platform_url}/api/v3/accounts/{account_id}/projects/{project_id}/environments/?state=1&offset={offset}&limit={page_size}",
-            headers=headers,
-        )
-        environments_response.raise_for_status()
-        page = environments_response.json()["data"]
-        environments.extend(
-            DbtPlatformEnvironmentResponse(**environment) for environment in page
-        )
-        if len(page) < page_size:
-            break
-        offset += page_size
+    async with httpx.AsyncClient() as client:
+        while True:
+            response = await client.get(
+                f"{dbt_platform_url}/api/v3/accounts/{account_id}/projects/{project_id}/environments/?state=1&offset={offset}&limit={page_size}",
+                headers=headers,
+            )
+            response.raise_for_status()
+            page = response.json()["data"]
+            environments.extend(
+                DbtPlatformEnvironmentResponse(**environment) for environment in page
+            )
+            if len(page) < page_size:
+                break
+            offset += page_size
     return environments
 
 
@@ -195,7 +198,7 @@ def create_app(
         return {"ok": True}
 
     @app.get("/projects")
-    def projects() -> list[DbtPlatformProject]:
+    async def projects() -> list[DbtPlatformProject]:
         if app.state.decoded_access_token is None:
             raise RuntimeError("Access token missing; OAuth flow not completed")
         access_token = app.state.decoded_access_token.access_token_response.access_token
@@ -203,14 +206,14 @@ def create_app(
             "Accept": "application/json",
             "Authorization": f"Bearer {access_token}",
         }
-        accounts = _get_all_accounts(
+        accounts = await _get_all_accounts(
             dbt_platform_url=dbt_platform_url,
             headers=headers,
         )
         projects: list[DbtPlatformProject] = []
         for account in [a for a in accounts if a.state == 1 and not a.locked]:
             projects.extend(
-                _get_all_projects_for_account(
+                await _get_all_projects_for_account(
                     dbt_platform_url=dbt_platform_url,
                     account=account,
                     headers=headers,
@@ -224,7 +227,7 @@ def create_app(
         return dbt_platform_context_manager.read_context() or DbtPlatformContext()
 
     @app.post("/environments")
-    def get_deployment_environments(
+    async def get_deployment_environments(
         request: GetEnvironmentsRequest,
     ) -> list[DbtPlatformEnvironmentResponse]:
         """Get all deployment environments for a project, excluding development environments."""
@@ -236,7 +239,7 @@ def create_app(
             "Accept": "application/json",
             "Authorization": f"Bearer {access_token}",
         }
-        environments = _get_all_environments_for_project(
+        environments = await _get_all_environments_for_project(
             dbt_platform_url=dbt_platform_url,
             account_id=request.account_id,
             project_id=request.project_id,
@@ -251,7 +254,7 @@ def create_app(
         ]
 
     @app.post("/selected_project")
-    def set_selected_project(
+    async def set_selected_project(
         selected_project_request: SelectedProjectRequest,
     ) -> DbtPlatformContext:
         logger.info("Selected project received")
@@ -262,7 +265,7 @@ def create_app(
             "Accept": "application/json",
             "Authorization": f"Bearer {access_token}",
         }
-        accounts = _get_all_accounts(
+        accounts = await _get_all_accounts(
             dbt_platform_url=dbt_platform_url,
             headers=headers,
         )
@@ -271,7 +274,7 @@ def create_app(
         )
         if account is None:
             raise ValueError(f"Account {selected_project_request.account_id} not found")
-        environments = _get_all_environments_for_project(
+        environments = await _get_all_environments_for_project(
             dbt_platform_url=dbt_platform_url,
             account_id=selected_project_request.account_id,
             project_id=selected_project_request.project_id,

--- a/tests/unit/oauth/test_fastapi_app_pagination.py
+++ b/tests/unit/oauth/test_fastapi_app_pagination.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -26,34 +26,48 @@ def account():
     )
 
 
-@patch("dbt_mcp.oauth.fastapi_app.requests.get")
-def test_get_all_projects_for_account_paginates(mock_get: Mock, base_headers, account):
+def create_mock_response(data: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def create_mock_httpx_client(responses: list) -> AsyncMock:
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=responses)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+async def test_get_all_projects_for_account_paginates(base_headers, account):
     # Two pages: first full page (limit=2), second partial page (1 item) -> stop
-    first_page_resp = Mock()
-    first_page_resp.json.return_value = {
-        "data": [
-            {"id": 101, "name": "Proj A", "account_id": account.id},
-            {"id": 102, "name": "Proj B", "account_id": account.id},
-        ]
-    }
-    first_page_resp.raise_for_status.return_value = None
-
-    second_page_resp = Mock()
-    second_page_resp.json.return_value = {
-        "data": [
-            {"id": 103, "name": "Proj C", "account_id": account.id},
-        ]
-    }
-    second_page_resp.raise_for_status.return_value = None
-
-    mock_get.side_effect = [first_page_resp, second_page_resp]
-
-    result = _get_all_projects_for_account(
-        dbt_platform_url="https://cloud.getdbt.com",
-        account=account,
-        headers=base_headers,
-        page_size=2,
+    first_page_resp = create_mock_response(
+        {
+            "data": [
+                {"id": 101, "name": "Proj A", "account_id": account.id},
+                {"id": 102, "name": "Proj B", "account_id": account.id},
+            ]
+        }
     )
+    second_page_resp = create_mock_response(
+        {
+            "data": [
+                {"id": 103, "name": "Proj C", "account_id": account.id},
+            ]
+        }
+    )
+
+    mock_client = create_mock_httpx_client([first_page_resp, second_page_resp])
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await _get_all_projects_for_account(
+            dbt_platform_url="https://cloud.getdbt.com",
+            account=account,
+            headers=base_headers,
+            page_size=2,
+        )
 
     # Should aggregate 3 projects and include account_name field
     assert len(result) == 3
@@ -65,42 +79,38 @@ def test_get_all_projects_for_account_paginates(mock_get: Mock, base_headers, ac
         "https://cloud.getdbt.com/api/v3/accounts/1/projects/?state=1&offset=0&limit=2",
         "https://cloud.getdbt.com/api/v3/accounts/1/projects/?state=1&offset=2&limit=2",
     ]
-    actual_urls = [
-        call.kwargs["url"] if "url" in call.kwargs else call.args[0]
-        for call in mock_get.call_args_list
-    ]
+    actual_urls = [call.args[0] for call in mock_client.get.call_args_list]
     assert actual_urls == expected_urls
 
 
-@patch("dbt_mcp.oauth.fastapi_app.requests.get")
-def test_get_all_environments_for_project_paginates(mock_get: Mock, base_headers):
+async def test_get_all_environments_for_project_paginates(base_headers):
     # Two pages: first full page (limit=2), second partial (1 item)
-    first_page_resp = Mock()
-    first_page_resp.json.return_value = {
-        "data": [
-            {"id": 201, "name": "Dev", "deployment_type": "development"},
-            {"id": 202, "name": "Prod", "deployment_type": "production"},
-        ]
-    }
-    first_page_resp.raise_for_status.return_value = None
-
-    second_page_resp = Mock()
-    second_page_resp.json.return_value = {
-        "data": [
-            {"id": 203, "name": "Staging", "deployment_type": "development"},
-        ]
-    }
-    second_page_resp.raise_for_status.return_value = None
-
-    mock_get.side_effect = [first_page_resp, second_page_resp]
-
-    result = _get_all_environments_for_project(
-        dbt_platform_url="https://cloud.getdbt.com",
-        account_id=1,
-        project_id=9,
-        headers=base_headers,
-        page_size=2,
+    first_page_resp = create_mock_response(
+        {
+            "data": [
+                {"id": 201, "name": "Dev", "deployment_type": "development"},
+                {"id": 202, "name": "Prod", "deployment_type": "production"},
+            ]
+        }
     )
+    second_page_resp = create_mock_response(
+        {
+            "data": [
+                {"id": 203, "name": "Staging", "deployment_type": "development"},
+            ]
+        }
+    )
+
+    mock_client = create_mock_httpx_client([first_page_resp, second_page_resp])
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await _get_all_environments_for_project(
+            dbt_platform_url="https://cloud.getdbt.com",
+            account_id=1,
+            project_id=9,
+            headers=base_headers,
+            page_size=2,
+        )
 
     assert len(result) == 3
     assert {e.id for e in result} == {201, 202, 203}
@@ -109,8 +119,5 @@ def test_get_all_environments_for_project_paginates(mock_get: Mock, base_headers
         "https://cloud.getdbt.com/api/v3/accounts/1/projects/9/environments/?state=1&offset=0&limit=2",
         "https://cloud.getdbt.com/api/v3/accounts/1/projects/9/environments/?state=1&offset=2&limit=2",
     ]
-    actual_urls = [
-        call.kwargs["url"] if "url" in call.kwargs else call.args[0]
-        for call in mock_get.call_args_list
-    ]
+    actual_urls = [call.args[0] for call in mock_client.get.call_args_list]
     assert actual_urls == expected_urls

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,6 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -285,7 +284,6 @@ dev = [
     { name = "ruff" },
     { name = "types-authlib" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -301,7 +299,6 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "~=2.10.1" },
     { name = "pyjwt", specifier = "~=2.12.0" },
     { name = "pyyaml", specifier = "~=6.0.2" },
-    { name = "requests", specifier = "~=2.32.4" },
     { name = "starlette", specifier = "~=0.50.0" },
     { name = "uvicorn", specifier = "~=0.38.0" },
 ]
@@ -317,7 +314,6 @@ dev = [
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "types-authlib", specifier = ">=1.6.4.20250920" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
-    { name = "types-requests", specifier = ">=2.32.0.20250328" },
 ]
 
 [[package]]
@@ -1349,18 +1345,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.32.4.20250913"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113, upload-time = "2025-09-13T02:40:02.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1", size = 20658, upload-time = "2025-09-13T02:40:01.115Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Why

The codebase already uses `httpx.AsyncClient` throughout (e.g. `dbt_admin/client.py`, `discovery/client.py`). The OAuth FastAPI app still had a dependency on `requests` for three helper functions that fetch accounts, projects, and environments from the dbt Platform API. This PR removes `requests` and `types-requests` as dependencies by migrating those functions to async `httpx`.

# What

- Converted `_get_all_accounts`, `_get_all_projects_for_account`, and `_get_all_environments_for_project` in `src/dbt_mcp/oauth/fastapi_app.py` from sync `requests.get` to `async def` with `httpx.AsyncClient`
- Updated the three FastAPI route handlers (`/projects`, `/environments`, `/selected_project`) that call these helpers to `async def` with `await`
- Removed `requests~=2.32.4` from `[dependencies]` and `types-requests` from `[dependency-groups.dev]` in `pyproject.toml`
- Updated `tests/unit/oauth/test_fastapi_app_pagination.py` to use async tests with `httpx.AsyncClient` mocking (matching the pattern used in `tests/unit/dbt_admin/test_client.py`)

Drafted by claude-sonnet-4-6 under the direction of @DevonFulcher