### PR TITLE
Fix unstructured tool errors being masked as 'outputSchema defined but no structured output returned'

### DIFF
--- a/.changes/unreleased/Bug Fix-20260514-154649.yaml
+++ b/.changes/unreleased/Bug Fix-20260514-154649.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix unstructured tool errors being masked as 'outputSchema defined but no structured output returned'
+time: 2026-05-14T15:46:49.572423-07:00

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -9,7 +9,7 @@ from typing import Any
 from dbtlabs_vortex.producer import shutdown
 from mcp.server.fastmcp import FastMCP
 from mcp.server.lowlevel.server import LifespanResultT
-from mcp.types import CallToolResult, ContentBlock, TextContent, Tool
+from mcp.types import ContentBlock, Tool
 
 from dbt_mcp.config.config import Config
 from dbt_mcp.dbt_admin.tools import register_admin_api_tools
@@ -79,11 +79,9 @@ class DbtMCP(FastMCP):
             settings.dbt_project_ids is not None and len(settings.dbt_project_ids) > 0
         )
 
-    async def call_tool(  # type: ignore[override]
+    async def call_tool(
         self, name: str, arguments: dict[str, Any]
-    ) -> Sequence[ContentBlock] | dict[str, Any] | CallToolResult:
-        # Return type includes CallToolResult on error to satisfy outputSchema check
-        # Parent class, FastMCP.call_tool does not include this type
+    ) -> Sequence[ContentBlock] | dict[str, Any]:
         logger.info(f"Calling tool: {name} with arguments: {_safe_args(arguments)}")
         result = None
         start_time = int(time.time() * 1000)
@@ -110,10 +108,8 @@ class DbtMCP(FastMCP):
                 )
             except Exception:
                 logger.debug("Usage tracking failed — skipping", exc_info=True)
-            return CallToolResult(
-                content=[TextContent(type="text", text=str(e))],
-                isError=True,
-            )
+            raise
+
         end_time = int(time.time() * 1000)
         logger.info(f"Tool {name} called successfully in {end_time - start_time}ms")
         try:

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -9,7 +9,7 @@ from typing import Any
 from dbtlabs_vortex.producer import shutdown
 from mcp.server.fastmcp import FastMCP
 from mcp.server.lowlevel.server import LifespanResultT
-from mcp.types import ContentBlock, TextContent, Tool
+from mcp.types import CallToolResult, ContentBlock, TextContent, Tool
 
 from dbt_mcp.config.config import Config
 from dbt_mcp.dbt_admin.tools import register_admin_api_tools
@@ -79,9 +79,11 @@ class DbtMCP(FastMCP):
             settings.dbt_project_ids is not None and len(settings.dbt_project_ids) > 0
         )
 
-    async def call_tool(
+    async def call_tool(  # type: ignore[override]
         self, name: str, arguments: dict[str, Any]
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
+    ) -> Sequence[ContentBlock] | dict[str, Any] | CallToolResult:
+        # Return type includes CallToolResult on error to satisfy outputSchema check
+        # Parent class, FastMCP.call_tool does not include this type
         logger.info(f"Calling tool: {name} with arguments: {_safe_args(arguments)}")
         result = None
         start_time = int(time.time() * 1000)
@@ -108,12 +110,10 @@ class DbtMCP(FastMCP):
                 )
             except Exception:
                 logger.debug("Usage tracking failed — skipping", exc_info=True)
-            return [
-                TextContent(
-                    type="text",
-                    text=str(e),
-                )
-            ]
+            return CallToolResult(
+                content=[TextContent(type="text", text=str(e))],
+                isError=True,
+            )
         end_time = int(time.time() * 1000)
         logger.info(f"Tool {name} called successfully in {end_time - start_time}ms")
         try:

--- a/tests/unit/mcp/test_dispatcher.py
+++ b/tests/unit/mcp/test_dispatcher.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import CallToolResult, TextContent, Tool
+from mcp.types import TextContent, Tool
 
 from dbt_mcp.errors.common import MissingHostError
 from dbt_mcp.config.settings import DbtMcpSettings
@@ -191,7 +191,7 @@ class TestCallToolRouting:
         mcps[called].call_tool.assert_awaited_once()
         mcps[not_called].call_tool.assert_not_awaited()
 
-    async def test_returns_error_result_on_tool_error(self):
+    async def test_raises_on_tool_error(self):
         multi = MagicMock(spec=FastMCP)
         single = MagicMock(spec=FastMCP)
         single.call_tool = AsyncMock(side_effect=RuntimeError("something broke"))
@@ -202,15 +202,10 @@ class TestCallToolRouting:
         with patch.object(
             dispatcher, "_is_multi_project", AsyncMock(return_value=False)
         ):
