### PR TITLE
Auto-fetch DBT_HOST_PREFIX from dbt Platform for SL and Discovery API URL construction

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260408-161529.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260408-161529.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Auto-fetch DBT_HOST_PREFIX from dbt Platform for SL and Discovery API URL construction
+time: 2026-04-08T16:15:29.864297-07:00

--- a/src/dbt_mcp/config/credentials.py
+++ b/src/dbt_mcp/config/credentials.py
@@ -17,6 +17,7 @@ from dbt_mcp.oauth.token_provider import (
     OAuthTokenProvider,
     StaticTokenProvider,
 )
+from dbt_mcp.project.project_resolver import get_account
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +112,30 @@ def _try_refresh_token(
         return updated_context
     except Exception as e:
         logger.warning(f"Failed to refresh token at startup: {e}")
+        return None
+
+
+async def _fetch_host_prefix_from_platform(
+    *,
+    dbt_platform_url: str,
+    account_id: int,
+    token: str,
+) -> str | None:
+    try:
+        account = await get_account(
+            dbt_platform_url=dbt_platform_url,
+            account_id=account_id,
+            headers={
+                "Authorization": f"Token {token}",
+                "Accept": "application/json",
+            },
+        )
+        return account.host_prefix
+    except Exception:
+        logger.warning(
+            "Failed to fetch host prefix from dbt platform. "
+            "If your account requires a prefix, try setting DBT_HOST_PREFIX explicitly."
+        )
         return None
 
 
@@ -235,6 +260,26 @@ class CredentialsProvider:
             self._log_settings()
             return self.settings, self.token_provider
         self.token_provider = StaticTokenProvider(token=self.settings.dbt_token)
+        # Fetch host prefix from the platform when not explicitly configured via env vars
+        # Only strip dbt_host to base_host if the fetch succeeds , otherwise
+        # preserve what the user set in DBT_HOST. (The OAuth flow always strips dbt_host
+        # to base_host since host_prefix is guaranteed to be set after login)
+        if (
+            not self.settings.actual_host_prefix
+            and self.settings.dbt_account_id
+            and self.settings.dbt_token
+            and self.settings.actual_host
+        ):
+            dbt_platform_url = _build_dbt_platform_url(self.settings.actual_host, None)
+            fetched_prefix = await _fetch_host_prefix_from_platform(
+                dbt_platform_url=dbt_platform_url,
+                account_id=self.settings.dbt_account_id,
+                token=self.settings.dbt_token,
+            )
+            if fetched_prefix:
+                self.settings.host_prefix = fetched_prefix
+                self.settings.dbt_host = self.settings.base_host
+                logger.info(f"Fetched prefix {fetched_prefix} from dbt Platform.")
         validate_settings(self.settings)
         self.authentication_method = AuthenticationMethod.ENV_VAR
         self._log_settings()

--- a/src/dbt_mcp/project/project_resolver.py
+++ b/src/dbt_mcp/project/project_resolver.py
@@ -12,6 +12,22 @@ from dbt_mcp.oauth.dbt_platform import (
 logger = logging.getLogger(__name__)
 
 
+async def get_account(
+    *,
+    dbt_platform_url: str,
+    account_id: int,
+    headers: dict[str, str],
+) -> DbtPlatformAccount:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            # Using v2 as this endpoint in v3 was not available in testing
+            url=f"{dbt_platform_url}/api/v2/accounts/{account_id}/",
+            headers=headers,
+        )
+        response.raise_for_status()
+        return DbtPlatformAccount(**response.json()["data"])
+
+
 async def get_all_accounts(
     *,
     dbt_platform_url: str,

--- a/tests/unit/config/test_fetch_host_prefix.py
+++ b/tests/unit/config/test_fetch_host_prefix.py
@@ -1,0 +1,190 @@
+"""Tests for the env-var auth path's host prefix fetching from dbt Platform."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dbt_mcp.config.credentials import (
+    CredentialsProvider,
+    _fetch_host_prefix_from_platform,
+)
+from dbt_mcp.config.settings import DbtMcpSettings
+
+
+class TestFetchHostPrefixFromPlatform:
+    """Unit tests for the _fetch_host_prefix_from_platform helper."""
+
+    @pytest.mark.asyncio
+    async def test_returns_prefix_from_account(self):
+        """Returns static_subdomain-based prefix when account fetch succeeds."""
+        mock_account = MagicMock()
+        mock_account.host_prefix = "ab123"
+
+        with patch(
+            "dbt_mcp.config.credentials.get_account",
+            new=AsyncMock(return_value=mock_account),
+        ):
+            result = await _fetch_host_prefix_from_platform(
+                dbt_platform_url="https://us1.dbt.com",
+                account_id=42,
+                token="my-token",
+            )
+
+        assert result == "ab123"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_account_has_no_prefix(self):
+        """Returns None when the account exists but has no host_prefix."""
+        mock_account = MagicMock()
+        mock_account.host_prefix = None
+
+        with patch(
+            "dbt_mcp.config.credentials.get_account",
+            new=AsyncMock(return_value=mock_account),
+        ):
+            result = await _fetch_host_prefix_from_platform(
+                dbt_platform_url="https://us1.dbt.com",
+                account_id=42,
+                token="my-token",
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error_and_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Returns None gracefully and logs a warning when the API call fails."""
+        with patch(
+            "dbt_mcp.config.credentials.get_account",
+            new=AsyncMock(side_effect=Exception("network error")),
+        ):
+            with caplog.at_level(logging.WARNING, logger="dbt_mcp.config.credentials"):
+                result = await _fetch_host_prefix_from_platform(
+                    dbt_platform_url="https://us1.dbt.com",
+                    account_id=42,
+                    token="my-token",
+                )
+
+        assert result is None
+        assert "DBT_HOST_PREFIX" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_passes_bearer_token_in_headers(self):
+        """The token is passed as a bearer/service token auth header."""
+        mock_account = MagicMock()
+        mock_account.host_prefix = "ab123"
+        captured_calls: list[dict] = []
+
+        async def capture_get_account(**kwargs: object) -> MagicMock:
+            captured_calls.append(dict(kwargs))
+            return mock_account
+
+        with patch(
+            "dbt_mcp.config.credentials.get_account",
+            new=capture_get_account,
+        ):
+            await _fetch_host_prefix_from_platform(
+                dbt_platform_url="https://us1.dbt.com",
+                account_id=42,
+                token="my-token",
+            )
+
+        assert len(captured_calls) == 1
+        headers = captured_calls[0]["headers"]
+        assert headers["Authorization"] == "Token my-token"
+
+
+class TestCredentialsProviderEnvVarPrefixFetch:
+    """Integration tests: env var auth path fetches host prefix from platform when unset."""
+
+    def _make_settings(
+        self,
+        *,
+        host: str = "us1.dbt.com",
+        token: str = "my-token",
+        account_id: int | None = 42,
+        prod_env_id: int = 123,
+        host_prefix: str | None = None,
+        multicell_account_prefix: str | None = None,
+    ) -> DbtMcpSettings:
+        return DbtMcpSettings.model_construct(
+            dbt_host=host,
+            dbt_token=token,
+            dbt_account_id=account_id,
+            dbt_prod_env_id=prod_env_id,
+            host_prefix=host_prefix,
+            multicell_account_prefix=multicell_account_prefix,
+            disable_semantic_layer=True,
+            disable_discovery=True,
+            disable_admin_api=True,
+            disable_sql=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetches_and_applies_prefix_when_unset(self):
+        """When host_prefix is unset, prefix is fetched and dbt_host is normalized to the base host."""
+        settings = self._make_settings(
+            host="ab123.us1.dbt.com", host_prefix=None, account_id=42
+        )
+        provider = CredentialsProvider(settings)
+
+        with (
+            patch(
+                "dbt_mcp.config.credentials._fetch_host_prefix_from_platform",
+                new=AsyncMock(return_value="ab123"),
+            ),
+            patch("dbt_mcp.config.settings.validate_settings"),
+        ):
+            returned_settings, _ = await provider.get_credentials()
+
+        assert returned_settings.host_prefix == "ab123"
+        assert returned_settings.dbt_host == "us1.dbt.com"
+        assert returned_settings.base_host == "us1.dbt.com"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"host_prefix": "existing-prefix"},
+            {"multicell_account_prefix": "legacy-prefix"},
+            {"account_id": None},
+        ],
+        ids=["host_prefix_set", "multicell_prefix_set", "no_account_id"],
+    )
+    async def test_does_not_fetch_when_prefix_configured_or_no_account_id(
+        self, kwargs: dict
+    ):
+        """No API call is made when a prefix is already configured or account_id is missing."""
+        settings = self._make_settings(**kwargs)
+        provider = CredentialsProvider(settings)
+
+        mock_fetch = AsyncMock(return_value="should-not-be-used")
+        with (
+            patch(
+                "dbt_mcp.config.credentials._fetch_host_prefix_from_platform",
+                new=mock_fetch,
+            ),
+            patch("dbt_mcp.config.settings.validate_settings"),
+        ):
+            await provider.get_credentials()
+
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_graceful_when_api_returns_none(self):
+        """When the API returns None, settings.host_prefix stays None (no crash)."""
+        settings = self._make_settings(host_prefix=None, account_id=42)
+        provider = CredentialsProvider(settings)
+
+        with (
+            patch(
+                "dbt_mcp.config.credentials._fetch_host_prefix_from_platform",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("dbt_mcp.config.settings.validate_settings"),
+        ):
+            returned_settings, _ = await provider.get_credentials()
+
+        assert returned_settings.host_prefix is None

--- a/tests/unit/config/test_fetch_host_prefix.py
+++ b/tests/unit/config/test_fetch_host_prefix.py
@@ -120,6 +120,7 @@ class TestCredentialsProviderEnvVarPrefixFetch:
             disable_discovery=True,
             disable_admin_api=True,
             disable_sql=True,
+            disable_dbt_cli=True,
         )
 
     @pytest.mark.asyncio
