### PR TITLE
fix: improve input validation and logging for dbt CLI tool parameters

### DIFF
--- a/.changes/unreleased/Bug Fix-20260505-153711.yaml
+++ b/.changes/unreleased/Bug Fix-20260505-153711.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Improve input validation for dbt CLI tool parameters and reduce verbosity of argument logging.
+time: 2026-05-05T15:37:11.024363+02:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -30,7 +30,10 @@ logger = logging.getLogger(__name__)
 
 _VALID_RESOURCE_TYPES = frozenset(
     {
+        "all",
         "analysis",
+        "default",
+        "exposure",
         "function",
         "metric",
         "model",

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -28,6 +28,22 @@ from dbt_mcp.tools.toolsets import Toolset
 
 logger = logging.getLogger(__name__)
 
+_VALID_RESOURCE_TYPES = frozenset(
+    {
+        "analysis",
+        "function",
+        "metric",
+        "model",
+        "saved_query",
+        "seed",
+        "semantic_model",
+        "snapshot",
+        "source",
+        "test",
+        "unit_test",
+    }
+)
+
 
 def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition]:
     def _run_dbt_command(
@@ -76,13 +92,23 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
 
             if node_selection and isinstance(node_selection, str):
                 selector_params = node_selection.split(" ")
+                if any(t.startswith("-") for t in selector_params):
+                    raise InvalidParameterError(
+                        "node_selection contains an invalid token. Tokens must not start with '-'."
+                    )
                 command.extend(["--select"] + selector_params)
 
             if yml_selector and isinstance(yml_selector, str):
                 command.extend(["--selector", yml_selector])
 
             if isinstance(resource_type, Iterable):
-                command.extend(["--resource-type"] + resource_type)
+                rt_list = list(resource_type)
+                if invalid := [v for v in rt_list if v not in _VALID_RESOURCE_TYPES]:
+                    raise InvalidParameterError(
+                        f"resource_type contains invalid values: {invalid}. "
+                        f"Allowed values: {sorted(_VALID_RESOURCE_TYPES)}"
+                    )
+                command.extend(["--resource-type"] + rt_list)
 
             full_command = command.copy()
             # Add --quiet flag to specific commands to reduce context window usage

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -91,7 +91,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
                 command.extend(["--vars", vars])
 
             if node_selection and isinstance(node_selection, str):
-                selector_params = node_selection.split(" ")
+                selector_params = node_selection.split()
                 if any(t.startswith("-") for t in selector_params):
                     raise InvalidParameterError(
                         "node_selection contains an invalid token. Tokens must not start with '-'."
@@ -101,7 +101,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             if yml_selector and isinstance(yml_selector, str):
                 command.extend(["--selector", yml_selector])
 
-            if isinstance(resource_type, Iterable):
+            if isinstance(resource_type, Iterable) and not isinstance(
+                resource_type, str
+            ):
                 rt_list = list(resource_type)
                 if invalid := [v for v in rt_list if v not in _VALID_RESOURCE_TYPES]:
                     raise InvalidParameterError(

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -30,6 +30,12 @@ from dbt_mcp.tracking.tracking import DefaultUsageTracker, ToolCalledEvent, Usag
 
 logger = logging.getLogger(__name__)
 
+_REDACT_ARGS: frozenset[str] = frozenset({"sql_query", "vars"})
+
+
+def _safe_args(arguments: dict[str, Any]) -> dict[str, Any]:
+    return {k: "***" if k in _REDACT_ARGS else v for k, v in arguments.items()}
+
 
 class DbtMCP(FastMCP):
     def __init__(
@@ -75,7 +81,7 @@ class DbtMCP(FastMCP):
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
     ) -> Sequence[ContentBlock] | dict[str, Any]:
-        logger.info(f"Calling tool: {name} with arguments: {arguments}")
+        logger.info(f"Calling tool: {name} with arguments: {_safe_args(arguments)}")
         result = None
         start_time = int(time.time() * 1000)
         try:
@@ -86,7 +92,7 @@ class DbtMCP(FastMCP):
         except Exception as e:
             end_time = int(time.time() * 1000)
             logger.error(
-                f"Error calling tool: {name} with arguments: {arguments} "
+                f"Error calling tool: {name} with arguments: {_safe_args(arguments)} "
                 + f"in {end_time - start_time}ms: {e}"
             )
             try:

--- a/src/dbt_mcp/prompts/dbt_cli/args/resource_type.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/resource_type.md
@@ -12,5 +12,6 @@ We can pick any from the following and need to return a list of all the resource
 - exposure
 - snapshot
 - seed
+- function
 - default
 - all

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -23,6 +23,8 @@ from dbt_mcp.tools.toolsets import Toolset, proxied_tools
 
 logger = logging.getLogger(__name__)
 
+_REDACT_ARGS: frozenset[str] = frozenset({"sql_query", "vars"})
+
 
 @dataclass
 class ToolCalledEvent:
@@ -99,7 +101,8 @@ class DefaultUsageTracker:
             return
         try:
             arguments_mapping: Mapping[str, str] = {
-                k: json.dumps(v) for k, v in tool_called_event.arguments.items()
+                k: ("***" if k in _REDACT_ARGS else json.dumps(v))
+                for k, v in tool_called_event.arguments.items()
             }
             event_id = str(uuid.uuid4())
             dbt_cloud_account_id = (

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -101,7 +101,7 @@ class DefaultUsageTracker:
             return
         try:
             arguments_mapping: Mapping[str, str] = {
-                k: ("***" if k in _REDACT_ARGS else json.dumps(v))
+                k: (json.dumps("***") if k in _REDACT_ARGS else json.dumps(v))
                 for k, v in tool_called_event.arguments.items()
             }
             event_id = str(uuid.uuid4())

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -595,3 +595,118 @@ def test_clone_command_binary_state_path_logic(
 
     assert "--state" in mock_calls[0]
     assert "/some/state/path" in mock_calls[0]
+
+
+@pytest.mark.parametrize(
+    "injection_payload",
+    [
+        "--profiles-dir /tmp/custom",
+        "--project-dir /tmp/custom",
+        "--target custom",
+        "my_model --profiles-dir /tmp/custom",
+        "-x",
+    ],
+)
+def test_node_selection_rejects_flag_injection(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, injection_payload
+):
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_process)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    with pytest.raises(InvalidParameterError, match="must not start with '-'"):
+        tools["run"](node_selection=injection_payload)
+
+
+@pytest.mark.parametrize(
+    "valid_selection",
+    [
+        "my_model",
+        "my_model my_other_model",
+        "+my_model",
+        "my_model+",
+        "1+my_model+1",
+        "tag:nightly",
+        "config.materialized:table",
+        "path/to/models/",
+        "source:my_source",
+        "@my_model",
+    ],
+)
+def test_node_selection_accepts_valid_tokens(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, valid_selection
+):
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_process)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    tools["run"](node_selection=valid_selection)
+
+
+@pytest.mark.parametrize(
+    "injection_payload",
+    [
+        ["model", "--profiles-dir", "/tmp/custom"],
+        ["--target", "custom"],
+    ],
+)
+def test_resource_type_rejects_flag_injection(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, injection_payload
+):
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_process)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    with pytest.raises(InvalidParameterError, match="invalid values"):
+        tools["ls"](resource_type=injection_payload)
+
+
+@pytest.mark.parametrize(
+    "valid_types",
+    [
+        ["model"],
+        ["model", "snapshot"],
+        ["source", "seed", "test"],
+        ["semantic_model", "metric", "saved_query"],
+    ],
+)
+def test_resource_type_accepts_valid_values(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, valid_types
+):
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_process)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    tools["ls"](resource_type=valid_types)

--- a/tests/unit/mcp/test_dispatcher.py
+++ b/tests/unit/mcp/test_dispatcher.py
@@ -229,3 +229,25 @@ class TestAppLifespanLogging:
             "Expected exc_info to be set so the full traceback appears in the log, "
             "not just the (empty) exception message"
         )
+
+
+class TestArgLogging:
+    async def test_sensitive_args_not_logged(self, caplog):
+        single = MagicMock(spec=FastMCP)
+        single.call_tool = AsyncMock(return_value=[TextContent(type="text", text="ok")])
+        dispatcher = _make_dispatcher(single_project_mcp=single)
+
+        with (
+            patch.object(
+                dispatcher, "_is_multi_project", AsyncMock(return_value=False)
+            ),
+            caplog.at_level(logging.INFO, logger="dbt_mcp.mcp.server"),
+        ):
+            await dispatcher.call_tool(
+                "show",
+                {"sql_query": "SELECT id FROM my_model", "limit": 5},
+            )
+
+        assert "SELECT id FROM my_model" not in caplog.text
+        assert "***" in caplog.text
+        assert "limit" in caplog.text

--- a/tests/unit/tracking/test_tracking.py
+++ b/tests/unit/tracking/test_tracking.py
@@ -594,3 +594,41 @@ class TestUsageTracker:
         mock_log_proto.assert_called_once()
         tool_called = mock_log_proto.call_args.args[0]
         assert tool_called.tool_name == "list_metrics"
+
+    @pytest.mark.asyncio
+    async def test_sql_query_and_vars_redacted_in_telemetry(self):
+        """sql_query and vars values are redacted; keys and other args are kept."""
+        mock_settings = DbtMcpSettings.model_construct(
+            do_not_track=None,
+            send_anonymous_usage_data=None,
+        )
+        tracker = DefaultUsageTracker(
+            credentials_provider=MockCredentialsProvider(mock_settings),
+            session_id=uuid.uuid4(),
+        )
+
+        with (
+            patch("dbt_mcp.tracking.tracking.log_proto") as mock_log_proto,
+            patch(
+                "dbt_mcp.tracking.tracking.DefaultUsageTracker._get_local_user_id",
+                return_value="local-user",
+            ),
+        ):
+            await tracker.emit_tool_called_event(
+                tool_called_event=ToolCalledEvent(
+                    tool_name="show",
+                    arguments={
+                        "sql_query": "SELECT id FROM my_model",
+                        "vars": '{"my_var": "my_value"}',
+                        "limit": 5,
+                    },
+                    start_time_ms=0,
+                    end_time_ms=1,
+                    error_message=None,
+                ),
+            )
+
+        tool_called = mock_log_proto.call_args.args[0]
+        assert tool_called.arguments["sql_query"] == "***"
+        assert tool_called.arguments["vars"] == "***"
+        assert tool_called.arguments["limit"] == "5"

--- a/tests/unit/tracking/test_tracking.py
+++ b/tests/unit/tracking/test_tracking.py
@@ -629,6 +629,6 @@ class TestUsageTracker:
             )
 
         tool_called = mock_log_proto.call_args.args[0]
-        assert tool_called.arguments["sql_query"] == "***"
-        assert tool_called.arguments["vars"] == "***"
+        assert tool_called.arguments["sql_query"] == '"***"'
+        assert tool_called.arguments["vars"] == '"***"'
         assert tool_called.arguments["limit"] == "5"


### PR DESCRIPTION
## Summary

- Validates `node_selection` tokens to reject arguments starting with `-`, preventing unintended flag injection into dbt subprocess calls
- Validates `resource_type` values against the known set of dbt resource types
- Reduces verbosity of argument logging in the server and telemetry by omitting specific parameter values