### PR TITLE
Move Admin API parameter docs into MCP tool schemas with shared descriptions

### DIFF
--- a/.changes/unreleased/Bug Fix-20260506-090056.yaml
+++ b/.changes/unreleased/Bug Fix-20260506-090056.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Move client_session_context out of client/main.py so importing it in tests no longer requires OPENAI_API_KEY.
+time: 2026-05-06T09:00:56.84291-05:00

--- a/.changes/unreleased/Bug Fix-20260506-090056.yaml
+++ b/.changes/unreleased/Bug Fix-20260506-090056.yaml
@@ -1,3 +1,0 @@
-kind: Bug Fix
-body: Move client_session_context out of client/main.py so importing it in tests no longer requires OPENAI_API_KEY.
-time: 2026-05-06T09:00:56.84291-05:00

--- a/.changes/unreleased/Enhancement or New Feature-20260505-142119.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260505-142119.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Move Admin API parameter docs into MCP tool schemas with shared descriptions
+time: 2026-05-05T14:21:19.139218-05:00

--- a/src/client/main.py
+++ b/src/client/main.py
@@ -1,20 +1,13 @@
 import asyncio
 import json
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from time import time
 
-from mcp.client.session import ClientSession
-from mcp.shared.memory import (
-    create_connected_server_and_client_session as client_session,
-)
 from openai import OpenAI
 from openai.types.responses.response_input_param import FunctionCallOutput
 from openai.types.responses.response_output_message import ResponseOutputMessage
 
+from client.session import client_session_context
 from client.tools import map_tools
-from dbt_mcp.config.config import load_config
-from dbt_mcp.mcp.server import create_dbt_mcp
 
 LLM_MODEL = "gpt-4o-mini"
 TOOL_RESPONSE_TRUNCATION = 100  # set to None for no truncation
@@ -22,14 +15,6 @@ TOOL_RESPONSE_TRUNCATION = 100  # set to None for no truncation
 
 llm_client = OpenAI()
 messages = []
-
-
-@asynccontextmanager
-async def client_session_context() -> AsyncGenerator[ClientSession, None]:
-    config = load_config()
-    server = await create_dbt_mcp(config)
-    async with client_session(server) as client:
-        yield client
 
 
 async def main():

--- a/src/client/main.py
+++ b/src/client/main.py
@@ -1,7 +1,10 @@
 import asyncio
 import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from time import time
 
+from mcp.client.session import ClientSession
 from mcp.shared.memory import (
     create_connected_server_and_client_session as client_session,
 )
@@ -21,10 +24,16 @@ llm_client = OpenAI()
 messages = []
 
 
-async def main():
+@asynccontextmanager
+async def client_session_context() -> AsyncGenerator[ClientSession, None]:
     config = load_config()
     server = await create_dbt_mcp(config)
     async with client_session(server) as client:
+        yield client
+
+
+async def main():
+    async with client_session_context() as client:
         user_role = "user"
         available_tools = (await client.list_tools()).tools
         tools_str = "\n".join(

--- a/src/client/session.py
+++ b/src/client/session.py
@@ -1,0 +1,18 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from mcp.client.session import ClientSession
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as client_session,
+)
+
+from dbt_mcp.config.config import load_config
+from dbt_mcp.mcp.server import create_dbt_mcp
+
+
+@asynccontextmanager
+async def client_session_context() -> AsyncGenerator[ClientSession, None]:
+    config = load_config()
+    server = await create_dbt_mcp(config)
+    async with client_session(server) as client:
+        yield client

