### PR TITLE
Add YML selectors support for CLI tools

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260331-154652.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260331-154652.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add YML selectors support for CLI tools
+time: 2026-03-31T15:46:52.28835-07:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -34,6 +34,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         is_full_refresh: bool | None = False,
         vars: str | None = None,
         sample: str | None = None,
+        yml_selector: str | None = None,
     ) -> str:
         try:
             # Commands that should always be quiet to reduce output verbosity
@@ -56,9 +57,12 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             if vars and isinstance(vars, str):
                 command.extend(["--vars", vars])
 
-            if node_selection:
-                selector_params = str(node_selection).split(" ")
+            if node_selection and isinstance(node_selection, str):
+                selector_params = node_selection.split(" ")
                 command.extend(["--select"] + selector_params)
+
+            if yml_selector and isinstance(yml_selector, str):
+                command.extend(["--selector", yml_selector])
 
             if isinstance(resource_type, Iterable):
                 command.extend(["--resource-type"] + resource_type)
@@ -100,6 +104,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         node_selection: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/node_selection")
         ),
+        yml_selector: str | None = Field(
+            default=None, description=get_prompt("dbt_cli/args/yml_selector")
+        ),
         is_full_refresh: bool | None = Field(
             default=None, description=get_prompt("dbt_cli/args/full_refresh")
         ),
@@ -117,14 +124,20 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             is_full_refresh=is_full_refresh,
             vars=vars,
             sample=sample,
+            yml_selector=yml_selector,
         )
 
     def compile(
         node_selection: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/node_selection")
         ),
+        yml_selector: str | None = Field(
+            default=None, description=get_prompt("dbt_cli/args/yml_selector")
+        ),
     ) -> str:
-        return _run_dbt_command(["compile"], node_selection, is_selectable=True)
+        return _run_dbt_command(
+            ["compile"], node_selection, is_selectable=True, yml_selector=yml_selector
+        )
 
     def docs() -> str:
         return _run_dbt_command(["docs", "generate"])
@@ -132,6 +145,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     def ls(
         node_selection: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/node_selection")
+        ),
+        yml_selector: str | None = Field(
+            default=None, description=get_prompt("dbt_cli/args/yml_selector")
         ),
         resource_type: list[str] | None = Field(
             default=None,
@@ -143,6 +159,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             node_selection,
             resource_type=resource_type,
             is_selectable=True,
+            yml_selector=yml_selector,
         )
 
     def parse() -> str:
@@ -151,6 +168,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     def run(
         node_selection: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/node_selection")
+        ),
+        yml_selector: str | None = Field(
+            default=None, description=get_prompt("dbt_cli/args/yml_selector")
         ),
         is_full_refresh: bool | None = Field(
             default=None, description=get_prompt("dbt_cli/args/full_refresh")
@@ -169,17 +189,27 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             is_full_refresh=is_full_refresh,
             vars=vars,
             sample=sample,
+            yml_selector=yml_selector,
         )
 
     def test(
         node_selection: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/node_selection")
         ),
+        yml_selector: str | None = Field(
+            default=None, description=get_prompt("dbt_cli/args/yml_selector")
+        ),
         vars: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/vars")
         ),
     ) -> str:
-        return _run_dbt_command(["test"], node_selection, is_selectable=True, vars=vars)
+        return _run_dbt_command(
+            ["test"],
+            node_selection,
+            is_selectable=True,
+            vars=vars,
+            yml_selector=yml_selector,
+        )
 
     def show(
         sql_query: str = Field(description=get_prompt("dbt_cli/args/sql_query")),

--- a/src/dbt_mcp/prompts/dbt_cli/args/node_selection.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/node_selection.md
@@ -1,10 +1,7 @@
 Node selection string passed to dbt's `--select` flag (like `my_model`, `tag:nightly`, `path:models/staging`).
 
-**IMPORTANT — `--select` vs `--selector`:**
-- This parameter maps to dbt's `--select` flag and accepts **inline node selection syntax only**.
-- It does **NOT** accept named selectors from `selectors.yml`. Those are referenced via dbt's `--selector` flag, which is **not supported** by this tool.
-- If the user references a named selector (e.g. "run the `github` selector" or "use the selector defined in `selectors.yml`"), do **not** pass that name directly to this parameter. Instead, ask the user to provide the equivalent inline selection syntax (like `tag:github`, `path:models/github`, `fqn:*github*`), or look up the `selectors.yml` definition to translate it yourself.
-
+This parameter accepts **inline node selection syntax only**. It does **NOT** accept named
+selectors from `selectors.yml` — use the `yml_selector` parameter for those instead.
 
 A selection should be used when we need to select specific nodes or are asking to do actions on specific nodes. A node can be a model, a test, a seed or a snapshot. It is strongly preferred to provide a selection, especially on large projects. Always provide a selection initially.
 

--- a/src/dbt_mcp/prompts/dbt_cli/args/yml_selector.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/yml_selector.md
@@ -1,0 +1,10 @@
+Named selector from `selectors.yml`, passed to dbt's `--selector` flag
+(e.g. `nightly`, `github_actions`).
+
+Use this when the user references a selector by name that is defined in the
+project's `selectors.yml`. This maps directly to dbt's `--selector` flag.
+
+**IMPORTANT — mutually exclusive with `node_selection`:**
+Do not provide both `yml_selector` and `node_selection` in the same call.
+dbt does not allow `--selector` and `--select` together; if both are supplied
+dbt will return an error.

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -445,3 +445,66 @@ def test_compile_supports_selection(
     compile_tool(node_selection="my_model")
     assert "--select" in mock_calls[0]
     assert "my_model" in mock_calls[0]
+
+
+@pytest.mark.parametrize("command_name", ["build", "run", "test", "compile", "ls"])
+def test_yml_selector_flag_added_to_command(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, command_name
+):
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+    tool = tools[command_name]
+
+    assert "yml_selector" in inspect.signature(tool).parameters
+
+    tool(yml_selector="nightly")
+
+    assert mock_calls
+    args_list = mock_calls[0]
+    assert "--selector" in args_list
+    assert "nightly" in args_list
+    assert "--select" not in args_list
+
+
+def test_yml_selector_not_added_when_none(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+    build_tool = tools["build"]
+
+    build_tool()
+
+    assert mock_calls
+    args_list = mock_calls[0]
+    assert "--selector" not in args_list


### PR DESCRIPTION
## Summary
Related to the 2nd half of #676 - including the ability to use the `--selectors` YML selector in local dev. Builds on top of work in #677 !


## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Validation

Proper use of YML `--selector`.
<img width="1001" height="322" alt="Screenshot 2026-04-01 at 11 20 36 PM" src="https://github.com/user-attachments/assets/e08fa87d-9c0a-45d5-b065-ad831349105f" />

Solid use of node `--select`.
<img width="986" height="328" alt="Screenshot 2026-04-01 at 11 30 22 PM" src="https://github.com/user-attachments/assets/62c95674-7caf-439d-bf23-28df32ffe64b" />

