### PR TITLE
Fix: Raise NotFoundError for 404s in get_job_run_artifact

### DIFF
--- a/.changes/unreleased/Bug Fix-20260420-122147.yaml
+++ b/.changes/unreleased/Bug Fix-20260420-122147.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Raise NotFoundError instead of ArtifactRetrievalError for 404 responses in get_job_run_artifact
+time: 2026-04-20T12:21:47.231658+01:00

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -7,7 +7,12 @@ from typing import Any
 import httpx
 
 from dbt_mcp.config.config_providers import AdminApiConfig, ConfigProvider
-from dbt_mcp.errors import AdminAPIError, ArtifactRetrievalError, NotFoundError
+from dbt_mcp.errors import (
+    AdminAPIError,
+    ArtifactRetrievalError,
+    InvalidParameterError,
+    NotFoundError,
+)
 from dbt_mcp.oauth.dbt_platform import (
     DbtPlatformEnvironment,
     DbtPlatformEnvironmentResponse,
@@ -48,9 +53,14 @@ class DbtAdminAPIClient:
                 )
                 response.raise_for_status()
                 return response.json()
+        except httpx.HTTPStatusError as e:
+            if 400 <= e.response.status_code < 500:
+                raise InvalidParameterError(
+                    f"API request failed ({e.response.status_code}): {e}"
+                ) from e
+            raise AdminAPIError(f"API request failed: {e}") from e
         except httpx.HTTPError as e:
-            logger.error(f"API request failed: {e}")
-            raise AdminAPIError(f"API request failed: {e}")
+            raise AdminAPIError(f"API request failed: {e}") from e
 
     async def get_account(self, account_id: int) -> dict[str, Any]:
         """Get details for an account."""

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 
 from dbt_mcp.config.config_providers import AdminApiConfig, ConfigProvider
-from dbt_mcp.errors import AdminAPIError, ArtifactRetrievalError
+from dbt_mcp.errors import AdminAPIError, ArtifactRetrievalError, NotFoundError
 from dbt_mcp.oauth.dbt_platform import (
     DbtPlatformEnvironment,
     DbtPlatformEnvironmentResponse,
@@ -382,6 +382,14 @@ class DbtAdminAPIClient:
                 )
                 response.raise_for_status()
                 return response.text
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise NotFoundError(
+                    f"Artifact '{artifact_path}' not found for run {run_id}"
+                ) from e
+            raise ArtifactRetrievalError(
+                f"Artifact '{artifact_path}' not available for run {run_id}"
+            ) from e
         except httpx.HTTPError as e:
             raise ArtifactRetrievalError(
                 f"Artifact '{artifact_path}' not available for run {run_id}"

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -8,6 +8,7 @@ from dbt_mcp.dbt_admin.client import (
     AdminAPIError,
     ArtifactRetrievalError,
     DbtAdminAPIClient,
+    InvalidParameterError,
     NotFoundError,
 )
 
@@ -104,10 +105,27 @@ async def test_make_request_success(client):
     )
 
 
-async def test_make_request_failure(client):
+async def test_make_request_4xx_raises_invalid_parameter(client):
     mock_response = MagicMock()
     mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "404 Not Found", request=MagicMock(), response=MagicMock()
+        "400 Bad Request",
+        request=MagicMock(),
+        response=MagicMock(status_code=400),
+    )
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(InvalidParameterError):
+            await client._make_request("POST", "/test/endpoint")
+
+
+async def test_make_request_5xx_raises_admin_api_error(client):
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500 Internal Server Error",
+        request=MagicMock(),
+        response=MagicMock(status_code=500),
     )
 
     mock_client = create_mock_httpx_client(mock_response)

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -8,6 +8,7 @@ from dbt_mcp.dbt_admin.client import (
     AdminAPIError,
     ArtifactRetrievalError,
     DbtAdminAPIClient,
+    NotFoundError,
 )
 
 
@@ -546,17 +547,36 @@ async def test_get_job_run_artifact_no_step_param(client):
     )
 
 
-async def test_get_job_run_artifact_request_exception(client):
+async def test_get_job_run_artifact_404_raises_not_found(client):
     mock_response = MagicMock()
+    mock_response.status_code = 404
     mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "404 Not Found", request=MagicMock(), response=MagicMock()
+        "404 Not Found",
+        request=MagicMock(),
+        response=MagicMock(status_code=404),
+    )
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(NotFoundError, match="not found for run"):
+            await client.get_job_run_artifact(12345, 100, "nonexistent.json")
+
+
+async def test_get_job_run_artifact_server_error_raises_artifact_retrieval(client):
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500 Internal Server Error",
+        request=MagicMock(),
+        response=MagicMock(status_code=500),
     )
 
     mock_client = create_mock_httpx_client(mock_response)
 
     with patch("httpx.AsyncClient", return_value=mock_client):
         with pytest.raises(ArtifactRetrievalError):
-            await client.get_job_run_artifact(12345, 100, "nonexistent.json")
+            await client.get_job_run_artifact(12345, 100, "manifest.json")
 
 
 async def test_list_projects(client):


### PR DESCRIPTION
## Why

The Admin API client raises `AdminAPIError` (a `ServerToolCallError`) for all httpx errors — including 4xx client errors like 400 Bad Request and 404 Not Found. Downstream consumers (ai-codegen-api) classify `ServerToolCallError` as status 500, logging expected client errors as ERROR-level internal errors instead of warnings.

Additionally, `_make_request` didn't use exception chaining (`from e`), so downstream chain-unwrapping couldn't inspect the original httpx error.

## What

**`_make_request`** (affects all Admin API calls):
- Differentiate 4xx from 5xx `httpx.HTTPStatusError` responses
- Raise `InvalidParameterError` (a `ClientToolCallError`) for 4xx responses
- Keep `AdminAPIError` for 5xx and non-HTTP errors
- Add explicit exception chaining (`from e`) on all raises

**`get_job_run_artifact`**:
- Raise `NotFoundError` (a `ClientToolCallError`) for 404 responses
- Keep `ArtifactRetrievalError` for other errors
- Add explicit exception chaining

## Refs

- Companion PR: https://github.com/dbt-labs/ai-codegen-api/pull/946 (httpx fallback handling)

Drafted by Claude Opus 4.6 under the direction of @alan-andrade