### PR TITLE
Remove forked MCP SDK source

### DIFF
--- a/.changes/unreleased/Under the Hood-20260408-092641.yaml
+++ b/.changes/unreleased/Under the Hood-20260408-092641.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Remove forked MCP SDK source
+time: 2026-04-08T09:26:41.586097-05:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,6 @@ dev = [
   "types-authlib>=1.6.4.20250920",
 ]
 
-[tool.uv.sources]
-mcp = { git = "https://github.com/dbt-labs/mcp-python-sdk.git", branch = "dbt-labs/patched" }
-
 [project.urls]
 Documentation = "https://docs.getdbt.com/docs/dbt-ai/about-mcp"
 Issues = "https://github.com/dbt-labs/dbt-mcp/issues"

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ requires-dist = [
     { name = "fastapi", specifier = "~=0.128.0" },
     { name = "filelock", specifier = "~=3.20.3" },
     { name = "httpx", specifier = "~=0.28.1" },
-    { name = "mcp", extras = ["cli"], git = "https://github.com/dbt-labs/mcp-python-sdk.git?branch=dbt-labs%2Fpatched" },
+    { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
     { name = "pydantic-settings", specifier = "~=2.10.1" },
     { name = "pyjwt", specifier = "~=2.12.0" },
     { name = "pyyaml", specifier = "~=6.0.2" },
@@ -606,8 +606,8 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "0.0.1.dev699+3d4f595"
-source = { git = "https://github.com/dbt-labs/mcp-python-sdk.git?branch=dbt-labs%2Fpatched#3d4f595b8832bf04e9ab55aeaee87496ecf629d9" }
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
@@ -623,6 +623,10 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Upon further investigation, this fork isn't being used in the wheel we are distributing to pypi. For instance, this command shows that we still depend on the official SDK:
```
uvx --with dbt-mcp python -c "from importlib.metadata import version; print(version('mcp'), __import__('mcp').__file__)"
```
So, it is best to remove this dependency. We plan on continuing to depend on the fork internally for remote MCP due to the memory leak issues it fixes.

This supersedes this other PR: https://github.com/dbt-labs/dbt-mcp/pull/700

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes