### PR TITLE
Remove get_job_run_artifact tool

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260417-110838.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260417-110838.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Remove get_job_run_artifact tool
+time: 2026-04-17T11:08:38.084567-05:00

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Allowing your client to utilize dbt commands through the MCP tooling could modif
 To learn more about the dbt Administrative API, click [here](https://docs.getdbt.com/docs/dbt-cloud-apis/admin-cloud-api).
 - `cancel_job_run`: Cancels a running job.
 - `get_job_details`: Gets job configuration including triggers, schedule, and dbt commands.
-- `get_job_run_artifact`: Downloads a specific artifact file from a job run.
 - `get_job_run_details`: Gets run details including status, timing, steps, and artifacts.
 - `get_job_run_error`: Gets error and/or warning details for a job run; option to include or show warnings only.
 - `list_job_run_artifacts`: Lists available artifacts from a job run.

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -214,23 +214,6 @@ async def list_job_run_artifacts(context: AdminToolContext, run_id: int) -> list
 
 
 @dbt_mcp_tool(
-    description=get_prompt("admin_api/get_job_run_artifact"),
-    title="Get Job Run Artifact",
-    read_only_hint=True,
-    destructive_hint=False,
-    idempotent_hint=True,
-)
-async def get_job_run_artifact(
-    context: AdminToolContext, run_id: int, artifact_path: str, step: int | None = None
-) -> Any:
-    """Get a specific job run artifact."""
-    admin_api_config = await context.admin_api_config_provider.get_config()
-    return await context.admin_client.get_job_run_artifact(
-        admin_api_config.account_id, run_id, artifact_path, step
-    )
-
-
-@dbt_mcp_tool(
     description=get_prompt("admin_api/get_job_run_error"),
     title="Get Job Run Error",
     read_only_hint=True,
@@ -287,7 +270,6 @@ ADMIN_TOOLS = [
     cancel_job_run,
     retry_job_run,
     list_job_run_artifacts,
-    get_job_run_artifact,
     get_job_run_error,
 ]
 

--- a/src/dbt_mcp/tools/readme_mappings.py
+++ b/src/dbt_mcp/tools/readme_mappings.py
@@ -57,7 +57,6 @@ HUMAN_DESCRIPTIONS: dict[ToolName, str] = {
     ToolName.CANCEL_JOB_RUN: "Cancels a running job.",
     ToolName.RETRY_JOB_RUN: "Retries a failed job run.",
     ToolName.LIST_JOB_RUN_ARTIFACTS: "Lists available artifacts from a job run.",
-    ToolName.GET_JOB_RUN_ARTIFACT: "Downloads a specific artifact file from a job run.",
     ToolName.GET_JOB_RUN_ERROR: "Gets error and/or warning details for a job run; option to include or show warnings only.",
     # dbt-codegen tools
     ToolName.GENERATE_SOURCE: "Generates source YAML by introspecting database schemas; option to include columns.",

--- a/src/dbt_mcp/tools/tool_names.py
+++ b/src/dbt_mcp/tools/tool_names.py
@@ -61,7 +61,6 @@ class ToolName(Enum):
     CANCEL_JOB_RUN = "cancel_job_run"
     RETRY_JOB_RUN = "retry_job_run"
     LIST_JOB_RUN_ARTIFACTS = "list_job_run_artifacts"
-    GET_JOB_RUN_ARTIFACT = "get_job_run_artifact"
     GET_JOB_RUN_ERROR = "get_job_run_error"
 
     # dbt-codegen tools

--- a/src/dbt_mcp/tools/toolsets.py
+++ b/src/dbt_mcp/tools/toolsets.py
@@ -101,7 +101,6 @@ toolsets = {
         ToolName.CANCEL_JOB_RUN,
         ToolName.RETRY_JOB_RUN,
         ToolName.LIST_JOB_RUN_ARTIFACTS,
-        ToolName.GET_JOB_RUN_ARTIFACT,
         ToolName.GET_JOB_RUN_ERROR,
     },
     Toolset.DBT_CODEGEN: {

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -8,7 +8,6 @@ from dbt_mcp.dbt_admin.tools import (
     JobRunStatus,
     cancel_job_run,
     get_job_details,
-    get_job_run_artifact,
     get_job_run_details,
     get_job_run_error,
     list_job_run_artifacts,
@@ -19,6 +18,8 @@ from dbt_mcp.dbt_admin.tools import (
     trigger_job_run,
 )
 from tests.mocks.config import mock_config
+
+NUM_ADMIN_TOOLS = 10
 
 
 @pytest.fixture
@@ -121,7 +122,7 @@ async def test_register_admin_api_tools_all_tools(mock_register_tools, mock_fast
     mock_register_tools.assert_called_once()
     args, kwargs = mock_register_tools.call_args
     tool_definitions = kwargs["tool_definitions"]
-    assert len(tool_definitions) == 11
+    assert len(tool_definitions) == NUM_ADMIN_TOOLS
 
 
 @patch("dbt_mcp.dbt_admin.tools.register_tools")
@@ -146,7 +147,7 @@ async def test_register_admin_api_tools_with_disabled_tools(
     args, kwargs = mock_register_tools.call_args
     tool_definitions = kwargs["tool_definitions"]
     disabled_tools = kwargs["disabled_tools"]
-    assert len(tool_definitions) == 11
+    assert len(tool_definitions) == NUM_ADMIN_TOOLS
     assert disabled_tools == set(disable_tools)
 
 
@@ -213,17 +214,6 @@ async def test_list_job_run_artifacts_tool(admin_context):
     assert isinstance(result, list)
     admin_context.admin_client.list_job_run_artifacts.assert_called_once_with(
         12345, 100
-    )
-
-
-async def test_get_job_run_artifact_tool(admin_context):
-    result = await get_job_run_artifact.fn(
-        admin_context, run_id=100, artifact_path="manifest.json", step=1
-    )
-
-    assert result is not None
-    admin_context.admin_client.get_job_run_artifact.assert_called_once_with(
-        12345, 100, "manifest.json", 1
     )
 
 
@@ -371,10 +361,9 @@ def test_admin_tools_list_contains_all_tools():
         "cancel_job_run",
         "retry_job_run",
         "list_job_run_artifacts",
-        "get_job_run_artifact",
         "get_job_run_error",
     }
 
     actual_tool_names = {tool.fn.__name__ for tool in ADMIN_TOOLS}
     assert actual_tool_names == expected_tool_names
-    assert len(ADMIN_TOOLS) == 11
+    assert len(ADMIN_TOOLS) == NUM_ADMIN_TOOLS


### PR DESCRIPTION
## Summary

This tool is quite token-inefficient.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes