### PR TITLE
Propagate operational errors from semantic layer query_metrics

### DIFF
--- a/.changes/unreleased/Bug Fix-20260603-090806.yaml
+++ b/.changes/unreleased/Bug Fix-20260603-090806.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Semantic layer query_metrics now lets operational errors (authentication, connection) propagate instead of flattening them into a returned query-error string, so callers can distinguish an invalid query from an unreachable semantic layer.
+time: 2026-06-03T09:08:06.019505-05:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -494,8 +494,11 @@ class SemanticLayerFetcher:
                 config=config,
             )
             with sl_client.session():
-                # Catching any exception within the session
-                # to ensure it is closed properly
+                # Only query-level failures (the SL processed the query and
+                # rejected it) are returned to the caller as data. Operational
+                # failures (auth, connection, transport) propagate so callers
+                # can distinguish a bad query from an unreachable semantic layer.
+                # The `with` block handles session cleanup either way.
                 try:
                     parsed_order_by: list[OrderBySpec] = self._get_order_bys(
                         order_by=order_by, metrics=metrics, group_by=group_by
@@ -524,7 +527,7 @@ class SemanticLayerFetcher:
                             f"filters, reducing dimensions, or limiting results."
                         ) from e
                     query_error = e
-                except Exception as e:
+                except QueryFailedError as e:
                     query_error = e
             if query_error:
                 return self._format_query_failed_error(query_error)
@@ -533,5 +536,5 @@ class SemanticLayerFetcher:
             return QueryMetricsSuccess(result=json_result or "")
         except SemanticLayerQueryTimeoutError:
             raise
-        except Exception as e:
+        except QueryFailedError as e:
             return self._format_query_failed_error(e)

--- a/tests/integration/semantic_layer/test_semantic_layer.py
+++ b/tests/integration/semantic_layer/test_semantic_layer.py
@@ -1,6 +1,7 @@
 import io
 from dataclasses import replace
 
+from dbtsl.error import AuthError
 import pyarrow as pa
 import pyarrow.csv
 import pytest
@@ -12,7 +13,7 @@ from dbt_mcp.semantic_layer.client import (
     DefaultSemanticLayerClientProvider,
     SemanticLayerFetcher,
 )
-from dbt_mcp.semantic_layer.types import OrderByParam, QueryMetricsError
+from dbt_mcp.semantic_layer.types import OrderByParam
 
 config = load_config()
 
@@ -50,20 +51,37 @@ async def test_semantic_layer_sdk_respects_fetcher_config_environment_id():
     assert config.semantic_layer_config_provider is not None
     provider = config.semantic_layer_config_provider
     default_cfg = await provider.get_config()
-    invalid_cfg = replace(default_cfg, prod_environment_id=9_999_999_999)
+    invalid_env_id = 9_999_999_999
+    invalid_cfg = replace(default_cfg, prod_environment_id=invalid_env_id)
 
     fetcher = SemanticLayerFetcher(
         client_provider=DefaultSemanticLayerClientProvider(),
     )
 
-    with pytest.raises(GraphQLError):
+    # list_metrics (GraphQL) authenticates fine but rejects the unknown
+    # environment. The error message naming our injected env id is what proves
+    # the failure is genuinely environment-scoped — not a broken token or some
+    # other environmental auth issue, either of which would fail before reaching
+    # this environment lookup. It also confirms the credentials are valid (a bad
+    # token would surface as AuthError here, not a NOT_FOUND GraphQLError).
+    with pytest.raises(GraphQLError) as list_exc:
         await fetcher.list_metrics(config=invalid_cfg)
