### PR TITLE
Update deprecated streamablehttp_client function to streamable_http_client

### DIFF
--- a/.changes/unreleased/Under the Hood-20260417-140906.yaml
+++ b/.changes/unreleased/Under the Hood-20260417-140906.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Update deprecated streamablehttp_client function to streamable_http_client
+time: 2026-04-17T14:09:06.40019-07:00

--- a/src/dbt_mcp/proxy/tools.py
+++ b/src/dbt_mcp/proxy/tools.py
@@ -7,10 +7,10 @@ from typing import (
     ForwardRef,
 )
 
-import httpx
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import ClientSession
 from mcp.client.streamable_http import GetSessionIdCallback, streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import InvalidSignature
 from mcp.server.fastmcp.tools.base import Tool as InternalTool
@@ -103,6 +103,9 @@ class ProxiedToolsManager:
     async def get_remote_mcp_session(
         self, url: str, headers: dict[str, str]
     ) -> ClientSession:
+        http_client = await self._stack.enter_async_context(
+            create_mcp_http_client(headers=headers)
+        )
         streamable_http_client_context: tuple[
             MemoryObjectReceiveStream[SessionMessage | Exception],
             MemoryObjectSendStream[SessionMessage],
@@ -110,7 +113,7 @@ class ProxiedToolsManager:
         ] = await self._stack.enter_async_context(
             streamable_http_client(
                 url=url,
-                http_client=httpx.AsyncClient(headers=headers),
+                http_client=http_client,
             )
         )
         read_stream, write_stream, _ = streamable_http_client_context

--- a/src/dbt_mcp/proxy/tools.py
+++ b/src/dbt_mcp/proxy/tools.py
@@ -7,9 +7,10 @@ from typing import (
     ForwardRef,
 )
 
+import httpx
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import ClientSession
-from mcp.client.streamable_http import GetSessionIdCallback, streamablehttp_client
+from mcp.client.streamable_http import GetSessionIdCallback, streamable_http_client
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import InvalidSignature
 from mcp.server.fastmcp.tools.base import Tool as InternalTool
@@ -102,17 +103,17 @@ class ProxiedToolsManager:
     async def get_remote_mcp_session(
         self, url: str, headers: dict[str, str]
     ) -> ClientSession:
-        streamablehttp_client_context: tuple[
+        streamable_http_client_context: tuple[
             MemoryObjectReceiveStream[SessionMessage | Exception],
             MemoryObjectSendStream[SessionMessage],
             GetSessionIdCallback,
         ] = await self._stack.enter_async_context(
-            streamablehttp_client(
+            streamable_http_client(
                 url=url,
-                headers=headers,
+                http_client=httpx.AsyncClient(headers=headers),
             )
         )
-        read_stream, write_stream, _ = streamablehttp_client_context
+        read_stream, write_stream, _ = streamable_http_client_context
         return await self._stack.enter_async_context(
             ClientSession(read_stream, write_stream)
         )

--- a/src/remote_mcp/session.py
+++ b/src/remote_mcp/session.py
@@ -2,9 +2,9 @@ import contextlib
 import os
 from collections.abc import AsyncGenerator
 
-import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 
 @contextlib.asynccontextmanager
@@ -23,14 +23,15 @@ async def session_context() -> AsyncGenerator[ClientSession, None]:
     token = os.environ.get("DBT_TOKEN")
     prod_environment_id = os.environ.get("DBT_PROD_ENV_ID", "")
     async with (
+        create_mcp_http_client(
+            headers={
+                "Authorization": f"token {token}",
+                "x-dbt-prod-environment-id": prod_environment_id,
+            }
+        ) as http_client,
         streamable_http_client(
             url=url,
-            http_client=httpx.AsyncClient(
-                headers={
-                    "Authorization": f"token {token}",
-                    "x-dbt-prod-environment-id": prod_environment_id,
-                }
-            ),
+            http_client=http_client,
         ) as (
             read_stream,
             write_stream,

--- a/src/remote_mcp/session.py
+++ b/src/remote_mcp/session.py
@@ -2,8 +2,9 @@ import contextlib
 import os
 from collections.abc import AsyncGenerator
 
+import httpx
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 @contextlib.asynccontextmanager
@@ -22,12 +23,14 @@ async def session_context() -> AsyncGenerator[ClientSession, None]:
     token = os.environ.get("DBT_TOKEN")
     prod_environment_id = os.environ.get("DBT_PROD_ENV_ID", "")
     async with (
-        streamablehttp_client(
+        streamable_http_client(
             url=url,
-            headers={
-                "Authorization": f"token {token}",
-                "x-dbt-prod-environment-id": prod_environment_id,
-            },
+            http_client=httpx.AsyncClient(
+                headers={
+                    "Authorization": f"token {token}",
+                    "x-dbt-prod-environment-id": prod_environment_id,
+                }
+            ),
         ) as (
             read_stream,
             write_stream,


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
MCP python-sdk [updated streamable_http_client](https://github.com/modelcontextprotocol/python-sdk/pull/1177),  now deprecated in favor of `streamable_http_client` with a slightly different signature but returns the same exact tuple.

Basically a name change!

## What Changed
<!-- Describe the changes made in this PR -->

## Why
<!-- Explain the motivation for these changes -->

## Related Issues
<!-- Link any related issues using #issue_number -->
Closes #
Related to #


## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->