### PR TITLE
Remove dbt-artifacts-parser from 7 day exclusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260513-150204.yaml
+++ b/.changes/unreleased/Under the Hood-20260513-150204.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Remove dbt-artifacts-parser from 7 day exclusion
+time: 2026-05-13T15:02:04.845708-07:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
 ]
 [tool.uv]
 exclude-newer = "7 days"
-exclude-newer-package = { dbt-protos = false, dbt-sl-sdk = false, dbtlabs-vortex = false, dbt-artifacts-parser = false}
+exclude-newer-package = { dbt-protos = false, dbt-sl-sdk = false, dbtlabs-vortex = false }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
# Summary
Added this exclusion as short-term config as i created a change in dbt-artifacts-parser repo to support some work in the dbt-mcp. A fresh [release](https://github.com/yu-iskw/dbt-artifacts-parser/releases/tag/v0.13.2) was coordinated with that project to help unblock me. 

In retrospect, I should've just waited the 7 days to remove the exclusion config before merging the PR (did not register with me). Conveniently, by around 6p PT TODAY it will be 7 days since release so `uv sync` should works properly with this exclusion removed. 

<img width="1448" height="114" alt="Screenshot 2026-05-13 at 3 14 22 PM" src="https://github.com/user-attachments/assets/fcf7f589-45a9-4af9-abec-a78c97979c63" />
