### PR TITLE
Update dependabot config to batch examples/ security PRs

### DIFF
--- a/.changes/unreleased/Under the Hood-20260410-105942.yaml
+++ b/.changes/unreleased/Under the Hood-20260410-105942.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Update dependabot config to batch examples/ security PRs
+time: 2026-04-10T10:59:42.41955-07:00

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
+
+multi-ecosystem-groups:
+  examples:
+    schedule:
+      interval: "monthly"
+
 updates:
+  # Prod manifests 
   - package-ecosystem: "uv"
     directory: "/"
     # Ignore version update PRs - security updates remain active
@@ -15,3 +22,34 @@ updates:
     open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
+
+  # Examples manifests
+  - package-ecosystem: "uv"
+    directory: "/examples"
+    multi-ecosystem-group: "examples"
+    open-pull-requests-limit: 1
+    versioning-strategy: "increase"
+    groups:
+      examples-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/examples"
+    multi-ecosystem-group: "examples"
+    open-pull-requests-limit: 1
+    versioning-strategy: "increase"
+    groups:
+      examples-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/examples"
+    multi-ecosystem-group: "examples"
+    open-pull-requests-limit: 1
+    versioning-strategy: "increase"
+    groups:
+      examples-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Today, `examples/` automatic PRs are disabled as configured (to reduce noise) in our repo rules BUT still are flagged in repo's "Security and quality" tab. Can be concerning to see even though not production code.

Per internal discussions, attempting to batch all `examples/` security PRs into one monthly PR.

## Why
<!-- Explain the motivation for these changes -->
Reduce noise yet resolve flagged security issues in this repo.