### PR TITLE
ci: make integration test check blocking for fork PRs

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-104220.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-104220.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: 'Make integration test check blocking for fork PRs: fail early instead of skipping when ok-to-test label is absent'
+time: 2026-04-28T10:42:20.688843+02:00

--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -4,8 +4,9 @@ name: Integration tests
 # 1. Internal PRs (same repo): Runs automatically via pull_request trigger
 # 2. Fork PRs: Requires 'ok-to-test' label added by maintainer (pull_request_target)
 #
-# Fork PRs via pull_request are skipped (not failed) to avoid confusing status checks.
-# This protects secrets from being exfiltrated by malicious fork PRs.
+# Fork PRs via pull_request run but fail early (before checkout) until approved.
+# This makes the check blocking rather than showing as a green skip.
+# Secrets are never exposed — the auth gate runs before any checkout of fork code.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -26,12 +27,12 @@ permissions:
 
 jobs:
   integration:
-    # Only run for:
-    # 1. pull_request_target from fork PRs (with ok-to-test label)
-    # 2. pull_request from internal PRs (not forks)
+    # Run for:
+    # 1. pull_request_target from fork PRs (triggered by ok-to-test label)
+    # 2. pull_request from any PR — fork PRs fail at the auth gate before checkout
     if: |
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     environment: integration
     permissions:

--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -6,7 +6,7 @@ name: Integration tests
 #
 # Fork PRs via pull_request run but fail early (before checkout) until approved.
 # This makes the check blocking rather than showing as a green skip.
-# Secrets are never exposed — the auth gate runs before any checkout of fork code.
+# Secrets are not exposed to fork PRs until the ok-to-test gate passes.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -28,18 +28,20 @@ permissions:
 jobs:
   integration:
     # Run for:
-    # 1. pull_request_target from fork PRs (triggered by ok-to-test label)
-    # 2. pull_request from any PR — fork PRs fail at the auth gate before checkout
+    # 1. pull_request_target from fork PRs when the ok-to-test label is applied
+    # 2. pull_request from any PR — fork PRs fail at the auth gate step before checkout
     if: |
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name != github.repository &&
+       github.event.label.name == 'ok-to-test') ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     environment: integration
     permissions:
       contents: read
     steps:
-      # Gate: Block fork PRs that come through pull_request (no secrets, no label check)
-      # This is a safety net - the job-level `if` should skip these, but this ensures they fail if reached
+      # Gate: Block fork PRs that come through pull_request (no secrets, no label check).
+      # Fork PRs intentionally reach this step and fail here until ok-to-test is added.
       - name: Check fork PR authorization
         if: |
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary

- Fork PRs without the `ok-to-test` label currently show the integration test check as **skipped**, which GitHub treats as passing — making the PR look green when integration tests haven't run
- Remove `&& github.event.pull_request.head.repo.full_name == github.repository` from the job-level `if`, so the job runs for all `pull_request` events (including forks)
- For unapproved fork PRs, the existing "Check fork PR authorization" step fails immediately with `exit 1` before `actions/checkout`, making the check **blocking** instead of silently green
- No security change: fork code is never checked out until after the label gate passes via `pull_request_target`

## Test plan

- [ ] Fork PR without `ok-to-test` label → integration check shows as failed, not skipped
- [ ] Fork PR with `ok-to-test` label added → `pull_request_target` fires, integration tests run normally
- [ ] Internal PR (same repo) → integration tests run automatically as before