### PR TITLE
Add DBT_HOST_PREFIX env var to remote session initialization

### DIFF
--- a/.changes/unreleased/Under the Hood-20260415-145943.yaml
+++ b/.changes/unreleased/Under the Hood-20260415-145943.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Add DBT_HOST_PREFIX support to remote session initialization
+time: 2026-04-15T14:59:43.695388-07:00

--- a/src/remote_mcp/session.py
+++ b/src/remote_mcp/session.py
@@ -9,7 +9,9 @@ from mcp.client.streamable_http import streamablehttp_client
 @contextlib.asynccontextmanager
 async def session_context() -> AsyncGenerator[ClientSession, None]:
     host = os.environ.get("DBT_HOST")
-    prefix = os.environ.get("MULTICELL_ACCOUNT_PREFIX")
+    prefix = os.environ.get("DBT_HOST_PREFIX") or os.environ.get(
+        "MULTICELL_ACCOUNT_PREFIX"
+    )
     url = (
         f"https://{prefix}.{host}/api/ai/v1/mcp/"
         if prefix

--- a/src/remote_mcp/session.py
+++ b/src/remote_mcp/session.py
@@ -5,18 +5,18 @@ from collections.abc import AsyncGenerator
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
+from dbt_mcp.config.settings import _build_dbt_platform_url
+
 
 @contextlib.asynccontextmanager
 async def session_context() -> AsyncGenerator[ClientSession, None]:
     host = os.environ.get("DBT_HOST")
+    if not host:
+        raise ValueError("DBT_HOST environment variable is required")
     prefix = os.environ.get("DBT_HOST_PREFIX") or os.environ.get(
         "MULTICELL_ACCOUNT_PREFIX"
     )
-    url = (
-        f"https://{prefix}.{host}/api/ai/v1/mcp/"
-        if prefix
-        else f"https://{host}/api/ai/v1/mcp/"
-    )
+    url = _build_dbt_platform_url(host, prefix) + "/api/ai/v1/mcp/"
     token = os.environ.get("DBT_TOKEN")
     prod_environment_id = os.environ.get("DBT_PROD_ENV_ID", "")
     async with (

--- a/src/remote_mcp/session.py
+++ b/src/remote_mcp/session.py
@@ -5,8 +5,6 @@ from collections.abc import AsyncGenerator
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
-from dbt_mcp.config.settings import _build_dbt_platform_url
-
 
 @contextlib.asynccontextmanager
 async def session_context() -> AsyncGenerator[ClientSession, None]:
@@ -16,7 +14,11 @@ async def session_context() -> AsyncGenerator[ClientSession, None]:
     prefix = os.environ.get("DBT_HOST_PREFIX") or os.environ.get(
         "MULTICELL_ACCOUNT_PREFIX"
     )
-    url = _build_dbt_platform_url(host, prefix) + "/api/ai/v1/mcp/"
+    url = (
+        f"https://{prefix}.{host}/api/ai/v1/mcp/"
+        if prefix
+        else f"https://{host}/api/ai/v1/mcp/"
+    )
     token = os.environ.get("DBT_TOKEN")
     prod_environment_id = os.environ.get("DBT_PROD_ENV_ID", "")
     async with (


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Small change to add the other (primary) environment variable (`DBT_HOST_PREFIX`) for adding the account prefix to the host url for remote session initialization.

~~Also reuses `_build_dbt_platform_url` since it has some existing protections from user misconfigs.~~

^^ reverted the above:
> _build_dbt_platform_url has a heuristic that treats any 4-label host's first label as a potential account prefix. The CI environment uses DBT_HOST w/ 4 labels (us is a regional subdomainwith) while MULTICELL_ACCOUNT_PREFIX differs. This triggers a false-positive mismatch error. The function was designed to receive pre-validated values from DbtMcpSettings, not raw env var strings. session.py does not have the validation, so the assumed heuristic of  _build_dbt_platform_url does not hold.

## What Changed
<!-- Describe the changes made in this PR -->

## Why
<!-- Explain the motivation for these changes -->

## Related Issues
<!-- Link any related issues using #issue_number -->
Closes #
Related to #


## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->