### PR TITLE
fix: specify utf-8 encoding when reading manifest.json

### DIFF
--- a/.changes/unreleased/Bug Fix-20260428-100823.yaml
+++ b/.changes/unreleased/Bug Fix-20260428-100823.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix UnicodeDecodeError when reading manifest.json on Windows with UTF-8 model descriptions
+time: 2026-04-28T10:08:23.680284+02:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -283,7 +283,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         _run_dbt_command(["parse"])  # Ensure manifest is generated
         cwd_path = config.project_dir if os.path.isabs(config.project_dir) else None
         manifest_path = os.path.join(cwd_path or ".", "target", "manifest.json")
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             manifest_data = json.load(f)
         return Manifest(**manifest_data)
 

--- a/tests/unit/dbt_cli/test_manifest_encoding.py
+++ b/tests/unit/dbt_cli/test_manifest_encoding.py
@@ -1,0 +1,46 @@
+from unittest.mock import mock_open, patch
+
+import pytest
+from pytest import MonkeyPatch
+
+from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
+from tests.mocks.config import mock_dbt_cli_config
+
+
+@pytest.fixture
+def mock_process():
+    class MockProcess:
+        def communicate(self, timeout=None):
+            return "command output", None
+
+    return MockProcess()
+
+
+def test_manifest_uses_utf8_encoding(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    """Regression test for #594: open() without encoding defaults to CP-1252 on Windows."""
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    with patch("builtins.open", mock_open(read_data='{"nodes": {}}')) as mock_file:
+        tools["get_lineage_dev"](unique_id="model.a", types=None, depth=5)
+
+    mock_file.assert_called_once_with(
+        "/test/project/target/manifest.json", encoding="utf-8"
+    )

--- a/tests/unit/dbt_cli/test_manifest_encoding.py
+++ b/tests/unit/dbt_cli/test_manifest_encoding.py
@@ -20,10 +20,8 @@ def test_manifest_uses_utf8_encoding(
     monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
 ):
     """Regression test for #594: open() without encoding defaults to CP-1252 on Windows."""
-    mock_calls = []
 
     def mock_popen(args, **kwargs):
-        mock_calls.append(args)
         return mock_process
 
     monkeypatch.setattr("subprocess.Popen", mock_popen)

--- a/tests/unit/dbt_cli/test_manifest_non_ascii.py
+++ b/tests/unit/dbt_cli/test_manifest_non_ascii.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+from pytest import MonkeyPatch
+
+from dbt_mcp.config.config import DbtCliConfig
+from dbt_mcp.dbt_cli.binary_type import BinaryType
+from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
+
+
+@pytest.fixture
+def mock_process():
+    class MockProcess:
+        def communicate(self, timeout=None):
+            return "command output", None
+
+    return MockProcess()
+
+
+def test_manifest_loads_non_ascii_utf8(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, tmp_path
+):
+    """Regression test for #594: manifest with non-ASCII UTF-8 chars should load without error."""
+    manifest_dir = tmp_path / "target"
+    manifest_dir.mkdir()
+    manifest_data = {
+        "nodes": {
+            "model.my_project.customers": {
+                "name": "customers",
+                "description": "Área México — 注文追跡モデル",
+            }
+        }
+    }
+    (manifest_dir / "manifest.json").write_text(
+        json.dumps(manifest_data, ensure_ascii=False), encoding="utf-8"
+    )
+
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    config = DbtCliConfig(
+        project_dir=str(tmp_path),
+        dbt_path="/path/to/dbt",
+        dbt_cli_timeout=10,
+        binary_type=BinaryType.DBT_CORE,
+    )
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    tools["get_lineage_dev"](
+        unique_id="model.my_project.customers", types=None, depth=5
+    )


### PR DESCRIPTION
Fixes #594

open() without an explicit encoding argument defaults to the system
locale on Windows (CP-1252). When a dbt project has model docs with
valid UTF-8 characters (accented letters, CJK characters), this causes
a UnicodeDecodeError.

Adding encoding='utf-8' to the manifest.json open() call fixes this.