### PR TITLE
feat: add list_environment_variables tool to Admin API

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260508-232857.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260508-232857.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add list_environment_variables tool to Admin API toolset
+time: 2026-05-08T23:28:57.000000000Z

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ To learn more about the dbt Administrative API, click [here](https://docs.getdbt
 - `get_job_details`: Gets job configuration including triggers, schedule, and dbt commands.
 - `get_job_run_details`: Gets run details including status, timing, steps, and artifacts.
 - `get_job_run_error`: Gets error and/or warning details for a job run; option to include or show warnings only.
+- `list_environment_variables`: Lists environment variables for a project with their values across environments.
 - `list_job_run_artifacts`: Lists available artifacts from a job run.
 - `list_jobs`: Lists jobs in a dbt Platform account; option to filter by project or environment.
 - `list_jobs_runs`: Lists job runs; option to filter by job, status, or order by field.

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -263,6 +263,16 @@ class DbtAdminAPIClient:
             for p in data
         ]
 
+    async def list_environment_variables(
+        self, account_id: int, project_id: int
+    ) -> dict[str, Any]:
+        """List all environment variables for a project."""
+        result = await self._make_request(
+            "GET",
+            f"/api/v3/accounts/{account_id}/projects/{project_id}/environment-variables/environment/",
+        )
+        return result.get("data", {})
+
     async def trigger_job_run(
         self, account_id: int, job_id: int, cause: str, **kwargs: Any
     ) -> dict[str, Any]:

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -30,6 +30,7 @@ from dbt_mcp.dbt_admin.param_descriptions import (
 from dbt_mcp.dbt_admin.run_artifacts import ErrorFetcher, WarningFetcher
 from dbt_mcp.prompts.prompts import get_prompt
 from dbt_mcp.tools.definitions import dbt_mcp_tool
+from dbt_mcp.tools.multiproject_params import MULTI_PROJECT_PROJECT_ID_DESCRIPTION
 from dbt_mcp.tools.register import register_tools
 from dbt_mcp.tools.tool_names import ToolName
 from dbt_mcp.tools.toolsets import Toolset
@@ -58,6 +59,24 @@ async def list_projects(context: AdminToolContext) -> list[dict[str, Any]]:
     """List active projects in the account."""
     admin_api_config = await context.admin_api_config_provider.get_config()
     return await context.admin_client.list_projects(admin_api_config.account_id)
+
+
+@dbt_mcp_tool(
+    description=get_prompt("admin_api/list_environment_variables"),
+    title="List Environment Variables",
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+)
+async def list_environment_variables(
+    context: AdminToolContext,
+    project_id: Annotated[int, Field(description=MULTI_PROJECT_PROJECT_ID_DESCRIPTION)],
+) -> dict[str, Any]:
+    """List all environment variables for a project."""
+    admin_api_config = await context.admin_api_config_provider.get_config()
+    return await context.admin_client.list_environment_variables(
+        admin_api_config.account_id, project_id
+    )
 
 
 @dbt_mcp_tool(
@@ -299,6 +318,7 @@ async def get_job_run_error(
 
 ADMIN_TOOLS = [
     list_projects,
+    list_environment_variables,
     list_jobs,
     get_job_details,
     trigger_job_run,

--- a/src/dbt_mcp/prompts/admin_api/list_environment_variables.md
+++ b/src/dbt_mcp/prompts/admin_api/list_environment_variables.md
@@ -5,8 +5,8 @@ This tool retrieves environment variables from the dbt Admin API. Environment va
 Parameters:
 - **project_id**: The ID of the project to list environment variables for
 
-Returns a mapping of environment variable names to their values across environments:
-- **project default**: The default value set at the project level
-- **environment overrides**: Values that override the default for specific environments (development, staging, production)
+Returns a mapping of environment variable names to objects containing:
+- **project**: The value set at the project level
+- **environments**: Per-environment override values (for example, development, staging, production)
 
 Use this tool to inspect how environment variables are configured across environments, debug environment-specific behavior, or understand project configuration.

--- a/src/dbt_mcp/prompts/admin_api/list_environment_variables.md
+++ b/src/dbt_mcp/prompts/admin_api/list_environment_variables.md
@@ -1,0 +1,12 @@
+List all environment variables for a specific project in the dbt Cloud account.
+
+This tool retrieves environment variables from the dbt Admin API. Environment variables in dbt Cloud are used to customize project behavior across different environments (development, staging, production) without changing code.
+
+Parameters:
+- **project_id**: The ID of the project to list environment variables for
+
+Returns a mapping of environment variable names to their values across environments:
+- **project default**: The default value set at the project level
+- **environment overrides**: Values that override the default for specific environments (development, staging, production)
+
+Use this tool to inspect how environment variables are configured across environments, debug environment-specific behavior, or understand project configuration.

--- a/src/dbt_mcp/tools/readme_mappings.py
+++ b/src/dbt_mcp/tools/readme_mappings.py
@@ -49,6 +49,7 @@ HUMAN_DESCRIPTIONS: dict[ToolName, str] = {
     ToolName.EXECUTE_SQL: "Executes SQL on dbt Platform infrastructure with Semantic Layer support.",
     # Admin API tools
     ToolName.LIST_PROJECTS: "Lists all projects in the dbt Platform account.",
+    ToolName.LIST_ENVIRONMENT_VARIABLES: "Lists environment variables for a project with their values across environments.",
     ToolName.LIST_JOBS: "Lists jobs in a dbt Platform account; option to filter by project or environment.",
     ToolName.GET_JOB_DETAILS: "Gets job configuration including triggers, schedule, and dbt commands.",
     ToolName.TRIGGER_JOB_RUN: "Triggers a job run; option to override git branch, schema, or other settings.",

--- a/src/dbt_mcp/tools/tool_names.py
+++ b/src/dbt_mcp/tools/tool_names.py
@@ -53,6 +53,7 @@ class ToolName(Enum):
 
     # Admin API tools
     LIST_PROJECTS = "list_projects"
+    LIST_ENVIRONMENT_VARIABLES = "list_environment_variables"
     LIST_JOBS = "list_jobs"
     GET_JOB_DETAILS = "get_job_details"
     TRIGGER_JOB_RUN = "trigger_job_run"

--- a/src/dbt_mcp/tools/toolsets.py
+++ b/src/dbt_mcp/tools/toolsets.py
@@ -93,6 +93,7 @@ toolsets = {
     },
     Toolset.ADMIN_API: {
         ToolName.LIST_PROJECTS,
+        ToolName.LIST_ENVIRONMENT_VARIABLES,
         ToolName.LIST_JOBS,
         ToolName.GET_JOB_DETAILS,
         ToolName.TRIGGER_JOB_RUN,

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -749,3 +749,42 @@ async def test_list_projects_no_semantic_layer(client):
     assert p["has_semantic_layer"] is False
     assert p["environments"] == []
     assert p["repository_full_name"] is None
+
+
+async def test_list_environment_variables(client):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": {
+            "DBT_ENV_SECRET_GIT_CREDENTIAL": {
+                "project": "xxxxxxxxx",
+                "environments": {
+                    "Development": "xxxxxxxxx",
+                    "Production": "xxxxxxxxx",
+                },
+            },
+            "DBT_ENV_CUSTOM_ENV_PARTNER_SHARE": {
+                "project": "placeholder",
+                "environments": {
+                    "Production": "enabled",
+                },
+            },
+        }
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await client.list_environment_variables(12345, 99)
+
+    assert "DBT_ENV_SECRET_GIT_CREDENTIAL" in result
+    assert "DBT_ENV_CUSTOM_ENV_PARTNER_SHARE" in result
+    assert result["DBT_ENV_CUSTOM_ENV_PARTNER_SHARE"]["project"] == "placeholder"
+
+    headers = await client.get_headers()
+    mock_client.request.assert_called_once_with(
+        "GET",
+        "https://cloud.getdbt.com/api/v3/accounts/12345/projects/99/environment-variables/environment/",
+        headers=headers,
+        follow_redirects=True,
+    )

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -12,6 +12,7 @@ from dbt_mcp.dbt_admin.tools import (
     get_job_details,
     get_job_run_details,
     get_job_run_error,
+    list_environment_variables,
     list_job_run_artifacts,
     list_jobs,
     list_jobs_runs,
@@ -22,7 +23,7 @@ from dbt_mcp.dbt_admin.tools import (
 from dbt_mcp.mcp.server import register_multi_project_dbt_mcp
 from tests.mocks.config import mock_config
 
-NUM_ADMIN_TOOLS = 10
+NUM_ADMIN_TOOLS = 11
 
 
 @pytest.fixture
@@ -95,6 +96,23 @@ def mock_admin_client():
         return_value=["manifest.json", "catalog.json"]
     )
     client.get_job_run_artifact = AsyncMock(return_value={"nodes": {}})
+    client.list_environment_variables = AsyncMock(
+        return_value={
+            "DBT_ENV_SECRET_GIT_CREDENTIAL": {
+                "project": "xxxxxxxxx",
+                "environments": {
+                    "Development": "xxxxxxxxx",
+                    "Production": "xxxxxxxxx",
+                },
+            },
+            "DBT_ENV_CUSTOM_ENV_PARTNER_SHARE": {
+                "project": "placeholder",
+                "environments": {
+                    "Production": "enabled",
+                },
+            },
+        }
+    )
 
     return client
 
@@ -159,6 +177,15 @@ async def test_list_jobs_tool(admin_context):
 
     assert isinstance(result, list)
     admin_context.admin_client.list_jobs.assert_called_once()
+
+
+async def test_list_environment_variables_tool(admin_context):
+    result = await list_environment_variables.fn(admin_context, project_id=99)
+
+    assert isinstance(result, dict)
+    admin_context.admin_client.list_environment_variables.assert_called_once_with(
+        12345, 99
+    )
 
 
 async def test_get_job_details_tool(admin_context):
@@ -363,6 +390,7 @@ def test_admin_tools_list_contains_all_tools():
     """Test that ADMIN_TOOLS contains all expected tools."""
     expected_tool_names = {
         "list_projects",
+        "list_environment_variables",
         "list_jobs",
         "get_job_details",
         "trigger_job_run",


### PR DESCRIPTION
## Summary

Adds a new `list_environment_variables` tool to the Admin API toolset. This tool retrieves all environment variables configured for a given project, showing their values across different environments.

## Changes

- Added `list_environment_variables` tool function and client method
- Endpoint: `GET /api/v3/accounts/{account_id}/projects/{project_id}/environment-variables/environment/`
- Registered tool in `ToolName`, `toolsets`, and `readme_mappings`
- Added prompt file describing the tool for LLM consumption
- Added unit tests for both client and tool layers

## Testing

- Unit tests pass (`tests/unit/dbt_admin/`)
- Manually verified against a live dbt Cloud account
