### PR TITLE
feat: enrich list_projects response

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260319-132633.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260319-132633.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: 'Add more data to list_projects response: dbt_project_subdirectory, has_semantic_layer, type, environments (id/name/type), and repository_full_name'
+time: 2026-03-19T13:26:33.410861+01:00

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -131,7 +131,10 @@ class DbtAdminAPIClient:
         result = await self._make_request(
             "GET",
             f"/api/v3/accounts/{account_id}/projects/",
-            params={"state": 1},
+            params={
+                "state": 1,
+                "include_related": "['environments','repository']",
+            },
         )
         data = result.get("data", [])
         return [
@@ -139,6 +142,20 @@ class DbtAdminAPIClient:
                 "id": p["id"],
                 "name": p["name"],
                 "description": p.get("description"),
+                "dbt_project_subdirectory": p.get("dbt_project_subdirectory"),
+                "has_semantic_layer": p.get("semantic_layer_config_id") is not None,
+                "type": p.get("type"),
+                "environments": [
+                    {
+                        "id": e.get("id"),
+                        "name": e.get("name"),
+                        "type": (e.get("deployment_type") or "generic")
+                        if e.get("type") == "deployment"
+                        else e.get("type"),
+                    }
+                    for e in (p.get("environments") or [])
+                ],
+                "repository_full_name": (p.get("repository") or {}).get("full_name"),
             }
             for p in data
         ]

--- a/src/dbt_mcp/prompts/admin_api/list_projects.md
+++ b/src/dbt_mcp/prompts/admin_api/list_projects.md
@@ -6,5 +6,10 @@ Returns a list of project objects with:
 - **id**: The project ID
 - **name**: The project name
 - **description**: The project description (if set)
+- **dbt_project_subdirectory**: Path within the repository where the dbt project lives (if set)
+- **has_semantic_layer**: Whether the project has a semantic layer configured
+- **type**: The project type (0=default, 1=hybrid)
+- **environments**: List of environments, each with id, name, and type (development, production, staging, or generic)
+- **repository_full_name**: The repository name in `org/repo` format (if set)
 
 Use this tool to discover available projects in the account, especially when working across multiple projects.

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -546,3 +546,108 @@ async def test_get_job_run_artifact_request_exception(client):
     with patch("httpx.AsyncClient", return_value=mock_client):
         with pytest.raises(ArtifactRetrievalError):
             await client.get_job_run_artifact(12345, 100, "nonexistent.json")
+
+
+async def test_list_projects(client):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "id": 1,
+                "name": "My Project",
+                "description": "A test project",
+                "dbt_project_subdirectory": "dbt/",
+                "semantic_layer_config_id": 42,
+                "type": 0,
+                "environments": [
+                    {
+                        "id": 10,
+                        "name": "Production",
+                        "type": "deployment",
+                        "deployment_type": "production",
+                    },
+                    {
+                        "id": 11,
+                        "name": "Staging",
+                        "type": "deployment",
+                        "deployment_type": "staging",
+                    },
+                    {
+                        "id": 12,
+                        "name": "Generic",
+                        "type": "deployment",
+                        "deployment_type": None,
+                    },
+                    {
+                        "id": 13,
+                        "name": "Dev",
+                        "type": "development",
+                        "deployment_type": None,
+                    },
+                ],
+                "repository": {"full_name": "my-org/my-repo"},
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await client.list_projects(12345)
+
+    assert len(result) == 1
+    p = result[0]
+    assert p["id"] == 1
+    assert p["name"] == "My Project"
+    assert p["description"] == "A test project"
+    assert p["dbt_project_subdirectory"] == "dbt/"
+    assert p["has_semantic_layer"] is True
+    assert p["type"] == 0
+    assert p["environments"] == [
+        {"id": 10, "name": "Production", "type": "production"},
+        {"id": 11, "name": "Staging", "type": "staging"},
+        {"id": 12, "name": "Generic", "type": "generic"},
+        {"id": 13, "name": "Dev", "type": "development"},
+    ]
+    assert p["repository_full_name"] == "my-org/my-repo"
+
+    headers = await client.get_headers()
+    mock_client.request.assert_called_once_with(
+        "GET",
+        "https://cloud.getdbt.com/api/v3/accounts/12345/projects/",
+        headers=headers,
+        params={
+            "state": 1,
+            "include_related": "['environments','repository']",
+        },
+    )
+
+
+async def test_list_projects_no_semantic_layer(client):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "id": 2,
+                "name": "Bare Project",
+                "description": None,
+                "dbt_project_subdirectory": None,
+                "semantic_layer_config_id": None,
+                "type": 1,
+                "environments": [],
+                "repository": None,
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await client.list_projects(12345)
+
+    p = result[0]
+    assert p["has_semantic_layer"] is False
+    assert p["environments"] == []
+    assert p["repository_full_name"] is None


### PR DESCRIPTION
Closes #665

## What changed

The `list_projects` tool now returns richer data per project by using `include_related=["environments", "repository"]` on the Admin API request.

New fields:
- `dbt_project_subdirectory` — path in the repo where the dbt project lives
- `has_semantic_layer` — bool derived from `semantic_layer_config_id`
- `type` — project type (0=default, 1=hybrid)
- `environments` — list of environments with `id`, `name`, and `type` (`development`, `production`, `staging`, or `generic`)
- `repository_full_name` — repo in `org/repo` format

For environment `type`, the value is derived by combining `type` and `deployment_type` from the API:
- `development` → `development`
- `deployment` + `deployment_type: production` → `production`
- `deployment` + `deployment_type: staging` → `staging`
- `deployment` + no `deployment_type` → `generic`

## Example response

```json
[
  {
    "id": 1001,
    "name": "Core Analytics",
    "description": "Our core analytics project, maintained by the data team.",
    "dbt_project_subdirectory": null,
    "has_semantic_layer": true,
    "type": 0,
    "environments": [
      { "id": 1001, "name": "Production",   "type": "production" },
      { "id": 1002, "name": "Staging",      "type": "staging" },
      { "id": 1003, "name": "Development",  "type": "development" },
      { "id": 1004, "name": "CI Jobs",      "type": "generic" }
    ],
    "repository_full_name": "my-org/core-analytics"
  },
  {
    "id": 1005,
    "name": "Marketing Analytics",
    "description": null,
    "dbt_project_subdirectory": "dbt/",
    "has_semantic_layer": false,
    "type": 0,
    "environments": [
      { "id": 1006, "name": "Production",  "type": "production" },
      { "id": 1007, "name": "Development", "type": "development" },
      { "id": 1008, "name": "CI",          "type": "generic" }
    ],
    "repository_full_name": "my-org/marketing-analytics"
  }
]
```