### PR TITLE
Fix dev env retrieval

### DIFF
--- a/.changes/unreleased/Bug Fix-20260501-145042.yaml
+++ b/.changes/unreleased/Bug Fix-20260501-145042.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix dev env retrieval
+time: 2026-05-01T14:50:42.714358-05:00

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -82,9 +82,6 @@ class DbtAdminAPIClient:
         """Resolve prod and dev environments from a list of environment responses.
 
         Returns a tuple of (prod_environment, dev_environment).
-
-        Auto-detects prod based on deployment_type == "production".
-        Dev environment is auto-detected based on deployment_type == "development".
         """
         prod_environment: DbtPlatformEnvironment | None = None
         dev_environment: DbtPlatformEnvironment | None = None

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -102,14 +102,11 @@ class DbtAdminAPIClient:
                 break
 
         for environment in environments:
-            if (
-                environment.deployment_type
-                and environment.deployment_type.lower() == "development"
-            ):
+            if environment.type and environment.type.lower() == "development":
                 dev_environment = DbtPlatformEnvironment(
                     id=environment.id,
                     name=environment.name,
-                    deployment_type=environment.deployment_type,
+                    deployment_type=None,
                 )
                 break
 

--- a/src/dbt_mcp/oauth/dbt_platform.py
+++ b/src/dbt_mcp/oauth/dbt_platform.py
@@ -46,7 +46,7 @@ class DbtPlatformEnvironmentResponse(BaseModel):
 class DbtPlatformEnvironment(BaseModel):
     id: int
     name: str
-    deployment_type: str
+    deployment_type: str | None
 
 
 class SelectedProjectsRequest(BaseModel):


### PR DESCRIPTION
## Summary

This PR fixes the retrieval of development environments to align with the actual return types of the dbt admin API.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes