### PR TITLE
fix: add grain to order_by parameter for query_metrics

### DIFF
--- a/.changes/unreleased/Bug Fix-20260410-order-by-grain.yaml
+++ b/.changes/unreleased/Bug Fix-20260410-order-by-grain.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix query_metrics order_by to accept an explicit grain, matching the grain specified in group_by instead of silently inheriting it
+time: 2026-04-10T13:45:00.000000-07:00

--- a/.changes/unreleased/Bug Fix-20260410-order-by-grain.yaml
+++ b/.changes/unreleased/Bug Fix-20260410-order-by-grain.yaml
@@ -1,3 +1,3 @@
 kind: Bug Fix
-body: Fix query_metrics order_by to accept an explicit grain, matching the grain specified in group_by instead of silently inheriting it
+body: Add optional grain field to order_by in query_metrics; when provided it takes precedence over the matching group_by grain, preserving backward-compatible fallback when omitted
 time: 2026-04-10T13:45:00.000000-07:00

--- a/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
+++ b/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
@@ -8,7 +8,8 @@ and get_entities tools to get information about which metrics, dimensions,
 and entities to use.
 
 When using the `order_by` parameter, you must ensure that the dimension or
-entity also appears in the `group_by` parameter. When fulfilling a lookback
+entity also appears in the `group_by` parameter. For time dimensions, include
+the same `grain` in `order_by` as in `group_by`. When fulfilling a lookback
 query, prefer using order_by and limit instead of using the where parameter.
 A lookback query requires that the `order_by` parameter includes a descending
 order for a time dimension.
