### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@9c187f00d6706cb0c27aef4eb58f1a8869e9d6db
+        with:
+          mode: validate
+          skill-dir: .claude/skills/release-dbt-mcp
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This adds a small validate-only CI check for the existing skill metadata in this repo.

It only adds one workflow file, does not publish anything, and does not need secrets.

Why it looked like a fit here:
- A MCP (Model Context Protocol) server for interacting with dbt
- Tools for executing and generating SQL on dbt Platform infrastructure

It runs schema and trust validation for `.claude/skills/release-dbt-mcp` and leaves runtime code, release flow, and publish credentials alone.
Permissions: read-only. No secrets. No publish. No runtime changes.

If you'd like it folded into an existing workflow or pointed at a different path, I can adjust the branch.