### PR TITLE
Don't leak request URL in admin API error messages

### DIFF
--- a/.changes/unreleased/Bug Fix-20260603-112556.yaml
+++ b/.changes/unreleased/Bug Fix-20260603-112556.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Admin API client errors no longer include the full request URL, which could expose internal hostnames
+time: 2026-06-03T11:25:56.85535-05:00

--- a/src/dbt_mcp/dbt_admin/client.py
+++ b/src/dbt_mcp/dbt_admin/client.py
@@ -54,13 +54,20 @@ class DbtAdminAPIClient:
                 response.raise_for_status()
                 return response.json()
         except httpx.HTTPStatusError as e:
+            # Don't interpolate the httpx error directly: its string contains the
+            # full request URL, which can leak internal hostnames to the caller.
+            # The status code plus method/endpoint are enough to act on.
             if 400 <= e.response.status_code < 500:
                 raise InvalidParameterError(
-                    f"API request failed ({e.response.status_code}): {e}"
+                    f"API request failed ({e.response.status_code}) "
+                    f"for {method} {endpoint}"
                 ) from e
-            raise AdminAPIError(f"API request failed: {e}") from e
+            raise AdminAPIError(
+                f"API request failed ({e.response.status_code}) for {method} {endpoint}"
+            ) from e
         except httpx.HTTPError as e:
-            raise AdminAPIError(f"API request failed: {e}") from e
+            # Same rationale: transport errors also embed the URL in their string.
+            raise AdminAPIError(f"API request failed for {method} {endpoint}") from e
 
     async def get_account(self, account_id: int) -> dict[str, Any]:
         """Get details for an account."""

--- a/tests/unit/dbt_admin/test_client.py
+++ b/tests/unit/dbt_admin/test_client.py
@@ -135,6 +135,54 @@ async def test_make_request_5xx_raises_admin_api_error(client):
             await client._make_request("GET", "/test/endpoint")
 
 
+async def test_make_request_4xx_error_does_not_leak_request_url(client):
+    internal_url = (
+        "http://dbt-cloud-app.dbt-cloud.svc.cluster.local:8003"
+        "/api/v3/accounts/12345/projects/1/environments/?state=1"
+    )
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"Client error '404 Not Found' for url '{internal_url}'",
+        request=MagicMock(),
+        response=MagicMock(status_code=404),
+    )
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(InvalidParameterError) as exc_info:
+            await client._make_request(
+                "GET", "/api/v3/accounts/12345/projects/1/environments/?state=1"
+            )
+
+    message = str(exc_info.value)
+    assert "dbt-cloud-app.dbt-cloud.svc.cluster.local" not in message
+    assert internal_url not in message
+    assert "404" in message
+
+
+async def test_make_request_5xx_error_does_not_leak_request_url(client):
+    internal_url = (
+        "http://dbt-cloud-app.dbt-cloud.svc.cluster.local:8003/api/v2/accounts/12345/"
+    )
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"Server error '500 Internal Server Error' for url '{internal_url}'",
+        request=MagicMock(),
+        response=MagicMock(status_code=500),
+    )
+
+    mock_client = create_mock_httpx_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(AdminAPIError) as exc_info:
+            await client._make_request("GET", "/api/v2/accounts/12345/")
+
+    message = str(exc_info.value)
+    assert "dbt-cloud-app.dbt-cloud.svc.cluster.local" not in message
+    assert internal_url not in message
+
+
 async def test_list_jobs(client):
     mock_response = MagicMock()
     mock_response.json.return_value = {


### PR DESCRIPTION
# Why

When an admin API request fails, the client interpolated the raw `httpx` error into the message it raised. That error string contains the full request URL — so any failure (e.g. a 404 fetching project environments) surfaced the API host all the way back to the MCP caller. When dbt-mcp runs against an internal/self-hosted dbt platform endpoint, this leaks internal hostnames into tool error output, and the URL adds no value the LLM can act on anyway.

# What

Admin API errors now report the HTTP status code and the request method + endpoint path, but no longer include the full URL (host included) from the underlying `httpx` exception. The same applies to transport-level errors, whose string also embeds the URL.

Added unit tests asserting the raised error message does not contain the request host for both 4xx and 5xx responses.

Drafted by Claude Opus 4.8 under the direction of @wiggzz
