### PR TITLE
fix: specify UTF-8 encoding when reading manifest.json on Windows

### DIFF
--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -238,7 +238,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         _run_dbt_command(["parse"])  # Ensure manifest is generated
         cwd_path = config.project_dir if os.path.isabs(config.project_dir) else None
         manifest_path = os.path.join(cwd_path or ".", "target", "manifest.json")
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             manifest_data = json.load(f)
         return Manifest(**manifest_data)
 


### PR DESCRIPTION
**Closing this PR** — I missed the existing [PR #674](https://github.com/dbt-labs/dbt-mcp/pull/674) by @thakoreh which fixes the same issue with the same approach. Apologies for the duplicate.

The fix in #674 is correct: adding `encoding="utf-8"` to the `open()` call in `_get_manifest()` resolves the Windows `UnicodeDecodeError` for non-ASCII characters in manifest.json.