@@ -52,7 +53,7 @@ Thinking step-by-step:
 Parameters:
     metrics=["total_sales"]
     group_by=[{"name": "metric_time", "grain": "MONTH", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": true}]
+    order_by=[{"name": "metric_time", "grain": "MONTH", "descending": true}]
     limit=1
 </example>
 <example>
@@ -71,12 +72,12 @@ Thinking step-by-step:
 Parameters:
     metrics=["revenue"]
     group_by=[{"name": "customer_name", "type": "dimension"}, {"name": "metric_time", "grain": "QUARTER", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": true}, {"name": "revenue", "descending": true}]
+    order_by=[{"name": "metric_time", "grain": "QUARTER", "descending": true}, {"name": "revenue", "descending": true}]
     limit=5
 Follow-up Query (after verifying results):
     metrics=["revenue"]
     group_by=[{"name": "customer_name", "type": "dimension"}, {"name": "metric_time", "grain": "QUARTER", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": true}, {"name": "revenue", "descending": true}]
+    order_by=[{"name": "metric_time", "grain": "QUARTER", "descending": true}, {"name": "revenue", "descending": true}]
     limit=null
 </example>
 <example>
@@ -115,13 +116,13 @@ Thinking step-by-step:
 Parameters (initial query):
     metrics=["new_users"]
     group_by=[{"name": "metric_time", "grain": "WEEK", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": false}]
+    order_by=[{"name": "metric_time", "grain": "WEEK", "descending": false}]
     where="{{ TimeDimension('metric_time', 'WEEK') }} >= '2023-01-01' AND {{ TimeDimension('metric_time', 'WEEK') }} < '2024-01-01'"
     limit=4
 Follow-up Query (after verifying results):
     metrics=["new_users"]
     group_by=[{"name": "metric_time", "grain": "WEEK", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": false}]
+    order_by=[{"name": "metric_time", "grain": "WEEK", "descending": false}]
     where="{{ TimeDimension('metric_time', 'WEEK') }} >= '2023-01-01' AND {{ TimeDimension('metric_time', 'WEEK') }} < '2024-01-01'"
     limit=null
 </example>
@@ -148,7 +149,7 @@ Parameters:
 <parameters>
 metrics: List of metric names (strings) to query for.
 group_by: Optional list of objects with name (string), type ("dimension" or "time_dimension"), and grain (string or null for time dimensions only).
-order_by: Optional list of objects with name (string) and descending (boolean, default false).
+order_by: Optional list of objects with name (string), descending (boolean, default false), and grain (string or null, required for time dimensions to match the grain used in group_by).
 where: Optional SQL WHERE clause (string) to filter results.
 limit: Optional limit (integer) for number of results.
 </parameters>

--- a/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
+++ b/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
@@ -7,10 +7,12 @@ entities to provide. You can call the list_metrics, get_dimensions,
 and get_entities tools to get information about which metrics, dimensions,
 and entities to use.
 
-When using the `order_by` parameter, you must ensure that the dimension or
-entity also appears in the `group_by` parameter. For time dimensions, you may
+When using the `order_by` parameter, each item must refer to either a metric
+name or a field that also appears in `group_by`. For time dimensions, you may
 specify a `grain` in `order_by` independently from `group_by`; if omitted, it
-defaults to the grain of the matching `group_by` entry. When fulfilling a lookback
+defaults to the grain of the matching `group_by` entry. `grain` only applies to
+time dimensions and should be omitted for metrics and categorical dimensions.
+When fulfilling a lookback
 query, prefer using order_by and limit instead of using the where parameter.
 A lookback query requires that the `order_by` parameter includes a descending
 order for a time dimension.

--- a/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
+++ b/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
@@ -8,8 +8,9 @@ and get_entities tools to get information about which metrics, dimensions,
 and entities to use.
 
 When using the `order_by` parameter, you must ensure that the dimension or
-entity also appears in the `group_by` parameter. For time dimensions, include
-the same `grain` in `order_by` as in `group_by`. When fulfilling a lookback
+entity also appears in the `group_by` parameter. For time dimensions, you may
+specify a `grain` in `order_by` independently from `group_by`; if omitted, it
+defaults to the grain of the matching `group_by` entry. When fulfilling a lookback
 query, prefer using order_by and limit instead of using the where parameter.
 A lookback query requires that the `order_by` parameter includes a descending
 order for a time dimension.

--- a/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
+++ b/src/dbt_mcp/prompts/semantic_layer/query_metrics.md
@@ -8,7 +8,8 @@ and get_entities tools to get information about which metrics, dimensions,
 and entities to use.
 
 When using the `order_by` parameter, you must ensure that the dimension or
-entity also appears in the `group_by` parameter. When fulfilling a lookback
+entity also appears in the `group_by` parameter. For time dimensions, include
+the same `grain` in `order_by` as in `group_by`. When fulfilling a lookback
 query, prefer using order_by and limit instead of using the where parameter.
 A lookback query requires that the `order_by` parameter includes a descending
 order for a time dimension.
@@ -53,7 +54,7 @@ Thinking step-by-step:
 Parameters:
     metrics=["total_sales"]
     group_by=[{"name": "metric_time", "grain": "MONTH", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": true}]
+    order_by=[{"name": "metric_time", "grain": "MONTH", "descending": true}]
     limit=1
 </example>
 <example>
@@ -72,12 +73,12 @@ Thinking step-by-step:
 Parameters:
     metrics=["revenue"]
     group_by=[{"name": "customer_name", "type": "dimension"}, {"name": "metric_time", "grain": "QUARTER", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": true}, {"name": "revenue", "descending": true}]
+    order_by=[{"name": "metric_time", "grain": "QUARTER", "descending": true}, {"name": "revenue", "descending": true}]
     limit=5
 Follow-up Query (after verifying results):
     metrics=["revenue"]
     group_by=[{"name": "customer_name", "type": "dimension"}, {"name": "metric_time", "grain": "QUARTER", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": true}, {"name": "revenue", "descending": true}]
+    order_by=[{"name": "metric_time", "grain": "QUARTER", "descending": true}, {"name": "revenue", "descending": true}]
     limit=null
 </example>
 <example>
@@ -116,13 +117,13 @@ Thinking step-by-step:
 Parameters (initial query):
     metrics=["new_users"]
     group_by=[{"name": "metric_time", "grain": "WEEK", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": false}]
+    order_by=[{"name": "metric_time", "grain": "WEEK", "descending": false}]
     where="{{ TimeDimension('metric_time', 'WEEK') }} >= '2023-01-01' AND {{ TimeDimension('metric_time', 'WEEK') }} < '2024-01-01'"
     limit=4
 Follow-up Query (after verifying results):
     metrics=["new_users"]
     group_by=[{"name": "metric_time", "grain": "WEEK", "type": "time_dimension"}]
-    order_by=[{"name": "metric_time", "descending": false}]
+    order_by=[{"name": "metric_time", "grain": "WEEK", "descending": false}]
     where="{{ TimeDimension('metric_time', 'WEEK') }} >= '2023-01-01' AND {{ TimeDimension('metric_time', 'WEEK') }} < '2024-01-01'"
     limit=null
 </example>

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -314,18 +314,17 @@ class SemanticLayerFetcher:
         result: list[OrderBySpec] = []
         if order_by is None:
             return result
-        queried_group_by = {g.name: g for g in group_by} if group_by else {}
+        queried_group_by = {g.name for g in group_by} if group_by else set()
         queried_metrics = set(metrics)
         for o in order_by:
             if o.name in queried_metrics:
                 result.append(OrderByMetric(name=o.name, descending=o.descending))
             elif o.name in queried_group_by:
-                selected_group_by = queried_group_by[o.name]
                 result.append(
                     OrderByGroupBy(
-                        name=selected_group_by.name,
+                        name=o.name,
                         descending=o.descending,
-                        grain=selected_group_by.grain,
+                        grain=o.grain,
                     )
                 )
             else:

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -410,18 +410,17 @@ class SemanticLayerFetcher:
         result: list[OrderBySpec] = []
         if order_by is None:
             return result
-        queried_group_by = {g.name: g for g in group_by} if group_by else {}
+        queried_group_by = {g.name for g in group_by} if group_by else set()
         queried_metrics = set(metrics)
         for o in order_by:
             if o.name in queried_metrics:
                 result.append(OrderByMetric(name=o.name, descending=o.descending))
             elif o.name in queried_group_by:
-                selected_group_by = queried_group_by[o.name]
                 result.append(
                     OrderByGroupBy(
-                        name=selected_group_by.name,
+                        name=o.name,
                         descending=o.descending,
-                        grain=selected_group_by.grain,
+                        grain=o.grain,
                     )
                 )
             else:

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -410,17 +410,19 @@ class SemanticLayerFetcher:
         result: list[OrderBySpec] = []
         if order_by is None:
             return result
-        queried_group_by = {g.name for g in group_by} if group_by else set()
+        group_by_map = {g.name: g for g in group_by} if group_by else {}
         queried_metrics = set(metrics)
         for o in order_by:
             if o.name in queried_metrics:
                 result.append(OrderByMetric(name=o.name, descending=o.descending))
-            elif o.name in queried_group_by:
+            elif o.name in group_by_map:
                 result.append(
                     OrderByGroupBy(
                         name=o.name,
                         descending=o.descending,
-                        grain=o.grain,
+                        grain=o.grain
+                        if o.grain is not None
+                        else group_by_map[o.name].grain,
                     )
                 )
             else:

--- a/src/dbt_mcp/semantic_layer/param_descriptions.py
+++ b/src/dbt_mcp/semantic_layer/param_descriptions.py
@@ -34,8 +34,10 @@ SEMANTIC_GROUP_BY = (
 )
 
 SEMANTIC_ORDER_BY = (
-    "Sort keys; each item has `name` and `descending` (default false); "
-    "order fields should appear in group_by when grouping"
+    "Sort keys; each item has `name`, `descending` (default false), and optional "
+    "`grain` for time dimensions (overrides the grain from group_by; falls back to "
+    "the matching group_by grain when omitted); items may be metric names or "
+    "group_by fields"
 )
 
 SEMANTIC_WHERE = (

--- a/src/dbt_mcp/semantic_layer/types.py
+++ b/src/dbt_mcp/semantic_layer/types.py
@@ -10,6 +10,7 @@ from dbtsl.models.metric import MetricType
 class OrderByParam:
     name: str
     descending: bool
+    grain: str | None = None
 
 
 @dataclass

--- a/src/dbt_mcp/semantic_layer/types.py
+++ b/src/dbt_mcp/semantic_layer/types.py
@@ -9,7 +9,7 @@ from dbtsl.models.metric import MetricType
 @dataclass
 class OrderByParam:
     name: str
-    descending: bool
+    descending: bool = False
     grain: str | None = None
 
 

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -8,10 +8,18 @@ import pyarrow as pa
 import pytest
 from dbtsl.error import RetryTimeoutError
 
+from dbtsl.api.shared.query_params import (
+    GroupByParam,
+    GroupByType,
+    OrderByGroupBy,
+    OrderByMetric,
+)
+
 from dbt_mcp.config.config_providers import SemanticLayerConfig
+from dbt_mcp.errors import InvalidParameterError
 from dbt_mcp.errors.semantic_layer import SemanticLayerQueryTimeoutError
 from dbt_mcp.semantic_layer.client import DEFAULT_RESULT_FORMATTER, SemanticLayerFetcher
-from dbt_mcp.semantic_layer.types import QueryMetricsError
+from dbt_mcp.semantic_layer.types import OrderByParam, QueryMetricsError
 
 
 def test_default_result_formatter_outputs_iso_dates() -> None:
@@ -829,3 +837,42 @@ async def test_get_metrics_compiled_sql_sdk_client_uses_fetcher_config_override(
     await fetcher.get_metrics_compiled_sql(config=override, metrics=["revenue"])
 
     mock_client_provider.get_client.assert_awaited_once_with(config=override)
+
+
+# Tests for _get_order_bys
+
+
+def test_get_order_bys_explicit_grain_takes_precedence(fetcher) -> None:
+    group_by = [
+        GroupByParam(name="metric_time", type=GroupByType.TIME_DIMENSION, grain="MONTH")
+    ]
+    order_by = [OrderByParam(name="metric_time", descending=True, grain="WEEK")]
+    result = fetcher._get_order_bys(order_by, group_by=group_by)
+    assert result == [OrderByGroupBy(name="metric_time", descending=True, grain="WEEK")]
+
+
+def test_get_order_bys_falls_back_to_group_by_grain(fetcher) -> None:
+    group_by = [
+        GroupByParam(name="metric_time", type=GroupByType.TIME_DIMENSION, grain="MONTH")
+    ]
+    order_by = [OrderByParam(name="metric_time", descending=False)]
+    result = fetcher._get_order_bys(order_by, group_by=group_by)
+    assert result == [
+        OrderByGroupBy(name="metric_time", descending=False, grain="MONTH")
+    ]
+
+
+def test_get_order_bys_metric_name(fetcher) -> None:
+    order_by = [OrderByParam(name="revenue", descending=True)]
+    result = fetcher._get_order_bys(order_by, metrics=["revenue"])
+    assert result == [OrderByMetric(name="revenue", descending=True)]
+
+
+def test_get_order_bys_unknown_name_raises(fetcher) -> None:
+    order_by = [OrderByParam(name="unknown", descending=False)]
+    with pytest.raises(InvalidParameterError):
+        fetcher._get_order_bys(order_by, metrics=["revenue"], group_by=[])
+
+
+def test_get_order_bys_none_returns_empty(fetcher) -> None:
+    assert fetcher._get_order_bys(None) == []


### PR DESCRIPTION
## Summary

The `order_by` parameter for `query_metrics` had no `grain` field, making it asymmetric with `group_by` (which already accepts `grain`). This forced `_get_order_bys` to silently inherit grain from the matching `group_by` entry, which prevented ordering by a time dimension at a different grain than the one grouped by.

Changes:
- Add optional `grain` field to `OrderByParam` (mirrors `GroupByParam`)
- Update `_get_order_bys` to use `o.grain` directly instead of looking it up from the `group_by` entry
- Update `query_metrics` prompt examples to include `grain` in `order_by`, keeping it consistent with `group_by`

## Test plan

- [ ] Existing `_get_order_bys` tests still pass
- [ ] Verify a query with `order_by` grain different from `group_by` grain works as expected
- [ ] Verify existing queries without `grain` in `order_by` still work (field is optional, defaults to `None`)