-            result = await dispatcher.call_tool("bad_tool", {})
+            with pytest.raises(RuntimeError, match="something broke"):
+                await dispatcher.call_tool("bad_tool", {})
 
-        assert isinstance(result, CallToolResult)
-        assert result.isError is True
-        assert len(result.content) == 1
-        assert isinstance(result.content[0], TextContent)
-        assert "something broke" in result.content[0].text
-
-    async def test_tracking_failure_does_not_crash_call_tool(self):
+    async def test_tracking_failure_does_not_suppress_tool_error(self):
         single = MagicMock(spec=FastMCP)
         single.call_tool = AsyncMock(
             side_effect=MissingHostError("DBT_HOST is a required environment variable")
@@ -223,15 +218,10 @@ class TestCallToolRouting:
         with patch.object(
             dispatcher, "_is_multi_project", AsyncMock(return_value=False)
         ):
-            result = await dispatcher.call_tool("some_tool", {})
+            with pytest.raises(MissingHostError, match="DBT_HOST"):
+                await dispatcher.call_tool("some_tool", {})
 
-        # Tool error is returned cleanly despite tracking also failing
-        assert isinstance(result, CallToolResult)
-        assert result.isError is True
-        assert len(result.content) == 1
-        assert isinstance(result.content[0], TextContent)
-        assert "DBT_HOST" in result.content[0].text
-        # Tracking was attempted (and failed, but didn't crash)
+        # Tracking was attempted (and failed, but didn't suppress the tool error)
         dispatcher.usage_tracker.emit_tool_called_event.assert_awaited_once()
 
 

--- a/tests/unit/mcp/test_dispatcher.py
+++ b/tests/unit/mcp/test_dispatcher.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import TextContent, Tool
+from mcp.types import CallToolResult, TextContent, Tool
 
 from dbt_mcp.errors.common import MissingHostError
 from dbt_mcp.config.settings import DbtMcpSettings
@@ -191,7 +191,7 @@ class TestCallToolRouting:
         mcps[called].call_tool.assert_awaited_once()
         mcps[not_called].call_tool.assert_not_awaited()
 
-    async def test_returns_text_content_on_tool_error(self):
+    async def test_returns_error_result_on_tool_error(self):
         multi = MagicMock(spec=FastMCP)
         single = MagicMock(spec=FastMCP)
         single.call_tool = AsyncMock(side_effect=RuntimeError("something broke"))
@@ -204,9 +204,11 @@ class TestCallToolRouting:
         ):
             result = await dispatcher.call_tool("bad_tool", {})
 
-        assert len(result) == 1
-        assert isinstance(result[0], TextContent)
-        assert "something broke" in result[0].text
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+        assert "something broke" in result.content[0].text
 
     async def test_tracking_failure_does_not_crash_call_tool(self):
         single = MagicMock(spec=FastMCP)
@@ -224,9 +226,11 @@ class TestCallToolRouting:
             result = await dispatcher.call_tool("some_tool", {})
 
         # Tool error is returned cleanly despite tracking also failing
-        assert len(result) == 1
-        assert isinstance(result[0], TextContent)
-        assert "DBT_HOST" in result[0].text
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+        assert "DBT_HOST" in result.content[0].text
         # Tracking was attempted (and failed, but didn't crash)
         dispatcher.usage_tracker.emit_tool_called_event.assert_awaited_once()
 


### PR DESCRIPTION
## Summary

When a tool raised an exception, `DbtMCP.call_tool()` caught it and returned `[TextContent(...)]` which is unstructured. After #774 changed `structured_output` to default to `True`, all tools gained an `outputSchema`. Because of this, the MCP server rejects the unstructured error response with "Output validation error: outputSchema defined but no structured output returned". The actual error is not returned and hidden to the user/LLM:

<img width="703" height="71" alt="Screenshot 2026-05-15 at 8 46 38 AM" src="https://github.com/user-attachments/assets/8dc8e1c8-175e-41b7-89d9-d4a0b64f0f6e" />

To address this, ~~we instead return `CallToolResult(isError=True)` on exception so the MCP server "short circuits"~~ raise an error which gets caught by FastMCP's handler _before_ the `outputSchema` check which then properly outputs the failure:

<img width="1229" height="73" alt="Screenshot 2026-05-15 at 8 46 16 AM" src="https://github.com/user-attachments/assets/42a3a231-641a-4cb5-99ab-146073f1f92f" />

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Any additional information that would be helpful for reviewers -->
~~One thing Im unsure about about this implementation here is that we have to override the return type established by the parent `FastMCP.call_tool` method and add `CallToolResult` to `DbtMCP.call_tool`'s annotations. Because of this, mypy gets a bit mad and we have to tell it to "shhh". No behavioral changes with regards to the [LSP](https://en.wikipedia.org/wiki/Liskov_substitution_principle), just type annotations! Hope this is fine.~~

^^ addressed in comments
