### PR TITLE
Introduce MultiprojectSemanticLayerConfigProvider Protocol

### DIFF
--- a/src/dbt_mcp/config/config_providers.py
+++ b/src/dbt_mcp/config/config_providers.py
@@ -83,7 +83,14 @@ class ConfigProvider[ConfigType](ABC):
     async def get_config(self) -> ConfigType: ...
 
 
-class DefaultSemanticLayerConfigProvider(ConfigProvider[SemanticLayerConfig]):
+class MultiprojectConfigProvider[ConfigType](ConfigProvider[ConfigType]):
+    @abstractmethod
+    async def get_config_for_project(self, project_id: int) -> ConfigType: ...
+
+
+class DefaultSemanticLayerConfigProvider(
+    MultiprojectConfigProvider[SemanticLayerConfig]
+):
     def __init__(self, credentials_provider: CredentialsProvider):
         self.credentials_provider = credentials_provider
 

--- a/src/dbt_mcp/semantic_layer/tools_multiproject.py
+++ b/src/dbt_mcp/semantic_layer/tools_multiproject.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
-from typing import Protocol
 
 from dbtsl.api.shared.query_params import GroupByParam
 from mcp.server.fastmcp import FastMCP
 
-from dbt_mcp.config.config_providers import SemanticLayerConfig
+from dbt_mcp.config.config_providers import (
+    MultiprojectConfigProvider,
+    SemanticLayerConfig,
+)
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.semantic_layer.client import (
     SemanticLayerClientProvider,
@@ -25,28 +27,14 @@ from dbt_mcp.tools.tool_names import ToolName
 from dbt_mcp.tools.toolsets import Toolset
 
 
-class MultiprojectSemanticLayerConfigProvider(Protocol):
-    """Protocol for config providers that support per-project config resolution.
-
-    Any object implementing this protocol can be used as the config provider for
-    MultiProjectSemanticLayerToolContext, including both the CLI-facing
-    DefaultSemanticLayerConfigProvider and server-side implementations that resolve
-    environments via internal APIs.
-    """
-
-    async def get_config(self) -> SemanticLayerConfig: ...
-
-    async def get_config_for_project(self, project_id: int) -> SemanticLayerConfig: ...
-
-
 @dataclass
 class MultiProjectSemanticLayerToolContext:
-    semantic_layer_config_provider: MultiprojectSemanticLayerConfigProvider
+    semantic_layer_config_provider: MultiprojectConfigProvider[SemanticLayerConfig]
     _client_provider: SemanticLayerClientProvider
 
     def __init__(
         self,
-        config_provider: MultiprojectSemanticLayerConfigProvider,
+        config_provider: MultiprojectConfigProvider[SemanticLayerConfig],
         client_provider: SemanticLayerClientProvider,
     ):
         self.semantic_layer_config_provider = config_provider
@@ -57,7 +45,7 @@ class MultiProjectSemanticLayerToolContext:
             project_id
         )
         return SemanticLayerFetcher(
-            config_provider=self.semantic_layer_config_provider,  # type: ignore[arg-type]
+            config_provider=self.semantic_layer_config_provider,
             client_provider=self._client_provider,
             config=config,
         )
@@ -201,7 +189,7 @@ MULTIPROJECT_SEMANTIC_LAYER_TOOLS: list[GenericToolDefinition[ToolName]] = [
 
 def register_multiproject_sl_tools(
     dbt_mcp: FastMCP,
-    config_provider: MultiprojectSemanticLayerConfigProvider,
+    config_provider: MultiprojectConfigProvider[SemanticLayerConfig],
     client_provider: SemanticLayerClientProvider,
     *,
     disabled_tools: set[ToolName],


### PR DESCRIPTION
# Why

\`MultiProjectSemanticLayerToolContext\` and \`register_multiproject_sl_tools\` previously required \`DefaultSemanticLayerConfigProvider\` as the concrete config provider type. This class is designed for the CLI use case and resolves environments by calling the public dbt Cloud Admin API using \`DBT_HOST\`, \`DBT_TOKEN\`, and \`DBT_ACCOUNT_ID\` environment variables. Server-side callers (e.g. ai-codegen-api) cannot satisfy this requirement because those env vars don't exist in server environments.

# What

Add \`MultiprojectConfigProvider[ConfigType]\` as an intermediate ABC between \`ConfigProvider[ConfigType]\` and \`DefaultSemanticLayerConfigProvider\` in \`config_providers.py\`. It extends \`ConfigProvider\` with an additional abstract method \`get_config_for_project(project_id: int) -> ConfigType\`.

\`DefaultSemanticLayerConfigProvider\` now subclasses \`MultiprojectConfigProvider[SemanticLayerConfig]\` instead of \`ConfigProvider[SemanticLayerConfig]\` directly, satisfying the new contract with its existing \`get_config_for_project\` implementation.

\`MultiProjectSemanticLayerToolContext\` and \`register_multiproject_sl_tools\` now accept \`MultiprojectConfigProvider[SemanticLayerConfig]\` instead of the concrete \`DefaultSemanticLayerConfigProvider\`. Since \`MultiprojectConfigProvider\` IS-A \`ConfigProvider\`, it can be passed to \`SemanticLayerFetcher\` (which only calls \`get_config()\`) without any type cast or \`type: ignore\` comment.

The parallel \`MultiprojectSemanticLayerConfigProvider\` Protocol introduced in the previous commit has been removed — everything lives in the ABC hierarchy in \`config_providers.py\`.

Drafted by claude-sonnet-4-6 under the direction of @DevonFulcher