### PR TITLE
chore: remove unused OAuth helper endpoint and add host validation middleware

### DIFF
--- a/.changes/unreleased/Under the Hood-20260602-165320.yaml
+++ b/.changes/unreleased/Under the Hood-20260602-165320.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Remove unused endpoint from OAuth helper server and add host validation middleware
+time: 2026-06-02T16:53:20.035085+02:00

--- a/src/dbt_mcp/oauth/fastapi_app.py
+++ b/src/dbt_mcp/oauth/fastapi_app.py
@@ -6,6 +6,7 @@ from authlib.integrations.requests_client import OAuth2Session
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.types import Receive, Scope, Send
 from uvicorn import Server
 
@@ -72,6 +73,10 @@ def create_app(
     dbt_platform_context_manager: DbtPlatformContextManager,
 ) -> FastAPI:
     app = FastAPI()
+    app.add_middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=["localhost", "127.0.0.1"],
+    )
 
     app.state.decoded_access_token = cast(DecodedAccessToken | None, None)
     app.state.server_ref = cast(Server | None, None)
@@ -158,11 +163,6 @@ def create_app(
                 )
             )
         return projects
-
-    @app.get("/dbt_platform_context")
-    def get_dbt_platform_context() -> DbtPlatformContext:
-        logger.info("Selected project received")
-        return dbt_platform_context_manager.read_context() or DbtPlatformContext()
 
     @app.post("/selected_projects")
     async def set_selected_projects(


### PR DESCRIPTION
## Summary

- Removes the unused `GET /dbt_platform_context` endpoint from the OAuth helper FastAPI server — this endpoint was introduced in the initial OAuth implementation but became dead code after the multi-instance refactor in #320
- Adds `TrustedHostMiddleware` to the OAuth helper server, restricting requests to `localhost` and `127.0.0.1`

## Test plan

- [ ] Unit tests pass (`task test:unit`)
- [ ] Linting and type checks pass (`task check`)
- [ ] OAuth login flow works end-to-end