### PR TITLE
Remove mcp sdk version pin

### DIFF
--- a/.changes/unreleased/Under the Hood-20260407-134827.yaml
+++ b/.changes/unreleased/Under the Hood-20260407-134827.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Remove MCP SDK version pin
+time: 2026-04-07T13:48:27.544379-05:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,7 @@ dependencies = [
   "dbtlabs-vortex~=0.2.0",
   "fastapi~=0.128.0",
   "uvicorn~=0.38.0",
-  # Pinned to a patch range because src/dbt_mcp/proxy/tools.py accesses private
-  # MCP SDK internals (_tool_manager._tools, mcp.server.fastmcp.utilities.func_metadata).
-  # When upgrading, verify those APIs are unchanged and update this pin accordingly.
-  "mcp[cli]==1.26.0",
+  "mcp[cli]",
   "pydantic-settings~=2.10.1",
   "pyjwt~=2.12.0",
   "pyyaml~=6.0.2",


### PR DESCRIPTION
## Summary

Since we are now depending on a fork of the MCP SDK, we no longer need to pin a specific version. This pin was causing uv dependency resolution issues when importing dbt MCP into our internal server.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
