### PR TITLE
fix: change list_metrics search type to list[str] | None

### DIFF
--- a/.changes/unreleased/fix-list-metrics-schema.yaml
+++ b/.changes/unreleased/fix-list-metrics-schema.yaml
@@ -1,0 +1,2 @@
+kind: Bug Fix
+body: Change `list_metrics` search parameter to `list[str] | None` to resolve Vertex AI schema union error.

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -145,12 +145,12 @@ class SemanticLayerFetcher:
     async def list_metrics(
         self,
         config: SemanticLayerConfig,
-        search: str | list[str] | None = None,
+        search: list[str] | None = None,
     ) -> ListMetricsResponse:
-        # `search` may be a single substring or a list of substrings; for a list
-        # we fan out one GraphQL call per substring, then merge & dedupe by name.
+        # `search` is a list of substrings; we fan out one GraphQL call
+        # per substring, then merge & dedupe by name.
         search_terms: list[str | None]
-        if isinstance(search, list):
+        if search is not None:
             # Strip whitespace, drop empty values, and dedupe identical terms
             # (preserving first-seen order) so a whitespace-only or duplicated
             # term can't broaden the fan-out into redundant or no-filter calls.
@@ -171,11 +171,7 @@ class SemanticLayerFetcher:
                 )
             search_terms = list(cleaned) if cleaned else [None]
         else:
-            # Mirror the list-path normalization for parity: a single-string
-            # `search` is stripped, and an empty/whitespace-only string becomes
-            # no filter (search=None).
-            normalized = search.strip() if isinstance(search, str) else search
-            search_terms = [normalized if normalized else None]
+            search_terms = [None]
 
         cheap_results = await asyncio.gather(
             *(

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -130,7 +130,7 @@ class SemanticLayerToolContext:
 async def list_metrics(
     context: SemanticLayerToolContext,
     search: Annotated[
-        str | list[str] | None, Field(description=SEMANTIC_SEARCH_METRICS)
+        list[str] | None, Field(description=SEMANTIC_SEARCH_METRICS)
     ] = None,
 ) -> str:
     config = await context.config_provider.get_config()

--- a/src/dbt_mcp/semantic_layer/tools.py
+++ b/src/dbt_mcp/semantic_layer/tools.py
@@ -7,7 +7,10 @@ from typing import Annotated
 
 from dbtsl.api.shared.query_params import GroupByParam
 from mcp.server.fastmcp import FastMCP
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+
+def _coerce_str_to_list(v: "Any") -> "Any":
+    return [v] if isinstance(v, str) else v
 
 from dbt_mcp.config.config_providers import ConfigProvider, SemanticLayerConfig
 from dbt_mcp.prompts.prompts import get_prompt
@@ -130,7 +133,9 @@ class SemanticLayerToolContext:
 async def list_metrics(
     context: SemanticLayerToolContext,
     search: Annotated[
-        list[str] | None, Field(description=SEMANTIC_SEARCH_METRICS)
+        list[str] | None,
+        BeforeValidator(_coerce_str_to_list),
+        Field(description=SEMANTIC_SEARCH_METRICS),
     ] = None,
 ) -> str:
     config = await context.config_provider.get_config()

--- a/src/dbt_mcp/semantic_layer/tools_multiproject.py
+++ b/src/dbt_mcp/semantic_layer/tools_multiproject.py
@@ -3,7 +3,10 @@ from typing import Annotated
 
 from dbtsl.api.shared.query_params import GroupByParam
 from mcp.server.fastmcp import FastMCP
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+
+def _coerce_str_to_list(v):
+    return [v] if isinstance(v, str) else v
 
 from dbt_mcp.config.config_providers import (
     MultiProjectConfigProvider,
@@ -69,7 +72,9 @@ async def list_metrics(
     context: MultiProjectSemanticLayerToolContext,
     project_id: Annotated[int, Field(description=SEMANTIC_LAYER_PROJECT_ID)],
     search: Annotated[
-        list[str] | None, Field(description=SEMANTIC_SEARCH_METRICS)
+        list[str] | None,
+        BeforeValidator(_coerce_str_to_list),
+        Field(description=SEMANTIC_SEARCH_METRICS),
     ] = None,
 ) -> str:
     config = await context.semantic_layer_config_provider.get_config(project_id)

--- a/src/dbt_mcp/semantic_layer/tools_multiproject.py
+++ b/src/dbt_mcp/semantic_layer/tools_multiproject.py
@@ -69,7 +69,7 @@ async def list_metrics(
     context: MultiProjectSemanticLayerToolContext,
     project_id: Annotated[int, Field(description=SEMANTIC_LAYER_PROJECT_ID)],
     search: Annotated[
-        str | list[str] | None, Field(description=SEMANTIC_SEARCH_METRICS)
+        list[str] | None, Field(description=SEMANTIC_SEARCH_METRICS)
     ] = None,
 ) -> str:
     config = await context.semantic_layer_config_provider.get_config(project_id)

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -527,22 +527,22 @@ async def test_list_metrics_search_list_normalizes_and_dedupes_terms(
 
 @pytest.mark.asyncio
 @patch("dbt_mcp.semantic_layer.client.submit_request")
-async def test_list_metrics_single_string_search_is_normalized(
+async def test_list_metrics_single_element_list_search_is_normalized(
     mock_submit_request, fetcher, mock_config_provider
 ):
-    """A single-string search is stripped and empty/whitespace-only becomes no filter."""
+    """A single-element list search is stripped and empty/whitespace-only becomes no filter."""
     mock_submit_request.side_effect = _make_query_dispatcher()
     config = mock_config_provider.get_config.return_value
 
     # Whitespace-padded string is stripped to "rev"
-    await fetcher.list_metrics(config=config, search="  rev  ")
+    await fetcher.list_metrics(config=config, search=["  rev  "])
     for call in mock_submit_request.call_args_list:
         assert call.args[1]["variables"]["search"] == "rev"
     mock_submit_request.reset_mock()
     mock_submit_request.side_effect = _make_query_dispatcher()
 
     # Empty/whitespace-only string collapses to no filter
-    await fetcher.list_metrics(config=config, search="   ")
+    await fetcher.list_metrics(config=config, search=["   "])
     for call in mock_submit_request.call_args_list:
         assert call.args[1]["variables"]["search"] is None
 


### PR DESCRIPTION
Fixes #784.

Addresses the JSON schema parsing issue encountered with the Google ADK (Vertex AI backend) when generating the schema for `list_metrics`.

Fix:
- Removed `str` from the `search` parameter type union across `client.py`, `tools.py`, and `tools_multiproject.py`. The parameter is now strictly `list[str] | None`.
- Updated `client.py` logic to process only list and None inputs, removing the fallback handling for bare strings.
- Updated the unit tests in `test_client.py` to pass `list[str]` instead of bare strings, aligning with the new signature and preventing unintended character iteration.