### PR TITLE
Handle null data in list_job_run_artifacts

### DIFF
--- a/.changes/unreleased/Bug Fix-20260603-112434.yaml
+++ b/.changes/unreleased/Bug Fix-20260603-112434.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Handle null data in list_job_run_artifacts when a run produced no artifacts
+time: 2026-06-03T11:24:34.706505-05:00

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -355,7 +355,9 @@ class DbtAdminAPIClient:
         result = await self._make_request(
             "GET", f"/api/v2/accounts/{account_id}/runs/{run_id}/artifacts/"
         )
-        data = result.get("data", [])
+        # The API returns {"data": null} when a run produced no artifacts, so
+        # coalesce to a list rather than passing the null through to iteration.
+        data = result.get("data") or []
 
         # we remove the compiled and run artifacts, they are not very relevant and there are thousands of them, filling the context
         filtered_data = [

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -513,6 +513,22 @@ async def test_list_job_run_artifacts(client):
     )
 
 
+async def test_list_job_run_artifacts_null_data(client):
+    # The dbt Cloud API returns {"data": null} when a run produced no
+    # artifacts (e.g. it errored before generating any). The null must be
+    # normalized to an empty list rather than iterated over.
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": None}
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await client.list_job_run_artifacts(12345, 100)
+
+    assert result == []
+
+
 async def test_get_job_run_artifact_json(client):
     mock_response = MagicMock()
     mock_response.text = '{"nodes": {"model.test": {}}}'


### PR DESCRIPTION
# Why

`list_job_run_artifacts` calls the dbt Cloud `runs/{id}/artifacts/` endpoint, which
returns `{"data": null}` when a run produced no artifacts (e.g. it errored before
generating any). `result.get("data", [])` only substitutes the default when the key
is absent, so a present-but-null value passed `None` straight into the list
comprehension and raised `TypeError: 'NoneType' object is not iterable`.

# What

Coalesce the response to a list (`result.get("data") or []`) so a null `data` field
is treated the same as an empty artifact list. Added a unit test covering the
`{"data": null}` response.

Drafted by Claude Opus 4.8 under the direction of @wiggzz
