### PR TITLE
Fix test_local_mcp_list_metrics_returns_valid_response integration test

### DIFF
--- a/.changes/unreleased/Under the Hood-20260513-221446.yaml
+++ b/.changes/unreleased/Under the Hood-20260513-221446.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Fix test_local_mcp_list_metrics_returns_valid_response integration test
+time: 2026-05-13T22:14:46.582981-07:00

--- a/tests/integration/remote_mcp/test_remote_mcp.py
+++ b/tests/integration/remote_mcp/test_remote_mcp.py
@@ -2,6 +2,8 @@ import csv
 import io
 from itertools import dropwhile
 
+from mcp.types import ContentBlock, TextContent
+
 from dbt_mcp.config.config import load_config
 from dbt_mcp.mcp.server import create_dbt_mcp
 from remote_mcp.session import session_context
@@ -14,11 +16,13 @@ async def test_local_mcp_list_metrics_returns_valid_response() -> None:
         name="list_metrics",
         arguments={},
     )
-    assert isinstance(result, list)
-    assert len(result) == 1
-    content = result[0]
-    assert hasattr(content, "text")
-    csv_text = content.text  # type: ignore[union-attr]
+    # call_tool returns (content_list, structured_dict) when structured_output=True
+    content_list: list[ContentBlock]
+    content_list, _ = result  # type: ignore[assignment]
+    assert len(content_list) == 1
+    content = content_list[0]
+    assert isinstance(content, TextContent)
+    csv_text = content.text
     # Drop only the leading block of `#`-prefixed comment lines (pandas-style
     # convention); the tool may prepend a `# Note: ...` line when
     # description/metadata are trimmed for broad listings. `dropwhile` stops at


### PR DESCRIPTION
## Summary
Failure surfaced in #777 's integration test - https://github.com/dbt-labs/dbt-mcp/actions/runs/25841708919/job/75928628173 - tho unrelated to PR.

4 failures total from that above integration test:
- 3 due to staging env error (unrelated to code and resolved after retry)
- 1 due to need for unpacking tuple result after #774 (this PR fixes this one only)