### PR TITLE
feat: support dbt Fusion LSP via dbt lsp subcommand

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260422-120543.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260422-120543.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Support dbt Fusion LSP via `dbt lsp` subcommand; prefer Fusion over legacy standalone binary, with `DBT_LSP_PATH` and editor storage paths as fallbacks
+time: 2026-04-22T12:05:43.850603+02:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -187,7 +187,9 @@ def load_config(enable_proxied_tools: bool = True) -> Config:
 
     lsp_config = None
     if settings.dbt_project_dir:
-        lsp_binary_info = dbt_lsp_binary_info(settings.dbt_lsp_path)
+        lsp_binary_info = dbt_lsp_binary_info(
+            lsp_path=settings.dbt_lsp_path, dbt_path=settings.dbt_path
+        )
         if lsp_binary_info:
             local_lsp_connection_provider = LocalLSPConnectionProvider(
                 lsp_binary_info=lsp_binary_info,

--- a/src/dbt_mcp/lsp/lsp_binary_manager.py
+++ b/src/dbt_mcp/lsp/lsp_binary_manager.py
@@ -9,6 +9,7 @@ from enum import StrEnum
 import os
 from pathlib import Path
 import platform
+import shutil
 import subprocess
 from dataclasses import dataclass
 
@@ -25,11 +26,12 @@ class LspBinaryInfo:
     """Information about a detected dbt LSP binary.
 
     Attributes:
-        path: Full filesystem path to the LSP binary executable.
+        cmd: Command to launch the LSP server (e.g. ["dbt", "lsp"] for Fusion
+            or ["/path/to/dbt-lsp"] for the legacy standalone binary).
         version: Version string of the LSP binary.
     """
 
-    path: str
+    cmd: list[str]
     version: str
 
 
@@ -89,34 +91,70 @@ def get_storage_path(editor: CodeEditor) -> Path:
     return Path(base, "User", "globalStorage", "dbtlabsinc.dbt", "bin", binary_name)
 
 
-def dbt_lsp_binary_info(lsp_path: str | None = None) -> LspBinaryInfo | None:
-    """Get dbt LSP binary information from a custom path or auto-detect it.
+def detect_fusion_lsp(dbt_path: str) -> LspBinaryInfo | None:
+    """Detect dbt Fusion LSP by probing the dbt CLI.
 
-    Attempts to locate and validate the dbt LSP binary. If a custom path is provided,
-    it will be validated first. If the custom path is invalid or not provided, the
-    function will attempt to auto-detect the binary in standard editor locations.
+    Checks whether the dbt binary at dbt_path supports the `lsp` subcommand
+    (i.e. is dbt Fusion, not dbt-core).
 
     Args:
-        lsp_path: Optional custom path to the dbt LSP binary. If provided, this
-            path will be validated and used if it exists. If None or invalid,
-            auto-detection will be attempted.
+        dbt_path: Path or name of the dbt CLI executable (e.g. "dbt" or "/usr/bin/dbt").
 
     Returns:
-        LspBinaryInfo object containing the path and version of the found binary,
-        or None if no valid binary could be found.
-
-    Note:
-        If a custom path is provided but invalid, a warning will be logged before
-        falling back to auto-detection.
+        LspBinaryInfo with cmd=[dbt_path, "lsp"] if Fusion is available, else None.
     """
+    if not shutil.which(dbt_path):
+        logger.debug(f"dbt executable not found in PATH: {dbt_path}")
+        return None
+    try:
+        result = subprocess.run(
+            [dbt_path, "lsp", "--help"],
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            logger.debug(f"{dbt_path} does not support the lsp subcommand")
+            return None
+    except subprocess.TimeoutExpired:
+        logger.debug(f"Timed out probing {dbt_path} lsp --help")
+        return None
+    version = subprocess.run(
+        [dbt_path, "--version"], capture_output=True, text=True
+    ).stdout.strip()
+    logger.debug(f"Found dbt Fusion LSP via {dbt_path} with version {version}")
+    return LspBinaryInfo(cmd=[dbt_path, "lsp"], version=version)
+
+
+def dbt_lsp_binary_info(
+    lsp_path: str | None = None, dbt_path: str = "dbt"
+) -> LspBinaryInfo | None:
+    """Get dbt LSP binary information, preferring dbt Fusion when available.
+
+    Resolution order:
+    1. dbt Fusion CLI (`dbt lsp`) if dbt_path supports the lsp subcommand
+    2. Custom legacy binary at lsp_path (DBT_LSP_PATH), if set and valid
+    3. Auto-detection in standard editor storage locations
+
+    Args:
+        lsp_path: Optional path to a legacy dbt-lsp binary (DBT_LSP_PATH).
+        dbt_path: Path or name of the dbt CLI executable (DBT_PATH, default "dbt").
+
+    Returns:
+        LspBinaryInfo with the resolved command and version, or None if not found.
+    """
+    fusion = detect_fusion_lsp(dbt_path)
+    if fusion:
+        return fusion
+
     if lsp_path:
         logger.debug(f"Using custom LSP binary path: {lsp_path}")
         if Path(lsp_path).exists() and Path(lsp_path).is_file():
             version = get_lsp_binary_version(lsp_path)
-            return LspBinaryInfo(path=lsp_path, version=version)
+            return LspBinaryInfo(cmd=[lsp_path], version=version)
         logger.warning(
             f"Provided LSP binary path {lsp_path} does not exist or is not a file, falling back to detecting LSP binary"
         )
+
     return detect_lsp_binary()
 
 
@@ -140,7 +178,7 @@ def detect_lsp_binary() -> LspBinaryInfo | None:
         if path.exists() and path.is_file():
             version = get_lsp_binary_version(path.as_posix())
             logger.debug(f"Found LSP binary in {path} with version {version}")
-            return LspBinaryInfo(path=path.as_posix(), version=version)
+            return LspBinaryInfo(cmd=[path.as_posix()], version=version)
 
     return None
 

--- a/src/dbt_mcp/lsp/lsp_binary_manager.py
+++ b/src/dbt_mcp/lsp/lsp_binary_manager.py
@@ -118,9 +118,28 @@ def detect_fusion_lsp(dbt_path: str) -> LspBinaryInfo | None:
     except subprocess.TimeoutExpired:
         logger.debug(f"Timed out probing {dbt_path} lsp --help")
         return None
-    version = subprocess.run(
-        [dbt_path, "--version"], capture_output=True, text=True
-    ).stdout.strip()
+    except OSError as exc:
+        logger.debug(f"Failed probing {dbt_path} lsp --help: {exc}")
+        return None
+
+    version = ""
+    try:
+        version_result = subprocess.run(
+            [dbt_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if version_result.returncode == 0:
+            version = version_result.stdout.strip()
+        else:
+            logger.debug(
+                f"Failed to get version from {dbt_path} --version "
+                f"(exit code {version_result.returncode})"
+            )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug(f"Failed probing {dbt_path} --version: {exc}")
+
     logger.debug(f"Found dbt Fusion LSP via {dbt_path} with version {version}")
     return LspBinaryInfo(cmd=[dbt_path, "lsp"], version=version)
 

--- a/src/dbt_mcp/lsp/lsp_connection.py
+++ b/src/dbt_mcp/lsp/lsp_connection.py
@@ -95,7 +95,7 @@ class SocketLSPConnection(LSPConnectionProviderProtocol):
 
         Args:
             cmd: Command to launch the LSP server (e.g. ["dbt", "lsp"] or ["/path/to/dbt-lsp"])
-            cwd: Working directory for the LSP process
+            cwd: dbt project directory passed to the LSP server via --project-dir
             args: Optional command-line arguments for the LSP server
             connection_timeout: Timeout in seconds for establishing the initial socket
                               connection (default: 10). Used during server startup.

--- a/src/dbt_mcp/lsp/lsp_connection.py
+++ b/src/dbt_mcp/lsp/lsp_connection.py
@@ -12,7 +12,6 @@ import socket
 import subprocess
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 import uuid
 from dataclasses import asdict
@@ -86,7 +85,7 @@ class SocketLSPConnection(LSPConnectionProviderProtocol):
 
     def __init__(
         self,
-        binary_path: str,
+        cmd: list[str],
         cwd: str,
         args: Sequence[str] | None = None,
         connection_timeout: float = 10,
@@ -95,7 +94,7 @@ class SocketLSPConnection(LSPConnectionProviderProtocol):
         """Initialize the LSP connection manager.
 
         Args:
-            binary_path: Path to the LSP server binary
+            cmd: Command to launch the LSP server (e.g. ["dbt", "lsp"] or ["/path/to/dbt-lsp"])
             cwd: Working directory for the LSP process
             args: Optional command-line arguments for the LSP server
             connection_timeout: Timeout in seconds for establishing the initial socket
@@ -104,7 +103,7 @@ class SocketLSPConnection(LSPConnectionProviderProtocol):
                                    (default: 60). Used when no timeout is specified for
                                    individual requests.
         """
-        self.binary_path = Path(binary_path)
+        self.cmd = cmd
         self.args = list(args) if args else []
         self.cwd = cwd
         self.host = "127.0.0.1"
@@ -129,7 +128,7 @@ class SocketLSPConnection(LSPConnectionProviderProtocol):
         self.connection_timeout = connection_timeout
         self.default_request_timeout = default_request_timeout
 
-        logger.debug(f"LSP Connection initialized with binary: {self.binary_path}")
+        logger.debug(f"LSP Connection initialized with command: {' '.join(self.cmd)}")
 
     def compiled(self) -> bool:
         return self.state.compiled
@@ -207,7 +206,7 @@ class SocketLSPConnection(LSPConnectionProviderProtocol):
         """
         # Prepare command with socket info
         cmd = [
-            str(self.binary_path),
+            *self.cmd,
             "--socket",
             f"{self.port}",
             "--project-dir",

--- a/src/dbt_mcp/lsp/providers/local_lsp_connection_provider.py
+++ b/src/dbt_mcp/lsp/providers/local_lsp_connection_provider.py
@@ -70,12 +70,12 @@ class LocalLSPConnectionProvider(LSPConnectionProvider):
 
         try:
             logger.info(
-                f"Using LSP binary in {self.lsp_binary_info.path} with version {self.lsp_binary_info.version}"
+                f"Using LSP command '{' '.join(self.lsp_binary_info.cmd)}' with version {self.lsp_binary_info.version}"
             )
 
             # Create the connection wrapper (doesn't start the process yet)
             lsp_connection = SocketLSPConnection(
-                binary_path=self.lsp_binary_info.path,
+                cmd=self.lsp_binary_info.cmd,
                 args=[],
                 cwd=self.project_dir,
             )

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -63,7 +63,7 @@ mock_dbt_codegen_config = DbtCodegenConfig(
 
 mock_local_lsp_connection_provider = LocalLSPConnectionProvider(
     lsp_binary_info=LspBinaryInfo(
-        path="/path/to/lsp",
+        cmd=["/path/to/lsp"],
         version="1.0.0",
     ),
     project_dir="/test/project",

--- a/tests/unit/lsp/test_local_lsp_connection_provider.py
+++ b/tests/unit/lsp/test_local_lsp_connection_provider.py
@@ -16,7 +16,7 @@ def lsp_binary_info(tmp_path) -> LspBinaryInfo:
     """Create a test LSP binary info."""
     binary_path = tmp_path / "dbt-lsp"
     binary_path.touch()
-    return LspBinaryInfo(path=str(binary_path), version="1.0.0")
+    return LspBinaryInfo(cmd=[str(binary_path)], version="1.0.0")
 
 
 @pytest.fixture
@@ -50,7 +50,7 @@ class TestLocalLSPConnectionProvider:
 
             # Verify connection was created with correct arguments
             mock_conn_class.assert_called_once_with(
-                binary_path=lsp_binary_info.path,
+                cmd=lsp_binary_info.cmd,
                 args=[],
                 cwd=project_dir,
             )

--- a/tests/unit/lsp/test_lsp_binary_manager.py
+++ b/tests/unit/lsp/test_lsp_binary_manager.py
@@ -9,6 +9,7 @@ from dbt_mcp.lsp.lsp_binary_manager import (
     CodeEditor,
     LspBinaryInfo,
     dbt_lsp_binary_info,
+    detect_fusion_lsp,
     detect_lsp_binary,
     get_lsp_binary_version,
     get_storage_path,
@@ -228,7 +229,7 @@ class TestDetectLspBinary:
         result = detect_lsp_binary()
 
         assert result is not None
-        assert result.path == "/path/to/cursor/dbt-lsp"
+        assert result.cmd == ["/path/to/cursor/dbt-lsp"]
         assert result.version == "1.5.0"
         assert mock_get_path.call_count == 2  # Called for CODE and CURSOR
 
@@ -289,94 +290,170 @@ class TestDetectLspBinary:
         result = detect_lsp_binary()
 
         assert result is not None
-        assert result.path == "/path/to/windsurf/dbt-lsp"
+        assert result.cmd == ["/path/to/windsurf/dbt-lsp"]
         assert result.version == "2.0.0"
+
+
+class TestDetectFusionLsp:
+    """Tests for detect_fusion_lsp function."""
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.subprocess.run")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_fusion_available_returns_binary_info(self, mock_which, mock_run):
+        """Test that Fusion LSP is detected when dbt supports lsp subcommand."""
+        mock_which.return_value = "/usr/local/bin/dbt"
+        mock_run.side_effect = [
+            Mock(returncode=0),  # dbt lsp --help
+            Mock(stdout="dbt-fusion 1.9.0\n"),  # dbt --version
+        ]
+
+        result = detect_fusion_lsp("dbt")
+
+        assert result is not None
+        assert result.cmd == ["dbt", "lsp"]
+        assert result.version == "dbt-fusion 1.9.0"
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_dbt_not_in_path_returns_none(self, mock_which):
+        """Test that None is returned when dbt is not in PATH."""
+        mock_which.return_value = None
+
+        result = detect_fusion_lsp("dbt")
+
+        assert result is None
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.subprocess.run")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_dbt_lsp_not_supported_returns_none(self, mock_which, mock_run):
+        """Test that None is returned when dbt does not support the lsp subcommand."""
+        mock_which.return_value = "/usr/bin/dbt"
+        mock_run.return_value = Mock(returncode=1)  # dbt lsp --help fails
+
+        result = detect_fusion_lsp("dbt")
+
+        assert result is None
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.subprocess.run")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_custom_dbt_path_used_in_cmd(self, mock_which, mock_run):
+        """Test that a custom dbt_path is reflected in the returned cmd."""
+        mock_which.return_value = "/custom/path/dbt"
+        mock_run.side_effect = [
+            Mock(returncode=0),
+            Mock(stdout="2.0.0\n"),
+        ]
+
+        result = detect_fusion_lsp("/custom/path/dbt")
+
+        assert result is not None
+        assert result.cmd == ["/custom/path/dbt", "lsp"]
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.subprocess.run")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_subprocess_timeout_returns_none(self, mock_which, mock_run):
+        """Test that a subprocess timeout is handled gracefully."""
+        import subprocess as sp
+
+        mock_which.return_value = "/usr/bin/dbt"
+        mock_run.side_effect = sp.TimeoutExpired(cmd="dbt", timeout=5)
+
+        result = detect_fusion_lsp("dbt")
+
+        assert result is None
 
 
 class TestDbtLspBinaryInfo:
     """Tests for dbt_lsp_binary_info function."""
 
-    def test_custom_path_valid_file(self, tmp_path):
-        """Test using a valid custom LSP binary path."""
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_fusion_lsp")
+    def test_fusion_takes_priority_over_custom_path(self, mock_fusion, tmp_path):
+        """Test that Fusion is preferred over a custom LSP path."""
+        mock_fusion.return_value = LspBinaryInfo(cmd=["dbt", "lsp"], version="2.0.0")
         lsp_binary = tmp_path / "custom-lsp"
         lsp_binary.touch()
-        version_file = tmp_path / ".version"
-        version_file.write_text("1.0.0")
 
-        with patch(
-            "dbt_mcp.lsp.lsp_binary_manager.get_lsp_binary_version"
-        ) as mock_version:
-            mock_version.return_value = "1.0.0"
-
-            result = dbt_lsp_binary_info(str(lsp_binary))
-
-            assert result is not None
-            assert result.path == str(lsp_binary)
-            assert result.version == "1.0.0"
-
-    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary")
-    def test_custom_path_invalid_falls_back_to_detection(self, mock_detect):
-        """Test that invalid custom path falls back to auto-detection."""
-        mock_detect.return_value = LspBinaryInfo(
-            path="/auto/detected/path", version="2.0.0"
-        )
-
-        result = dbt_lsp_binary_info("/nonexistent/path")
+        result = dbt_lsp_binary_info(lsp_path=str(lsp_binary), dbt_path="dbt")
 
         assert result is not None
-        assert result.path == "/auto/detected/path"
-        assert result.version == "2.0.0"
+        assert result.cmd == ["dbt", "lsp"]
+        mock_fusion.assert_called_once_with("dbt")
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_fusion_lsp")
+    def test_custom_path_used_when_no_fusion(self, mock_fusion, tmp_path):
+        """Test that custom LSP path is used when Fusion is not available."""
+        mock_fusion.return_value = None
+        lsp_binary = tmp_path / "custom-lsp"
+        lsp_binary.touch()
+
+        with patch("dbt_mcp.lsp.lsp_binary_manager.get_lsp_binary_version") as mock_v:
+            mock_v.return_value = "1.0.0"
+            result = dbt_lsp_binary_info(lsp_path=str(lsp_binary), dbt_path="dbt")
+
+        assert result is not None
+        assert result.cmd == [str(lsp_binary)]
+        assert result.version == "1.0.0"
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_fusion_lsp")
+    def test_editor_paths_fallback_when_no_fusion_no_custom_path(
+        self, mock_fusion, mock_detect
+    ):
+        """Test that editor storage paths are used as last resort."""
+        mock_fusion.return_value = None
+        mock_detect.return_value = LspBinaryInfo(
+            cmd=["/path/to/editor/dbt-lsp"], version="1.5.0"
+        )
+
+        result = dbt_lsp_binary_info(lsp_path=None, dbt_path="dbt")
+
+        assert result is not None
+        assert result.cmd == ["/path/to/editor/dbt-lsp"]
         mock_detect.assert_called_once()
 
     @patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary")
-    def test_custom_path_empty_string_uses_detection(self, mock_detect):
-        """Test that empty string path triggers auto-detection."""
-        mock_detect.return_value = LspBinaryInfo(
-            path="/auto/detected/path", version="3.0.0"
-        )
-
-        result = dbt_lsp_binary_info("")
-
-        assert result is not None
-        assert result.path == "/auto/detected/path"
-        mock_detect.assert_called_once()
-
-    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary")
-    def test_no_custom_path_uses_detection(self, mock_detect):
-        """Test that None path uses auto-detection."""
-        mock_detect.return_value = LspBinaryInfo(
-            path="/auto/detected/path", version="4.0.0"
-        )
-
-        result = dbt_lsp_binary_info(None)
-
-        assert result is not None
-        assert result.path == "/auto/detected/path"
-        mock_detect.assert_called_once()
-
-    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary")
-    def test_detection_returns_none(self, mock_detect):
-        """Test that None is returned when detection fails."""
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_fusion_lsp")
+    def test_returns_none_when_all_detection_fails(self, mock_fusion, mock_detect):
+        """Test that None is returned when all detection methods fail."""
+        mock_fusion.return_value = None
         mock_detect.return_value = None
 
-        result = dbt_lsp_binary_info(None)
+        result = dbt_lsp_binary_info(lsp_path=None, dbt_path="dbt")
 
         assert result is None
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.detect_fusion_lsp")
+    def test_invalid_custom_path_falls_back_to_editor(self, mock_fusion, mock_detect):
+        """Test that invalid custom path falls back to editor storage detection."""
+        mock_fusion.return_value = None
+        mock_detect.return_value = LspBinaryInfo(
+            cmd=["/editor/dbt-lsp"], version="3.0.0"
+        )
+
+        result = dbt_lsp_binary_info(lsp_path="/nonexistent/path", dbt_path="dbt")
+
+        assert result is not None
+        assert result.cmd == ["/editor/dbt-lsp"]
+        mock_detect.assert_called_once()
 
     def test_custom_path_directory_not_file(self, tmp_path):
         """Test that directory path (not file) falls back to detection."""
         lsp_dir = tmp_path / "lsp"
         lsp_dir.mkdir()
 
-        with patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary") as mock_detect:
+        with (
+            patch("dbt_mcp.lsp.lsp_binary_manager.detect_fusion_lsp") as mock_fusion,
+            patch("dbt_mcp.lsp.lsp_binary_manager.detect_lsp_binary") as mock_detect,
+        ):
+            mock_fusion.return_value = None
             mock_detect.return_value = LspBinaryInfo(
-                path="/detected/path", version="5.0.0"
+                cmd=["/detected/path"], version="5.0.0"
             )
 
-            result = dbt_lsp_binary_info(str(lsp_dir))
+            result = dbt_lsp_binary_info(lsp_path=str(lsp_dir), dbt_path="dbt")
 
             assert result is not None
-            assert result.path == "/detected/path"
+            assert result.cmd == ["/detected/path"]
             mock_detect.assert_called_once()
 
 
@@ -385,16 +462,23 @@ class TestLspBinaryInfo:
 
     def test_create_lsp_binary_info(self):
         """Test creating LspBinaryInfo instance."""
-        info = LspBinaryInfo(path="/path/to/lsp", version="1.2.3")
+        info = LspBinaryInfo(cmd=["/path/to/lsp"], version="1.2.3")
 
-        assert info.path == "/path/to/lsp"
+        assert info.cmd == ["/path/to/lsp"]
         assert info.version == "1.2.3"
+
+    def test_create_fusion_lsp_binary_info(self):
+        """Test creating LspBinaryInfo for Fusion (multi-element cmd)."""
+        info = LspBinaryInfo(cmd=["dbt", "lsp"], version="1.5.0")
+
+        assert info.cmd == ["dbt", "lsp"]
+        assert info.version == "1.5.0"
 
     def test_lsp_binary_info_equality(self):
         """Test LspBinaryInfo equality comparison."""
-        info1 = LspBinaryInfo(path="/path/to/lsp", version="1.2.3")
-        info2 = LspBinaryInfo(path="/path/to/lsp", version="1.2.3")
-        info3 = LspBinaryInfo(path="/other/path", version="1.2.3")
+        info1 = LspBinaryInfo(cmd=["/path/to/lsp"], version="1.2.3")
+        info2 = LspBinaryInfo(cmd=["/path/to/lsp"], version="1.2.3")
+        info3 = LspBinaryInfo(cmd=["/other/path"], version="1.2.3")
 
         assert info1 == info2
         assert info1 != info3

--- a/tests/unit/lsp/test_lsp_binary_manager.py
+++ b/tests/unit/lsp/test_lsp_binary_manager.py
@@ -304,7 +304,7 @@ class TestDetectFusionLsp:
         mock_which.return_value = "/usr/local/bin/dbt"
         mock_run.side_effect = [
             Mock(returncode=0),  # dbt lsp --help
-            Mock(stdout="dbt-fusion 1.9.0\n"),  # dbt --version
+            Mock(returncode=0, stdout="dbt-fusion 1.9.0\n"),  # dbt --version
         ]
 
         result = detect_fusion_lsp("dbt")
@@ -360,6 +360,33 @@ class TestDetectFusionLsp:
         result = detect_fusion_lsp("dbt")
 
         assert result is None
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.subprocess.run")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_oserror_on_probe_returns_none(self, mock_which, mock_run):
+        """Test that an OSError (e.g. exec format error) is handled gracefully."""
+        mock_which.return_value = "/usr/bin/dbt"
+        mock_run.side_effect = OSError("Exec format error")
+
+        result = detect_fusion_lsp("dbt")
+
+        assert result is None
+
+    @patch("dbt_mcp.lsp.lsp_binary_manager.subprocess.run")
+    @patch("dbt_mcp.lsp.lsp_binary_manager.shutil.which")
+    def test_version_failure_still_returns_binary_info(self, mock_which, mock_run):
+        """Test that a failed dbt --version still returns LspBinaryInfo with empty version."""
+        mock_which.return_value = "/usr/bin/dbt"
+        mock_run.side_effect = [
+            Mock(returncode=0),  # dbt lsp --help succeeds
+            Mock(returncode=1),  # dbt --version fails
+        ]
+
+        result = detect_fusion_lsp("dbt")
+
+        assert result is not None
+        assert result.cmd == ["dbt", "lsp"]
+        assert result.version == ""
 
 
 class TestDbtLspBinaryInfo:

--- a/tests/unit/lsp/test_lsp_connection.py
+++ b/tests/unit/lsp/test_lsp_connection.py
@@ -137,14 +137,14 @@ class TestLSPConnectionInitialization:
         binary_path.touch()
 
         conn = SocketLSPConnection(
-            binary_path=str(binary_path),
+            cmd=[str(binary_path)],
             cwd="/test/dir",
             args=["--arg1", "--arg2"],
             connection_timeout=15,
             default_request_timeout=60,
         )
 
-        assert conn.binary_path == binary_path
+        assert conn.cmd == [str(binary_path)]
         assert conn.cwd == "/test/dir"
         assert conn.args == ["--arg1", "--arg2"]
         assert conn.host == "127.0.0.1"
@@ -163,7 +163,7 @@ class TestSocketSetup:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         with patch("socket.socket") as mock_socket_class:
             mock_socket = MagicMock()
@@ -195,7 +195,7 @@ class TestProcessLaunching:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test/dir")
+        conn = SocketLSPConnection([str(binary_path)], "/test/dir")
         conn.port = 12345
 
         with patch("asyncio.create_subprocess_exec") as mock_create_subprocess:
@@ -208,7 +208,7 @@ class TestProcessLaunching:
             # Verify process was started with correct arguments
             mock_create_subprocess.assert_called_once_with(
                 str(binary_path), "--socket", "12345", "--project-dir", "/test/dir"
-            )
+            )  # cmd=[str(binary_path)] is spread, so Fusion would add "lsp" here
 
             assert conn.process == mock_process
 
@@ -222,7 +222,7 @@ class TestStartStop:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Mock socket setup
         mock_socket = MagicMock()
@@ -264,7 +264,7 @@ class TestStartStop:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()  # Simulate already running
 
         with (
@@ -282,7 +282,7 @@ class TestStartStop:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test", connection_timeout=0.1)
+        conn = SocketLSPConnection([str(binary_path)], "/test", connection_timeout=0.1)
 
         mock_socket = MagicMock()
         mock_socket.getsockname.return_value = ("127.0.0.1", 54321)
@@ -309,7 +309,7 @@ class TestStartStop:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Setup mocks for running state
         conn.process = MagicMock()
@@ -355,7 +355,7 @@ class TestStartStop:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Setup mock process that doesn't terminate
         mock_process = MagicMock()
@@ -382,7 +382,7 @@ class TestInitializeMethod:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()  # Simulate running
 
         # Mock send_request to return capabilities
@@ -426,7 +426,7 @@ class TestInitializeMethod:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()
         conn.state.initialized = True
 
@@ -442,7 +442,7 @@ class TestMessageParsing:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Create a valid LSP message
         content = '{"jsonrpc":"2.0","id":1,"result":{"test":true}}'
@@ -461,7 +461,7 @@ class TestMessageParsing:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         buffer = b"Content-Length: 50\r\n"  # Missing \r\n\r\n
 
@@ -475,7 +475,7 @@ class TestMessageParsing:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         content = '{"jsonrpc":"2.0","id":1,"result":{"test":true}}'
         header = f"Content-Length: {len(content)}\r\n\r\n"
@@ -492,7 +492,7 @@ class TestMessageParsing:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         content = '{"invalid json'
         header = f"Content-Length: {len(content)}\r\n\r\n"
@@ -508,7 +508,7 @@ class TestMessageParsing:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         buffer = b'Some-Header: value\r\n\r\n{"test":true}'
 
@@ -522,7 +522,7 @@ class TestMessageParsing:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Create two messages
         content1 = '{"jsonrpc":"2.0","id":1,"result":true}'
@@ -553,7 +553,7 @@ class TestMessageHandling:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Create a pending request
         future = asyncio.Future()
@@ -582,7 +582,7 @@ class TestMessageHandling:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Create a pending request
         future = asyncio.Future()
@@ -609,7 +609,7 @@ class TestMessageHandling:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Handle response with unknown ID
         message = JsonRpcMessage(id=999, result={"test": True})
@@ -629,7 +629,7 @@ class TestMessageHandling:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Create futures waiting for compile complete event
         future1 = asyncio.Future()
@@ -671,7 +671,7 @@ class TestMessageHandling:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Handle unknown notification
         message = JsonRpcMessage(method="unknown/notification", params={"data": "test"})
@@ -689,7 +689,7 @@ class TestSendRequest:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()  # Simulate running
 
         with (
@@ -719,7 +719,7 @@ class TestSendRequest:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         # process is None - not running
 
         with pytest.raises(RuntimeError, match="LSP server is not running"):
@@ -753,7 +753,7 @@ class TestSendNotification:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()
 
         with patch.object(conn, "_send_message") as mock_send:
@@ -774,7 +774,7 @@ class TestSendNotification:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         # process is None - not running
 
         with pytest.raises(RuntimeError, match="LSP server is not running"):
@@ -789,7 +789,7 @@ class TestWaitForNotification:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         with patch("asyncio.get_running_loop") as mock_get_loop:
             mock_loop = MagicMock()
@@ -816,7 +816,7 @@ class TestSendMessage:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn._outgoing_queue = MagicMock()
 
         message = JsonRpcMessage(id=1, method="test", params={"key": "value"})
@@ -843,7 +843,7 @@ class TestShutdown:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         with patch.object(conn, "_send_message") as mock_send:
             conn._send_shutdown_request()
@@ -872,7 +872,7 @@ class TestIsRunning:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()
         conn.process.returncode = None
 
@@ -883,7 +883,7 @@ class TestIsRunning:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         assert conn.is_running() is False
 
@@ -892,7 +892,7 @@ class TestIsRunning:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()
         conn.process.returncode = 0
 
@@ -908,7 +908,7 @@ class TestReadWriteLoops:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Setup mock connection
         mock_connection = MagicMock()
@@ -952,7 +952,7 @@ class TestReadWriteLoops:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Setup mock connection
         mock_connection = MagicMock()
@@ -993,7 +993,7 @@ class TestEdgeCases:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()
 
         # Track sent messages
@@ -1040,7 +1040,7 @@ class TestEdgeCases:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
         conn.process = MagicMock()
         conn.process.terminate = MagicMock()
         conn.process.wait = AsyncMock()
@@ -1061,7 +1061,7 @@ class TestEdgeCases:
         binary_path = tmp_path / "lsp"
         binary_path.touch()
 
-        conn = SocketLSPConnection(str(binary_path), "/test")
+        conn = SocketLSPConnection([str(binary_path)], "/test")
 
         # Create message with unicode
         content = '{"jsonrpc":"2.0","method":"test","params":{"text":"Hello 世界 🚀"}}'

--- a/tests/unit/tools/test_tool_names.py
+++ b/tests/unit/tools/test_tool_names.py
@@ -22,7 +22,7 @@ async def test_tool_names_match_server_tools(env_setup):
         ),
         patch(
             "dbt_mcp.config.config.dbt_lsp_binary_info",
-            return_value=LspBinaryInfo(path="/path/to/lsp", version="1.0.0"),
+            return_value=LspBinaryInfo(cmd=["/path/to/lsp"], version="1.0.0"),
         ),
     ):
         config = load_config(enable_proxied_tools=False)

--- a/tests/unit/tools/test_toolsets.py
+++ b/tests/unit/tools/test_toolsets.py
@@ -47,7 +47,7 @@ async def test_toolsets_match_server_tools(env_setup):
         ),
         patch(
             "dbt_mcp.config.config.dbt_lsp_binary_info",
-            return_value=LspBinaryInfo(path="/path/to/lsp", version="1.0.0"),
+            return_value=LspBinaryInfo(cmd=["/path/to/lsp"], version="1.0.0"),
         ),
     ):
         config = load_config(enable_proxied_tools=False)


### PR DESCRIPTION
## Summary

- Adds `detect_fusion_lsp(dbt_path)` which probes `dbt lsp --help` to check if the installed dbt CLI is Fusion
- Changes `LspBinaryInfo.path: str` → `LspBinaryInfo.cmd: list[str]` so Fusion (`["dbt", "lsp"]`) and legacy (`["/path/to/dbt-lsp"]`) are handled uniformly by `SocketLSPConnection`
- Updates detection order: Fusion CLI → `DBT_LSP_PATH` → editor storage paths (VS Code / Cursor / Windsurf)
- Passes `settings.dbt_path` (`DBT_PATH`) into `dbt_lsp_binary_info()` so a custom dbt binary location is respected consistently across CLI tools and LSP

## Test plan

- [ ] New unit tests for `detect_fusion_lsp`: dbt in PATH + exit 0, dbt not in PATH, non-Fusion dbt (exit non-0), custom `dbt_path`, subprocess timeout
- [ ] Updated `TestDbtLspBinaryInfo` covers the new three-step resolution order
- [ ] All existing LSP tests updated to use `cmd` instead of `binary_path`/`path`
- [ ] `task check` passes (ruff, mypy, pre-commit)
- [ ] Full unit test suite passes (544 tests)

Closes #732