-
-    result = await fetcher.query_metrics(config=invalid_cfg, metrics=["revenue"])
-    assert isinstance(result, QueryMetricsError), (
-        "query_metrics must not silently use the default environment when the fetcher "
-        "is scoped to a different (invalid) semantic layer config"
+    assert str(invalid_env_id) in str(list_exc.value), (
+        "GraphQL must reject the fetcher's scoped environment id specifically; "
+        "a failure that doesn't name it could be an unrelated auth/transport error"
     )
+
+    # The query path (ADBC/FlightSQL) sends the environment id as an RPC header.
+    # The gateway rejects an environment the token can't access as UNAUTHENTICATED,
+    # which dbtsl surfaces as AuthError. query_metrics propagates operational
+    # errors like this rather than flattening them into a QueryMetricsError, so a
+    # raised AuthError proves the query used the fetcher's scoped config instead of
+    # silently falling back to the default environment (which would have returned a
+    # successful result). We can't key on this message — the gateway returns the
+    # same generic "Invalid credentials" text for any auth failure — so the
+    # env-specific GraphQLError above is what anchors the failure to our bad env id.
+    with pytest.raises(AuthError):
+        await fetcher.query_metrics(config=invalid_cfg, metrics=["revenue"])
 
 
 async def test_semantic_layer_list_dimensions(

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pyarrow as pa
 import pytest
-from dbtsl.error import RetryTimeoutError
+from dbtsl.error import AuthError, QueryFailedError, RetryTimeoutError
 
 from dbtsl.api.shared.query_params import (
     GroupByParam,
@@ -775,6 +775,80 @@ class TestQueryMetricsCompiledTimeout:
 
         assert isinstance(result, QueryMetricsError)
         assert result.error is not None
+
+
+class TestQueryMetricsErrorPropagation:
+    """query_metrics returns a result for query-level failures (the SL processed
+    the query and rejected it) but lets operational failures (auth, connection)
+    propagate, so callers can tell 'the query was invalid' apart from 'we could
+    not reach the semantic layer'."""
+
+    @pytest.fixture
+    def mock_sl_client(self):
+        client = MagicMock()
+        session_ctx = MagicMock()
+        client.session.return_value = session_ctx
+        session_ctx.__enter__ = MagicMock(return_value=client)
+        session_ctx.__exit__ = MagicMock(return_value=False)
+        return client
+
+    @pytest.fixture
+    def client_provider(self, mock_sl_client):
+        provider = AsyncMock()
+        provider.get_client.return_value = mock_sl_client
+        return provider
+
+    @pytest.fixture
+    def mock_config(self):
+        token_p = MagicMock()
+        token_p.get_token.return_value = "tok"
+        headers_p = MagicMock()
+        headers_p.get_headers.return_value = {}
+        return SemanticLayerConfig(
+            url="https://test-host/api/graphql",
+            host="test-host",
+            prod_environment_id=123,
+            token_provider=token_p,
+            headers_provider=headers_p,
+        )
+
+    @pytest.fixture
+    def fetcher(self, client_provider):
+        return SemanticLayerFetcher(client_provider=client_provider)
+
+    async def test_query_failed_error_returns_error_result(
+        self, fetcher, mock_sl_client, mock_config
+    ):
+        """A query the SL processed and rejected is returned as data, so the
+        caller can surface it to the model for self-correction."""
+        mock_sl_client.query.side_effect = QueryFailedError(
+            "Dimension 'foo' not found", "FAILED"
+        )
+
+        result = await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
+
+        assert isinstance(result, QueryMetricsError)
+        assert "foo" in result.error
+
+    async def test_query_execution_operational_error_propagates(
+        self, fetcher, mock_sl_client, mock_config
+    ):
+        """An auth/connectivity failure during execution is not a query error —
+        it must propagate rather than be flattened into a returned error string."""
+        mock_sl_client.query.side_effect = AuthError("invalid credentials")
+
+        with pytest.raises(AuthError):
+            await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
+
+    async def test_client_acquisition_error_propagates(
+        self, fetcher, client_provider, mock_config
+    ):
+        """A failure obtaining the SL client (e.g. connection refused) must
+        propagate rather than be returned as a query error."""
+        client_provider.get_client.side_effect = ConnectionError("refused")
+
+        with pytest.raises(ConnectionError):
+            await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Why

`SemanticLayerFetcher.query_metrics` caught every exception and flattened it into a returned `QueryMetricsError` string. That made two very different situations indistinguishable to callers: a query the semantic layer processed and rejected (user/agent-fixable) versus an operational failure such as an authentication or connection error (the semantic layer being unreachable). A caller that wants to surface query errors to a model for self-correction while still detecting operational failures had no way to tell them apart.

# What

`query_metrics` now returns a `QueryMetricsError` only for genuine query-level failures (`QueryFailedError`). Operational errors (auth, connection, transport, etc.) propagate as exceptions instead of being swallowed.

Timeout behavior is unchanged: COMPILED-status timeouts still raise `SemanticLayerQueryTimeoutError`, and RUNNING/unknown-status timeouts still return a `QueryMetricsError`.

Added unit tests covering the three cases: a query failure is returned as data, and an execution-time operational error and a client-acquisition error both propagate.

---
Drafted by Claude Opus 4.8 under the direction of @wiggzz.