@@ -171,6 +172,28 @@ class TestCredentialsProviderEnvVarPrefixFetch:
             await provider.get_credentials()
 
         mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetches_and_applies_prefix_with_clean_base_host(self):
+        """When DBT_HOST is already a clean base host (no embedded prefix), the fetched prefix is
+        applied to host_prefix and dbt_host is left unchanged."""
+        settings = self._make_settings(
+            host="us1.dbt.com", host_prefix=None, account_id=42
+        )
+        provider = CredentialsProvider(settings)
+
+        with (
+            patch(
+                "dbt_mcp.config.credentials._fetch_host_prefix_from_platform",
+                new=AsyncMock(return_value="ab123"),
+            ),
+            patch("dbt_mcp.config.settings.validate_settings"),
+        ):
+            returned_settings, _ = await provider.get_credentials()
+
+        assert returned_settings.host_prefix == "ab123"
+        assert returned_settings.dbt_host == "us1.dbt.com"
+        assert returned_settings.base_host == "us1.dbt.com"
 
     @pytest.mark.asyncio
     async def test_graceful_when_api_returns_none(self):


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Add step to fetch DBT_HOST_PREFIX from platform (for SL/Discovery API url construction) for env var config (similar to what happens with OAuth flow). This is purely additive and backwards compatible.

