### PR TITLE
fix: catch NotFoundError in artifact fetchers to restore get_job_run_error output

### DIFF
--- a/.changes/unreleased/Bug Fix-20260427-150913.yaml
+++ b/.changes/unreleased/Bug Fix-20260427-150913.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix get_job_run_error returning empty failed_steps when artifact 404s raise NotFoundError
+time: 2026-04-27T15:09:13.154529+02:00

--- a/src/dbt_mcp/dbt_admin/run_artifacts/parser.py
+++ b/src/dbt_mcp/dbt_admin/run_artifacts/parser.py
@@ -21,7 +21,7 @@ from dbt_mcp.dbt_admin.run_artifacts.config import (
     RunStepSchema,
     SourcesArtifactSchema,
 )
-from dbt_mcp.errors import ArtifactRetrievalError
+from dbt_mcp.errors import ArtifactRetrievalError, NotFoundError
 from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ class JobRunFetcher:
                 logger.info(f"Got run_results.json from step {step_index}")
                 return run_results_content
             return None
-        except ArtifactRetrievalError as e:
+        except (ArtifactRetrievalError, NotFoundError) as e:
             logger.debug(f"No run_results.json for step {step_index}: {e}")
             return None
 
@@ -107,7 +107,7 @@ class JobRunFetcher:
                 logger.info(f"Got sources.json from step {step_index}")
                 return sources_content
             return None
-        except ArtifactRetrievalError as e:
+        except (ArtifactRetrievalError, NotFoundError) as e:
             logger.debug(f"No sources.json for step {step_index}: {e}")
             return None
 

--- a/tests/unit/dbt_admin/run_artifacts/test_error_fetcher.py
+++ b/tests/unit/dbt_admin/run_artifacts/test_error_fetcher.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from dbt_mcp.dbt_admin.run_artifacts.parser import ErrorFetcher
-from dbt_mcp.errors import ArtifactRetrievalError
+from dbt_mcp.errors import ArtifactRetrievalError, NotFoundError
 
 
 @pytest.mark.parametrize(
@@ -195,3 +195,48 @@ async def test_schema_validation_failure(mock_client, admin_config):
     assert step["step_name"] == "Invoke dbt with `dbt build`"
     assert "run_results.json not available" in step["results"][0]["message"]
     assert "Model compilation failed" in step["results"][0]["truncated_logs"]
+
+
+async def test_not_found_error_treated_as_missing_artifact(mock_client, admin_config):
+    """Regression test: NotFoundError (404) from get_job_run_artifact must be caught.
+
+    In v1.15, get_job_run_artifact started raising NotFoundError for 404 responses
+    instead of ArtifactRetrievalError. If _fetch_run_results_artifact only catches
+    ArtifactRetrievalError, the NotFoundError propagates into asyncio.gather and
+    causes every failed step to be silently dropped, returning {"failed_steps": []}.
+    """
+    run_details = {
+        "id": 500,
+        "status": 20,
+        "is_cancelled": False,
+        "finished_at": "2024-01-01T12:00:00Z",
+        "run_steps": [
+            {
+                "index": 1,
+                "name": "Invoke dbt with `dbt run`",
+                "status": 20,
+                "finished_at": "2024-01-01T12:00:00Z",
+                "logs": "Error in model my_model",
+            }
+        ],
+    }
+
+    mock_client.get_job_run_artifact = AsyncMock(
+        side_effect=NotFoundError("Artifact not found for run 500")
+    )
+
+    error_fetcher = ErrorFetcher(
+        run_id=500,
+        run_details=run_details,
+        client=mock_client,
+        admin_api_config=admin_config,
+    )
+
+    result = await error_fetcher.analyze_run_errors()
+
+    # Should fall back to logs rather than returning empty failed_steps
+    assert len(result["failed_steps"]) == 1
+    step = result["failed_steps"][0]
+    assert step["step_name"] == "Invoke dbt with `dbt run`"
+    assert "run_results.json not available" in step["results"][0]["message"]
+    assert "Error in model my_model" in step["results"][0]["truncated_logs"]


### PR DESCRIPTION
## Why

In v1.15, two changes combined to break `get_job_run_error`:

1. `get_job_run_artifact` was changed to raise `NotFoundError` for 404 responses instead of `ArtifactRetrievalError` (#729)
2. `JobRunFetcher._fetch_run_results_artifact` and `_fetch_sources_artifact` only caught `ArtifactRetrievalError`

When a step's artifact returns 404 (normal for many steps), the uncaught `NotFoundError` propagated into `asyncio.gather(..., return_exceptions=True)`, which treated each step as a failed exception and skipped it — resulting in `{"failed_steps": []}` even for genuinely failed runs.

Fixes #740

## What

- Catch `(ArtifactRetrievalError, NotFoundError)` in both `_fetch_run_results_artifact` and `_fetch_sources_artifact` so 404s fall back to log-based error output as intended
- Add regression test that verifies `NotFoundError` from `get_job_run_artifact` is handled gracefully

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation if required
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes