### PR TITLE
fix: don't merge stderr into stdout in subprocess calls

### DIFF
--- a/.changes/unreleased/Bug Fix-20260504-111117.yaml
+++ b/.changes/unreleased/Bug Fix-20260504-111117.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix build/run/test tools returning urllib3 warnings instead of 'OK' on success when using externalbrowser auth
+time: 2026-05-04T11:11:17.317214+02:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -104,7 +104,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
                 args=args,
                 cwd=cwd_path,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.PIPE,
                 stdin=subprocess.DEVNULL,
                 text=True,
             )

--- a/src/dbt_mcp/dbt_codegen/tools.py
+++ b/src/dbt_mcp/dbt_codegen/tools.py
@@ -53,7 +53,7 @@ def create_dbt_codegen_tool_definitions(
                 args=args_list,
                 cwd=cwd_path,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.PIPE,
                 stdin=subprocess.DEVNULL,
                 text=True,
             )

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -519,6 +519,8 @@ def test_stderr_not_merged_into_stdout(monkeypatch: MonkeyPatch, mock_fastmcp):
     captured_kwargs: dict = {}
 
     class MockProcessWithStderrWarning:
+        returncode = 0
+
         def communicate(self, timeout=None):
             return "", "urllib3 v2.0 only supports OpenSSL 1.1.1+: NotOpenSSLWarning"
 
@@ -543,6 +545,36 @@ def test_stderr_not_merged_into_stdout(monkeypatch: MonkeyPatch, mock_fastmcp):
 
     assert captured_kwargs.get("stderr") == subprocess.PIPE
     assert result == "OK"
+
+
+def test_failure_output_returned_when_dbt_errors(
+    monkeypatch: MonkeyPatch, mock_fastmcp
+):
+    class MockProcessWithFailure:
+        returncode = 1
+
+        def communicate(self, timeout=None):
+            return "Compilation Error in model my_model", ""
+
+    def mock_popen(args, **kwargs):
+        return MockProcessWithFailure()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+    build_tool = tools["build"]
+
+    result = build_tool()
+
+    assert result == "Compilation Error in model my_model"
 
 
 def test_clone_command_binary_state_path_logic(

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -515,6 +515,36 @@ def test_yml_selector_not_added_when_none(
     assert "--selector" not in args_list
 
 
+def test_stderr_not_merged_into_stdout(monkeypatch: MonkeyPatch, mock_fastmcp):
+    captured_kwargs: dict = {}
+
+    class MockProcessWithStderrWarning:
+        def communicate(self, timeout=None):
+            return "", "urllib3 v2.0 only supports OpenSSL 1.1.1+: NotOpenSSLWarning"
+
+    def mock_popen(args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return MockProcessWithStderrWarning()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+    build_tool = tools["build"]
+
+    result = build_tool()
+
+    assert captured_kwargs.get("stderr") == subprocess.PIPE
+    assert result == "OK"
+
+
 def test_clone_command_binary_state_path_logic(
     monkeypatch: MonkeyPatch,
     mock_process,

--- a/tests/unit/dbt_codegen/test_tools.py
+++ b/tests/unit/dbt_codegen/test_tools.py
@@ -437,6 +437,45 @@ def test_stderr_not_merged_into_stdout(monkeypatch: MonkeyPatch, mock_fastmcp):
     assert result == "OK"
 
 
+def test_failure_output_returned_when_dbt_errors(
+    monkeypatch: MonkeyPatch, mock_fastmcp
+):
+    """Test that stdout error output is surfaced correctly on failure."""
+
+    class MockProcessWithFailure:
+        returncode = 1
+
+        def communicate(self, timeout=None):
+            return "macro not found: generate_source", ""
+
+    def mock_popen(args, **kwargs):
+        return MockProcessWithFailure()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, _ = mock_fastmcp
+    register_dbt_codegen_tools(
+        fastmcp,
+        mock_dbt_codegen_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+    generate_source_tool = fastmcp.tools["generate_source"]
+
+    result = generate_source_tool(
+        schema_name="test_schema",
+        database_name=None,
+        table_names=None,
+        generate_columns=False,
+        include_descriptions=False,
+    )
+
+    assert "macro not found: generate_source" in result
+    assert result != "OK"
+
+
 def test_all_tools_registered(mock_fastmcp):
     """Test that all expected tools are registered."""
     fastmcp, _ = mock_fastmcp

--- a/tests/unit/dbt_codegen/test_tools.py
+++ b/tests/unit/dbt_codegen/test_tools.py
@@ -398,6 +398,45 @@ def test_absolute_path_handling(monkeypatch: MonkeyPatch, mock_process, mock_fas
     assert captured_kwargs["cwd"] == "/test/project"
 
 
+def test_stderr_not_merged_into_stdout(monkeypatch: MonkeyPatch, mock_fastmcp):
+    """Test that stderr (e.g. urllib3 warnings) doesn't pollute stdout on success."""
+    captured_kwargs: dict = {}
+
+    class MockProcessWithStderrWarning:
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return "", "urllib3 v2.0 only supports OpenSSL 1.1.1+: NotOpenSSLWarning"
+
+    def mock_popen(args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return MockProcessWithStderrWarning()
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, _ = mock_fastmcp
+    register_dbt_codegen_tools(
+        fastmcp,
+        mock_dbt_codegen_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+    generate_source_tool = fastmcp.tools["generate_source"]
+
+    result = generate_source_tool(
+        schema_name="test_schema",
+        database_name=None,
+        table_names=None,
+        generate_columns=False,
+        include_descriptions=False,
+    )
+
+    assert captured_kwargs.get("stderr") == subprocess.PIPE
+    assert result == "OK"
+
+
 def test_all_tools_registered(mock_fastmcp):
     """Test that all expected tools are registered."""
     fastmcp, _ = mock_fastmcp


### PR DESCRIPTION
## Summary

Closes #749

- Changed `stderr=subprocess.STDOUT` to `stderr=subprocess.PIPE` in `_run_dbt_command` (dbt CLI tools) and `_run_codegen_operation` (dbt codegen tools)
- This prevents Python-level warnings (e.g. `urllib3` `NotOpenSSLWarning` from the Snowflake `externalbrowser` authenticator) from being merged into stdout
- With `--quiet`, dbt produces no stdout on a successful run, so `output or "OK"` now correctly returns `"OK"` instead of the leaked warning string

## Test plan

- [ ] Unit tests added for both `dbt_cli` and `dbt_codegen`: simulate empty stdout + stderr warning and assert the tool returns `"OK"` and that `Popen` is called with `stderr=subprocess.PIPE`
- [ ] Run `task test:unit` — all 601 tests pass
- [ ] Run `task check` — linting and type checking pass