## Related Issues
<!-- Link any related issues using #issue_number -->
Closes #583 



## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Validation:

Ran `task run` and inspected the setting config logs with the following settings:
```bash
DBT_HOST=https://<redacted-prefix>.us1.dbt.com
DBT_ACCOUNT_ID=
DBT_PROD_ENV_ID=
DBT_TOKEN=
DBT_PROJECT_DIR=
DBT_PATH=
```
On the main branch:
```bash
INFO [dbt_mcp.mcp.server] Multi-project mode disabled -> Env-var mode
INFO [dbt_mcp.mcp.server] Registering product docs tools
INFO [dbt_mcp.mcp.server] Registering MCP server tools
INFO [dbt_mcp.mcp.server] Registering semantic layer tools
INFO [dbt_mcp.mcp.server] Registering discovery tools
INFO [dbt_mcp.mcp.server] Registering dbt cli tools
INFO [dbt_mcp.mcp.server] Registering dbt codegen tools
INFO [dbt_mcp.mcp.server] Registering dbt admin API tools
INFO [dbt_mcp.mcp.server] Registering LSP tools
INFO [dbt_mcp.mcp.server] Starting MCP server
INFO [dbt_mcp.mcp.server] Registering proxied tools
INFO [httpx] HTTP Request: GET https://vu491.us1.dbt.com/api/v2/accounts/1/ "HTTP/1.1 200 OK"
INFO [dbt_mcp.config.credentials] Fetched prefix <PREFIX> from dbt Platform.
INFO [dbt_mcp.config.credentials] Settings: {'dbt_host': 'us1.dbt.com', 'dbt_mcp_host': None, 'dbt_prod_env_id': ***redacted***, 'dbt_env_id': None, 'dbt_dev_env_id': None, 'dbt_user_id': None, 'dbt_account_id': ***redacted***, 'dbt_token': '***redacted***', 'multicell_account_prefix': None, 'host_prefix': 'None', 'dbt_lsp_path': None, 'dbt_project_dir': 
...
```

The full `DBT_HOST` w/ prefix is used in the env var config, but in the actual settings, only the base `dbt_host` is parsed out and saved. The `host_prefix` value is ignored and is set as None. This is the gap as SL / Discovery URLs get incorrectly constructed since they need `host_prefix`.

On this dev branch:
```bash
INFO [dbt_mcp.mcp.server] Multi-project mode disabled -> Env-var mode
INFO [dbt_mcp.mcp.server] Registering product docs tools
INFO [dbt_mcp.mcp.server] Registering MCP server tools
INFO [dbt_mcp.mcp.server] Registering semantic layer tools
INFO [dbt_mcp.mcp.server] Registering discovery tools
INFO [dbt_mcp.mcp.server] Registering dbt cli tools
INFO [dbt_mcp.mcp.server] Registering dbt codegen tools
INFO [dbt_mcp.mcp.server] Registering dbt admin API tools
INFO [dbt_mcp.mcp.server] Registering LSP tools
INFO [dbt_mcp.mcp.server] Starting MCP server
INFO [dbt_mcp.mcp.server] Registering proxied tools
INFO [httpx] HTTP Request: GET https://<PREFIX>.us1.dbt.com/api/v2/accounts/1/ "HTTP/1.1 200 OK"
INFO [dbt_mcp.config.credentials] Fetched prefix <PREFIX> from dbt Platform.
INFO [dbt_mcp.config.credentials] Settings: {'dbt_host': 'us1.dbt.com', 'dbt_mcp_host': None, 'dbt_prod_env_id': <***>, 'dbt_env_id': None, 'dbt_dev_env_id': None, 'dbt_user_id': None, 'dbt_account_id': ***redacted***, 'dbt_token': '***redacted***', 'multicell_account_prefix': None, 'host_prefix': '<PREFIX>', 'dbt_lsp_path': None, 'dbt_project_dir': 
...
```
With the changes in this PR, you can see in the logs that prefix was fetched from dbt platform and now both `dbt_host` AND `host_prefix` have values set. Now, SL / Discovery API urls can be correctly constructed with this env var config approach without need of explicitly setting `DBT_HOST_PREFIX` or `MULTICELL_ACCOUNT_PREFIX`.

**Note:** We _can_ technically parse out the DBT_HOST when the prefix is included, but URLs are prone to external factors that would make parsing them a pain. For this implementation, we have decided to hit the dbt Platform for the official population of the `host_prefix` as that is the most reliable way to do so.

PR aided with [Claude Code](https://claude.com/claude-code) 