--- a/src/dbt_mcp/dbt_admin/param_descriptions.py
+++ b/src/dbt_mcp/dbt_admin/param_descriptions.py
@@ -1,0 +1,44 @@
+"""JSON Schema parameter descriptions for dbt Admin API MCP tools."""
+
+# --- Shared across tools ---
+
+PAGINATION_LIMIT = "Maximum number of results to return"
+PAGINATION_OFFSET = "Number of results to skip for pagination"
+
+JOB_DEFINITION_ID = "The dbt job definition ID"
+JOB_RUN_ID = "The dbt job run ID"
+
+# --- list_jobs_runs ---
+
+JOB_RUNS_JOB_DEFINITION_ID_FILTER = (
+    "When set, only include runs for this job definition ID"
+)
+JOB_RUN_STATUS = (
+    "Filter by run status: queued, starting, running, success, error, or cancelled"
+)
+JOB_RUNS_ORDER_BY = (
+    'Sort field (e.g. "created_at", "finished_at", "id"); prefix with "-" '
+    'for descending order (e.g. "-created_at" for newest first)'
+)
+
+# --- trigger_job_run ---
+
+TRIGGER_CAUSE = (
+    "Why this run is being triggered (recorded in run history on the dbt platform)"
+)
+TRIGGER_GIT_BRANCH = "Override the Git branch to check out for this run"
+TRIGGER_GIT_SHA = "Override the Git commit SHA to check out for this run"
+TRIGGER_SCHEMA_OVERRIDE = "Override the destination schema for this run"
+TRIGGER_STEPS_OVERRIDE = (
+    "Replace the job's default dbt commands; each entry is a full dbt command "
+    '(e.g. "dbt run --select my_model+ --full-refresh")'
+)
+
+# --- get_job_run_error ---
+
+INCLUDE_WARNINGS_WITH_ERRORS = (
+    "If true, include warning analysis together with error details"
+)
+WARNINGS_ONLY = (
+    "If true, return only warning analysis (e.g. for successful runs with warnings)"
+)

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -1,8 +1,9 @@
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from dbt_mcp.config.config_providers import (
     AdminApiConfig,
@@ -10,6 +11,22 @@ from dbt_mcp.config.config_providers import (
 )
 from dbt_mcp.dbt_admin.client import DbtAdminAPIClient
 from dbt_mcp.dbt_admin.constants import STATUS_MAP, JobRunStatus
+from dbt_mcp.dbt_admin.param_descriptions import (
+    INCLUDE_WARNINGS_WITH_ERRORS,
+    JOB_DEFINITION_ID,
+    JOB_RUN_ID,
+    JOB_RUNS_JOB_DEFINITION_ID_FILTER,
+    JOB_RUNS_ORDER_BY,
+    JOB_RUN_STATUS,
+    PAGINATION_LIMIT,
+    PAGINATION_OFFSET,
+    TRIGGER_CAUSE,
+    TRIGGER_GIT_BRANCH,
+    TRIGGER_GIT_SHA,
+    TRIGGER_SCHEMA_OVERRIDE,
+    TRIGGER_STEPS_OVERRIDE,
+    WARNINGS_ONLY,
+)
 from dbt_mcp.dbt_admin.run_artifacts import ErrorFetcher, WarningFetcher
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.tools.definitions import dbt_mcp_tool
@@ -54,8 +71,8 @@ async def list_jobs(
     context: AdminToolContext,
     # TODO: add support for project_id in the future
     # project_id: Optional[int] = None,
-    limit: int | None = None,
-    offset: int | None = None,
+    limit: Annotated[int | None, Field(description=PAGINATION_LIMIT)] = None,
+    offset: Annotated[int | None, Field(description=PAGINATION_OFFSET)] = None,
 ) -> list[dict[str, Any]]:
     """List jobs in an account."""
     admin_api_config = await context.admin_api_config_provider.get_config()
@@ -78,7 +95,10 @@ async def list_jobs(
     destructive_hint=False,
     idempotent_hint=True,
 )
-async def get_job_details(context: AdminToolContext, job_id: int) -> dict[str, Any]:
+async def get_job_details(
+    context: AdminToolContext,
+    job_id: Annotated[int, Field(description=JOB_DEFINITION_ID)],
+) -> dict[str, Any]:
     """Get details for a specific job."""
     admin_api_config = await context.admin_api_config_provider.get_config()
     return await context.admin_client.get_job_details(
@@ -95,12 +115,16 @@ async def get_job_details(context: AdminToolContext, job_id: int) -> dict[str, A
 )
 async def trigger_job_run(
     context: AdminToolContext,
-    job_id: int,
-    cause: str = "Triggered by dbt MCP",
-    git_branch: str | None = None,
-    git_sha: str | None = None,
-    schema_override: str | None = None,
-    steps_override: list[str] | None = None,
+    job_id: Annotated[int, Field(description=JOB_DEFINITION_ID)],
+    cause: Annotated[str, Field(description=TRIGGER_CAUSE)] = "Triggered by dbt MCP",
+    git_branch: Annotated[str | None, Field(description=TRIGGER_GIT_BRANCH)] = None,
+    git_sha: Annotated[str | None, Field(description=TRIGGER_GIT_SHA)] = None,
+    schema_override: Annotated[
+        str | None, Field(description=TRIGGER_SCHEMA_OVERRIDE)
+    ] = None,
+    steps_override: Annotated[
+        list[str] | None, Field(description=TRIGGER_STEPS_OVERRIDE)
+    ] = None,
 ) -> dict[str, Any]:
     """Trigger a job run."""
     admin_api_config = await context.admin_api_config_provider.get_config()
@@ -127,11 +151,13 @@ async def trigger_job_run(
 )
 async def list_jobs_runs(
     context: AdminToolContext,
-    job_id: int | None = None,
-    status: JobRunStatus | None = None,
-    limit: int | None = None,
-    offset: int | None = None,
-    order_by: str | None = None,
+    job_id: Annotated[
+        int | None, Field(description=JOB_RUNS_JOB_DEFINITION_ID_FILTER)
+    ] = None,
+    status: Annotated[JobRunStatus | None, Field(description=JOB_RUN_STATUS)] = None,
+    limit: Annotated[int | None, Field(description=PAGINATION_LIMIT)] = None,
+    offset: Annotated[int | None, Field(description=PAGINATION_OFFSET)] = None,
+    order_by: Annotated[str | None, Field(description=JOB_RUNS_ORDER_BY)] = None,
 ) -> list[dict[str, Any]]:
     """List runs in an account."""
     admin_api_config = await context.admin_api_config_provider.get_config()
@@ -161,7 +187,7 @@ async def list_jobs_runs(
 )
 async def get_job_run_details(
     context: AdminToolContext,
-    run_id: int,
+    run_id: Annotated[int, Field(description=JOB_RUN_ID)],
 ) -> dict[str, Any]:
     """Get details for a specific job run."""
     admin_api_config = await context.admin_api_config_provider.get_config()
@@ -177,7 +203,10 @@ async def get_job_run_details(
     destructive_hint=False,
     idempotent_hint=False,
 )
-async def cancel_job_run(context: AdminToolContext, run_id: int) -> dict[str, Any]:
+async def cancel_job_run(
+    context: AdminToolContext,
+    run_id: Annotated[int, Field(description=JOB_RUN_ID)],
+) -> dict[str, Any]:
     """Cancel a job run."""
     admin_api_config = await context.admin_api_config_provider.get_config()
     return await context.admin_client.cancel_job_run(
@@ -192,7 +221,10 @@ async def cancel_job_run(context: AdminToolContext, run_id: int) -> dict[str, An
     destructive_hint=False,
     idempotent_hint=False,
 )
-async def retry_job_run(context: AdminToolContext, run_id: int) -> dict[str, Any]:
+async def retry_job_run(
+    context: AdminToolContext,
+    run_id: Annotated[int, Field(description=JOB_RUN_ID)],
+) -> dict[str, Any]:
     """Retry a failed job run."""
     admin_api_config = await context.admin_api_config_provider.get_config()
     return await context.admin_client.retry_job_run(admin_api_config.account_id, run_id)
@@ -205,7 +237,10 @@ async def retry_job_run(context: AdminToolContext, run_id: int) -> dict[str, Any
     destructive_hint=False,
     idempotent_hint=True,
 )
-async def list_job_run_artifacts(context: AdminToolContext, run_id: int) -> list[str]:
+async def list_job_run_artifacts(
+    context: AdminToolContext,
+    run_id: Annotated[int, Field(description=JOB_RUN_ID)],
+) -> list[str]:
     """List artifacts for a job run."""
     admin_api_config = await context.admin_api_config_provider.get_config()
     return await context.admin_client.list_job_run_artifacts(
@@ -222,9 +257,11 @@ async def list_job_run_artifacts(context: AdminToolContext, run_id: int) -> list
 )
 async def get_job_run_error(
     context: AdminToolContext,
-    run_id: int,
-    include_warnings: bool = False,
-    warning_only: bool = False,
+    run_id: Annotated[int, Field(description=JOB_RUN_ID)],
+    include_warnings: Annotated[
+        bool, Field(description=INCLUDE_WARNINGS_WITH_ERRORS)
+    ] = False,
+    warning_only: Annotated[bool, Field(description=WARNINGS_ONLY)] = False,
 ) -> dict[str, Any]:
     """Get focused error/warning information for a job run."""
     admin_api_config = await context.admin_api_config_provider.get_config()

--- a/src/dbt_mcp/prompts/admin_api/cancel_job_run.md
+++ b/src/dbt_mcp/prompts/admin_api/cancel_job_run.md
@@ -2,10 +2,6 @@ Cancel a currently running or queued dbt run.
 
 This tool allows you to stop a run that is currently executing or waiting in the queue.
 
-## Parameters
-
-- **run_id** (required): The run ID to cancel
-
 ## Returns
 
 Updated run object showing the cancelled status and timing information.

--- a/src/dbt_mcp/prompts/admin_api/get_job_details.md
+++ b/src/dbt_mcp/prompts/admin_api/get_job_details.md
@@ -2,10 +2,6 @@ Get detailed information for a specific dbt job.
 
 This tool retrieves comprehensive job configuration including execution settings, triggers, and scheduling information.
 
-## Parameters
-
-- **job_id** (required): The job ID to retrieve details for
-
 ## Returns
 
 Job object with detailed configuration including:

--- a/src/dbt_mcp/prompts/admin_api/get_job_run_artifact.md
+++ b/src/dbt_mcp/prompts/admin_api/get_job_run_artifact.md
@@ -2,12 +2,6 @@ Download a specific artifact file from a dbt job run.
 
 This tool retrieves the content of a specific artifact file generated during run execution, such as manifest.json, catalog.json, or compiled SQL files.
 
-## Parameters
-
-- **run_id** (required): The run ID containing the artifact
-- **artifact_path** (required): The path to the specific artifact file
-- **step** (optional): The step index to retrieve artifacts from (default: last step)
-
 ## Common Artifact Paths
 
 - **manifest.json**: Complete dbt project metadata, models, and lineage

--- a/src/dbt_mcp/prompts/admin_api/get_job_run_details.md
+++ b/src/dbt_mcp/prompts/admin_api/get_job_run_details.md
@@ -2,10 +2,6 @@ Get detailed information for a specific dbt job run.
 
 This tool retrieves comprehensive run information including execution details, steps, and artifacts.
 
-## Parameters
-
-- **run_id** (required): The run ID to retrieve details for
-
 ## Returns
 
 Run object with detailed execution information including:

--- a/src/dbt_mcp/prompts/admin_api/get_job_run_error.md
+++ b/src/dbt_mcp/prompts/admin_api/get_job_run_error.md
@@ -2,12 +2,6 @@ Get focused error and/or warning information for a dbt job run.
 
 This tool retrieves and analyzes job runs to provide concise, actionable error and warning details optimized for troubleshooting and monitoring. Instead of verbose run details, it returns structured information with minimal token usage.
 
-## Parameters
-
-- run_id (required): The run ID to analyze for error/warning information
-- include_warnings (optional, default: False): If True, include warnings along with errors in the response
-- warning_only (optional, default: False): If True, only return warnings without errors (useful for analyzing successful runs)
-
 ## Returns
 
 ### Default Behavior (errors only)

--- a/src/dbt_mcp/prompts/admin_api/get_project_details.md
+++ b/src/dbt_mcp/prompts/admin_api/get_project_details.md
@@ -2,10 +2,6 @@ Get detailed information for a specific dbt Cloud project.
 
 This tool retrieves comprehensive project configuration including repository connections, environment settings, and project metadata.
 
-## Parameters
-
-- **project_id** (required): The project ID to retrieve details for
-
 ## Returns
 
 Project object with detailed configuration including:

--- a/src/dbt_mcp/prompts/admin_api/list_job_run_artifacts.md
+++ b/src/dbt_mcp/prompts/admin_api/list_job_run_artifacts.md
@@ -2,10 +2,6 @@ List all available artifacts for a completed dbt job run.
 
 This tool retrieves the list of artifact files generated during a run execution, such as manifest.json, catalog.json, and run_results.json.
 
-## Parameters
-
-- **run_id** (required): The run ID to list artifacts for
-
 ## Returns
 
 List of artifact file paths available for download. Common artifacts include:

--- a/src/dbt_mcp/prompts/admin_api/list_jobs.md
+++ b/src/dbt_mcp/prompts/admin_api/list_jobs.md
@@ -2,11 +2,6 @@ List all jobs in a dbt platform account with optional filtering.
 
 This tool retrieves jobs from the dbt Admin API. Jobs are the configuration for scheduled or triggered dbt runs.
 
-## Parameters
-
-- **limit** (optional): Maximum number of results to return
-- **offset** (optional): Number of results to skip for pagination
-
 When a single project is configured, results are automatically scoped to that environment. Otherwise, all jobs in the account are returned — use `limit` to constrain large result sets.
 
 Returns a list of job objects with details like:

--- a/src/dbt_mcp/prompts/admin_api/list_jobs_runs.md
+++ b/src/dbt_mcp/prompts/admin_api/list_jobs_runs.md
@@ -2,14 +2,6 @@ List all job runs in a dbt platform account with optional filtering.
 
 This tool retrieves runs from the dbt Admin API. Runs represent executions of dbt jobs in dbt.
 
-## Parameters
-
-- **job_id** (optional, integer): Filter runs by specific job ID
-- **status** (optional, string): Filter runs by status. One of: `queued`, `starting`, `running`, `success`, `error`, `cancelled`
-- **limit** (optional, integer): Maximum number of results to return
-- **offset** (optional, integer): Number of results to skip for pagination
-- **order_by** (optional, string): Field to order results by (e.g., "created_at", "finished_at", "id"). Use a `-` prefix for reverse ordering (e.g., "-created_at" for newest first)
-
 Returns a list of run objects with details like:
 
 - Run ID and status

--- a/src/dbt_mcp/prompts/admin_api/retry_job_run.md
+++ b/src/dbt_mcp/prompts/admin_api/retry_job_run.md
@@ -2,10 +2,6 @@ Retry a failed dbt job run from the point of failure.
 
 This tool allows you to restart a failed run, continuing from where it failed rather than starting completely over.
 
-## Parameters
-
-- **run_id** (required): The run ID to retry
-
 ## Returns
 
 New run object for the retry attempt with a new run ID and execution details.

--- a/src/dbt_mcp/prompts/admin_api/trigger_job_run.md
+++ b/src/dbt_mcp/prompts/admin_api/trigger_job_run.md
@@ -4,15 +4,6 @@ Trigger a dbt job run with optional parameter overrides.
 
 This tool starts a new run for a specified job with the ability to override default settings like Git branch, schema, or other execution parameters.
 
-## Parameters
-
-- **job_id** (required): The job ID to trigger
-- **cause** (optional, default: "Triggered by dbt MCP"): Description of why the job is being triggered
-- **git_branch** (optional): Override the Git branch to checkout
-- **git_sha** (optional): Override the Git SHA to checkout
-- **schema_override** (optional): Override the destination schema
-- **steps_override** (optional): Override the dbt commands to execute. Each element is a full dbt command string (e.g., `"dbt run --select my_model --full-refresh"`). When provided, the job's default steps are replaced entirely.
-
 ## Returns
 
 Run object with information about the newly triggered run including:

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from client.main import client_session_context
+from client.session import client_session_context
 from dbt_mcp.dbt_admin.param_descriptions import PAGINATION_LIMIT, PAGINATION_OFFSET
 from dbt_mcp.dbt_admin.tools import (
     ADMIN_TOOLS,

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -2,7 +2,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from dbt_mcp.mcp.server import register_multi_project_dbt_mcp
+from client.main import client_session_context
+from dbt_mcp.dbt_admin.param_descriptions import PAGINATION_LIMIT, PAGINATION_OFFSET
 from dbt_mcp.dbt_admin.tools import (
     ADMIN_TOOLS,
     AdminToolContext,
@@ -18,6 +19,7 @@ from dbt_mcp.dbt_admin.tools import (
     retry_job_run,
     trigger_job_run,
 )
+from dbt_mcp.mcp.server import register_multi_project_dbt_mcp
 from tests.mocks.config import mock_config
 
 NUM_ADMIN_TOOLS = 10
@@ -375,3 +377,17 @@ def test_admin_tools_list_contains_all_tools():
     actual_tool_names = {tool.fn.__name__ for tool in ADMIN_TOOLS}
     assert actual_tool_names == expected_tool_names
     assert len(ADMIN_TOOLS) == NUM_ADMIN_TOOLS
+
+
+async def test_admin_tools_list_jobs_params():
+    """Test that the list_jobs tool has the correct parameters."""
+    async with client_session_context() as client:
+        available_tools = (await client.list_tools()).tools
+        list_jobs_tool = next(
+            tool for tool in available_tools if tool.name == "list_jobs"
+        )
+        assert list_jobs_tool.inputSchema is not None
+        props = list_jobs_tool.inputSchema.get("properties")
+        assert props is not None
+        assert props["limit"]["description"] == PAGINATION_LIMIT
+        assert props["offset"]["description"] == PAGINATION_OFFSET


### PR DESCRIPTION
## Summary

Putting tool parameter descriptions on the parameters themselves rather than in the prompt is more MCP-idiomatic. Additionally, this should improve performance for multi-project MCP tools that share prompts with their single-project counterparts but have different parameter lists. I'll update more toolsets accordingly

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes