### PR TITLE
[FIX]: Add patterns to examples dependencies in dependabot configuration

### DIFF
--- a/.changes/unreleased/Under the Hood-20260410-113056.yaml
+++ b/.changes/unreleased/Under the Hood-20260410-113056.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Add patterns to examples dependencies in dependabot configuration
+time: 2026-04-10T11:30:56.162786-07:00

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
   - package-ecosystem: "uv"
     directory: "/examples"
     multi-ecosystem-group: "examples"
+    patterns:
+      - "*"
     open-pull-requests-limit: 1
     versioning-strategy: "increase"
     groups:
@@ -37,6 +39,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples"
     multi-ecosystem-group: "examples"
+    patterns:
+      - "*"
     open-pull-requests-limit: 1
     versioning-strategy: "increase"
     groups:
@@ -47,6 +51,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/examples"
     multi-ecosystem-group: "examples"
+    patterns:
+      - "*"
     open-pull-requests-limit: 1
     versioning-strategy: "increase"
     groups:


### PR DESCRIPTION
Summary: 
- Fixes error here: https://github.com/dbt-labs/dbt-mcp/runs/70831083142
- This time, Ran locally via `dependabot update uv dbt-labs/dbt-mcp --directory /examples --local /Users/jairusmartinez/git-repos/dbt-mcp` with a sucessfull output

<img width="795" height="319" alt="Screenshot 2026-04-10 at 11 29 34 AM" src="https://github.com/user-attachments/assets/4a07cedf-cea9-4e57-9e12-036b08faab95" />
