### PR TITLE
fix: specify UTF-8 encoding for all text file I/O

### DIFF
--- a/.changes/unreleased/Bug Fix-20260511-132528.yaml
+++ b/.changes/unreleased/Bug Fix-20260511-132528.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: 'Specify UTF-8 encoding for all text file reads/writes to fix UnicodeDecodeError on Windows (closes #765)'
+time: 2026-05-11T13:25:28.435703+02:00

--- a/src/dbt_mcp/config/dbt_yaml.py
+++ b/src/dbt_mcp/config/dbt_yaml.py
@@ -11,9 +11,9 @@ def try_read_yaml(file_path: Path) -> dict | None:
         alternate_suffix = ".yaml" if suffix == ".yml" else ".yml"
         alternate_path = file_path.with_suffix(alternate_suffix)
         if file_path.exists():
-            return yaml.safe_load(file_path.read_text())
+            return yaml.safe_load(file_path.read_text(encoding="utf-8"))
         if alternate_path.exists():
-            return yaml.safe_load(alternate_path.read_text())
+            return yaml.safe_load(alternate_path.read_text(encoding="utf-8"))
     except Exception:
         return None
     return None

--- a/src/dbt_mcp/lsp/lsp_binary_manager.py
+++ b/src/dbt_mcp/lsp/lsp_binary_manager.py
@@ -226,7 +226,7 @@ def get_lsp_binary_version(path: str) -> str:
     """
     version_file = Path(path).parent / ".version"
     if version_file.exists():
-        return version_file.read_text().strip()
+        return version_file.read_text(encoding="utf-8").strip()
     else:
         return subprocess.run(
             [path, "--version"], capture_output=True, text=True

--- a/src/dbt_mcp/oauth/context_manager.py
+++ b/src/dbt_mcp/oauth/context_manager.py
@@ -21,7 +21,7 @@ class DbtPlatformContextManager:
         if not self.config_location.exists():
             return None
         try:
-            content = self.config_location.read_text()
+            content = self.config_location.read_text(encoding="utf-8")
             if not content.strip():
                 return None
             parsed_content = yaml.safe_load(content)
@@ -61,5 +61,6 @@ class DbtPlatformContextManager:
         """Write context to file with proper locking."""
         self._ensure_config_location_exists()
         self.config_location.write_text(
-            yaml.dump(context.model_dump(), default_flow_style=False)
+            yaml.dump(context.model_dump(), default_flow_style=False),
+            encoding="utf-8",
         )

--- a/src/dbt_mcp/prompts/mcp/server_instructions.md
+++ b/src/dbt_mcp/prompts/mcp/server_instructions.md
@@ -1,17 +1,17 @@
 Use these tools to interact with dbt resources (typically via dbt Platform):
 
 - Understand how the project is structured: what exists in the environment, how objects depend on one another, and where to look when something looks wrong or slow.
-- Reason over governed business meaning—named measures and breakdowns the project maintains—and answer questions with validated aggregates or the warehouse logic behind them when that helps.
+- Reason over governed business meaning -- named measures and breakdowns the project maintains -- and answer questions with validated aggregates or the warehouse logic behind them when that helps.
 - Work with platform automation when available: see what runs on a schedule, inspect past outcomes, act on failures or reruns, and dig into logs and outputs.
 - Assist with engineering work on dbt projects: take action on the project and reason about the underlying SQL.
 
 Example data-oriented questions (users may not use dbt vocabulary):
 
-- Revenue, ARR, bookings, pipeline, or quota: “how are we doing this quarter?”; “split it by region or product”; “this total doesn’t match finance.”
-- Customers, users, signups, or retention: “how many active …?” “is churn getting worse?” “cohorts or segments—whatever we already track.”
-- Orders, inventory, SKUs, or fulfillment: “what’s selling?” “stock or backorder questions” when they only describe the business problem.
-- Funnel, marketing, or web activity: “conversion from visit to purchase” “campaign performance” with loose wording and no metric names.
-- Trust and definitions: “where does this dashboard number come from?” “two reports disagree—help me find why” “what’s the official definition of …?”
-- Quality and freshness: “is this table up to date?” “missing yesterday’s data” “something looks stale in our reporting.”
-- Orchestration tied to data: “did last night’s refresh finish?” “prod load failed and Finance is blocked” without run or job IDs.
-- Engineering on a dbt project: “help me with this model,” “what’s wrong with my project?”
+- Revenue, ARR, bookings, pipeline, or quota: "how are we doing this quarter?"; "split it by region or product"; "this total doesn't match finance."
+- Customers, users, signups, or retention: "how many active ...?" "is churn getting worse?" "cohorts or segments -- whatever we already track."
+- Orders, inventory, SKUs, or fulfillment: "what's selling?" "stock or backorder questions" when they only describe the business problem.
+- Funnel, marketing, or web activity: "conversion from visit to purchase" "campaign performance" with loose wording and no metric names.
+- Trust and definitions: "where does this dashboard number come from?" "two reports disagree -- help me find why" "what's the official definition of ...?"
+- Quality and freshness: "is this table up to date?" "missing yesterday's data" "something looks stale in our reporting."
+- Orchestration tied to data: "did last night's refresh finish?" "prod load failed and Finance is blocked" without run or job IDs.
+- Engineering on a dbt project: "help me with this model," "what's wrong with my project?"

--- a/src/dbt_mcp/prompts/prompts.py
+++ b/src/dbt_mcp/prompts/prompts.py
@@ -2,4 +2,4 @@ from pathlib import Path
 
 
 def get_prompt(name: str) -> str:
-    return (Path(__file__).parent / f"{name}.md").read_text()
+    return (Path(__file__).parent / f"{name}.md").read_text(encoding="utf-8")

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -77,7 +77,8 @@ class DefaultUsageTracker:
                 self._local_user_id = str(uuid.uuid4())
                 with suppress(Exception):
                     Path(user_yaml_path).write_text(
-                        yaml.dump({"id": self._local_user_id})
+                        yaml.dump({"id": self._local_user_id}),
+                        encoding="utf-8",
                     )
         return self._local_user_id
 


### PR DESCRIPTION
## Summary

Fixes #765 and prevents the same class of bug on every other text I/O path in the codebase.

`open()` / `Path.read_text()` / `Path.write_text()` without an explicit `encoding=` argument falls back to the system locale on Windows (CP-1252), which fails on common UTF-8 bytes (smart quotes, em dashes, accented characters, CJK).

#674 already fixed this for `manifest.json` after #594. This PR extends the same one-line fix to the remaining unprotected readers/writers found by auditing the `src/` tree:

- `prompts/prompts.py` -- `server_instructions.md` (the file that triggers #765 on startup)
- `oauth/context_manager.py` -- OAuth context yaml read and write
- `config/dbt_yaml.py` -- `dbt_project.yml` / `.user.yml` read
- `lsp/lsp_binary_manager.py` -- LSP `.version` file read
- `tracking/tracking.py` -- `.user.yml` write

It also normalizes the smart quotes, em dashes, and ellipses in `server_instructions.md` to plain ASCII. The file is the only "user-visible" prompt asset and previously contained the byte (`0x9d`) that crashed the server on startup; making it pure ASCII means it can't trip the same bug again, and the rendered prompt looks identical to a model.

## Test plan

- [x] `task check` passes (ruff, mypy, formatter, doc generation)
- [x] `task test:unit` -- 634 tests pass
- [x] `server_instructions.md` is verified pure ASCII (no bytes > 127)