### PR TITLE
Match baseline dependabot docs for multi-ecosystem-groups config

### DIFF
--- a/.changes/unreleased/Under the Hood-20260410-150249.yaml
+++ b/.changes/unreleased/Under the Hood-20260410-150249.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Match baseline dependabot docs for multi-ecosystem-groups config
+time: 2026-04-10T15:02:49.141016-07:00

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ multi-ecosystem-groups:
       interval: "monthly"
 
 updates:
-  # Prod manifests 
+  # Prod manifests
   - package-ecosystem: "uv"
     directory: "/"
     # Ignore version update PRs - security updates remain active
@@ -29,33 +29,15 @@ updates:
     multi-ecosystem-group: "examples"
     patterns:
       - "*"
-    open-pull-requests-limit: 1
-    versioning-strategy: "increase"
-    groups:
-      examples-deps:
-        patterns:
-          - "*"
 
   - package-ecosystem: "npm"
     directory: "/examples"
     multi-ecosystem-group: "examples"
     patterns:
       - "*"
-    open-pull-requests-limit: 1
-    versioning-strategy: "increase"
-    groups:
-      examples-deps:
-        patterns:
-          - "*"
 
   - package-ecosystem: "pip"
     directory: "/examples"
     multi-ecosystem-group: "examples"
     patterns:
       - "*"
-    open-pull-requests-limit: 1
-    versioning-strategy: "increase"
-    groups:
-      examples-deps:
-        patterns:
-          - "*"


### PR DESCRIPTION
Dependabot has many configuration options for [groups](https://docs.github.com/en/enterprise-cloud@latest/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) but it is not clear what applies to the default behavior configuration versus the multi groups config.

Therefore, just going to use the [baseline config](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates) shown, in the docs for `multi-ecosystem-groups` which should do the trick!

EDIT: Looks like [GitHub actions finally picked](https://github.com/dbt-labs/dbt-mcp/pull/713/checks?check_run_id=70863516883) up the `dependabot.yml` file properly in CI (and validated it). I'm not sure why it wasn't able in the last two PRs