### PR TITLE
Add MCP server instructions

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260507-122743.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260507-122743.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add MCP server instructions
+time: 2026-05-07T12:27:43.171144-05:00

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -12,16 +12,17 @@ from mcp.server.lowlevel.server import LifespanResultT
 from mcp.types import ContentBlock, TextContent, Tool
 
 from dbt_mcp.config.config import Config
-from dbt_mcp.errors.common import MissingHostError
 from dbt_mcp.dbt_admin.tools import register_admin_api_tools
 from dbt_mcp.dbt_cli.tools import register_dbt_cli_tools
 from dbt_mcp.dbt_codegen.tools import register_dbt_codegen_tools
 from dbt_mcp.discovery.tools import register_discovery_tools
 from dbt_mcp.discovery.tools_multiproject import register_multiproject_discovery_tools
+from dbt_mcp.errors.common import MissingHostError
 from dbt_mcp.lsp.providers.lsp_connection_provider import LSPConnectionProviderProtocol
 from dbt_mcp.lsp.tools import register_lsp_tools
 from dbt_mcp.mcp_server_metadata.tools import register_mcp_server_tools
 from dbt_mcp.product_docs.tools import register_product_docs_tools
+from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.proxy.tools import ProxiedToolsManager, register_proxied_tools
 from dbt_mcp.semantic_layer.client import DefaultSemanticLayerClientProvider
 from dbt_mcp.semantic_layer.tools import register_sl_tools
@@ -339,6 +340,7 @@ async def create_dbt_mcp(config: Config) -> FastMCP:
 
     tool_dispatcher = DbtMCP(
         name="dbt",
+        instructions=get_prompt("mcp/server_instructions").strip(),
         config=config,
         usage_tracker=DefaultUsageTracker(
             credentials_provider=config.credentials_provider.inner_provider,

--- a/src/dbt_mcp/prompts/mcp/server_instructions.md
+++ b/src/dbt_mcp/prompts/mcp/server_instructions.md
@@ -3,7 +3,7 @@ Use these tools to interact with dbt resources (typically via dbt Platform):
 - Understand how the project is structured: what exists in the environment, how objects depend on one another, and where to look when something looks wrong or slow.
 - Reason over governed business meaning—named measures and breakdowns the project maintains—and answer questions with validated aggregates or the warehouse logic behind them when that helps.
 - Work with platform automation when available: see what runs on a schedule, inspect past outcomes, act on failures or reruns, and dig into logs and outputs.
-- Assist with engineering work on dbt projects: take action on the project, generate or modify project code, and reason about the underlying SQL.
+- Assist with engineering work on dbt projects: take action on the project and reason about the underlying SQL.
 
 Example data-oriented questions (users may not use dbt vocabulary):
 

--- a/src/dbt_mcp/prompts/mcp/server_instructions.md
+++ b/src/dbt_mcp/prompts/mcp/server_instructions.md
@@ -1,0 +1,15 @@
+Use these tools to interact with dbt resources (typically via dbt Platform):
+
+- Understand how the project is structured: what exists in the environment, how objects depend on one another, and where to look when something looks wrong or slow.
+- Reason over governed business meaning—named measures and breakdowns the project maintains—and answer questions with validated aggregates or the warehouse logic behind them when that helps.
+- Work with platform automation when available: see what runs on a schedule, inspect past outcomes, act on failures or reruns, and dig into logs and outputs.
+
+Example data-oriented questions (users may not use dbt vocabulary):
+
+- Revenue, ARR, bookings, pipeline, or quota: “how are we doing this quarter?”; “split it by region or product”; “this total doesn’t match finance.”
+- Customers, users, signups, or retention: “how many active …?” “is churn getting worse?” “cohorts or segments—whatever we already track.”
+- Orders, inventory, SKUs, or fulfillment: “what’s selling?” “stock or backorder questions” when they only describe the business problem.
+- Funnel, marketing, or web activity: “conversion from visit to purchase” “campaign performance” with loose wording and no metric names.
+- Trust and definitions: “where does this dashboard number come from?” “two reports disagree—help me find why” “what’s the official definition of …?”
+- Quality and freshness: “is this table up to date?” “missing yesterday’s data” “something looks stale in our reporting.”
+- Orchestration tied to data: “did last night’s refresh finish?” “prod load failed and Finance is blocked” without run or job IDs.

--- a/src/dbt_mcp/prompts/mcp/server_instructions.md
+++ b/src/dbt_mcp/prompts/mcp/server_instructions.md
@@ -3,6 +3,7 @@ Use these tools to interact with dbt resources (typically via dbt Platform):
 - Understand how the project is structured: what exists in the environment, how objects depend on one another, and where to look when something looks wrong or slow.
 - Reason over governed business meaning—named measures and breakdowns the project maintains—and answer questions with validated aggregates or the warehouse logic behind them when that helps.
 - Work with platform automation when available: see what runs on a schedule, inspect past outcomes, act on failures or reruns, and dig into logs and outputs.
+- Assist with engineering work on dbt projects: take action on the project, generate or modify project code, and reason about the underlying SQL.
 
 Example data-oriented questions (users may not use dbt vocabulary):
 
@@ -13,3 +14,4 @@ Example data-oriented questions (users may not use dbt vocabulary):
 - Trust and definitions: “where does this dashboard number come from?” “two reports disagree—help me find why” “what’s the official definition of …?”
 - Quality and freshness: “is this table up to date?” “missing yesterday’s data” “something looks stale in our reporting.”
 - Orchestration tied to data: “did last night’s refresh finish?” “prod load failed and Finance is blocked” without run or job IDs.
+- Engineering on a dbt project: “help me with this model,” “what’s wrong with my project?”


### PR DESCRIPTION
## Summary

I've been testing with a new MCP client. It requires a lot of explicit instructions to use the server. I'm hoping these instructions will allow the agent to use dbt MCP more readily.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes