### PR TITLE
fix(semantic-layer): run session lifecycle off the event loop

### DIFF
--- a/.changes/unreleased/Bug Fix-20260604-093731.yaml
+++ b/.changes/unreleased/Bug Fix-20260604-093731.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Run the full Semantic Layer session lifecycle (open, query, close) in a worker thread so session acquisition no longer blocks the event loop
+time: 2026-06-04T09:37:31.049545-05:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -366,12 +366,18 @@ class SemanticLayerFetcher:
     ) -> DimensionValuesResponse:
         try:
             sl_client = await self.client_provider.get_client(config=config)
-            with sl_client.session():
-                raw_table: pa.Table = await asyncio.to_thread(
-                    sl_client.dimension_values,
-                    metrics=metrics or [],
-                    group_by=dimension,
-                )
+
+            # Opening a session is blocking I/O (it establishes a GraphQL and an
+            # ADBC/Arrow-Flight connection), so run the whole session lifecycle —
+            # open, query, close — in a worker thread to keep it off the event loop.
+            def query() -> pa.Table:
+                with sl_client.session():
+                    return sl_client.dimension_values(
+                        metrics=metrics or [],
+                        group_by=dimension,
+                    )
+
+            raw_table: pa.Table = await asyncio.to_thread(query)
             # SDK doesn't support server-side limiting; truncation is applied client-side.
             # SDK returns column names in uppercase; match case-insensitively.
             schema_names = raw_table.schema.names
@@ -493,26 +499,27 @@ class SemanticLayerFetcher:
             GetMetricsCompiledSqlResult with either the compiled SQL or an error
         """
         try:
-            sl_client = await self.client_provider.get_client(
-                config=config,
+            sl_client = await self.client_provider.get_client(config=config)
+            parsed_order_by: list[OrderBySpec] = self._get_order_bys(
+                order_by=order_by, metrics=metrics, group_by=group_by
             )
-            with sl_client.session():
-                parsed_order_by: list[OrderBySpec] = self._get_order_bys(
-                    order_by=order_by, metrics=metrics, group_by=group_by
-                )
-                compiled_sql = await asyncio.to_thread(
-                    sl_client.compile_sql,
-                    metrics=metrics,
-                    group_by=group_by,  # type: ignore
-                    order_by=parsed_order_by,  # type: ignore
-                    where=[normalized_where]
-                    if (normalized_where := self._normalize_where(where))
-                    else None,
-                    limit=limit,
-                    read_cache=True,
-                )
+            normalized_where = self._normalize_where(where)
 
-                return GetMetricsCompiledSqlSuccess(sql=compiled_sql)
+            # Run the whole session lifecycle off the event loop — see the note
+            # in get_dimension_values; opening a session is blocking I/O.
+            def query() -> str:
+                with sl_client.session():
+                    return sl_client.compile_sql(
+                        metrics=metrics,
+                        group_by=group_by,  # type: ignore
+                        order_by=parsed_order_by,  # type: ignore
+                        where=[normalized_where] if normalized_where else None,
+                        limit=limit,
+                        read_cache=True,
+                    )
+
+            compiled_sql = await asyncio.to_thread(query)
+            return GetMetricsCompiledSqlSuccess(sql=compiled_sql)
 
         except Exception as e:
             return self._format_get_metrics_compiled_sql_error(e)
@@ -529,45 +536,46 @@ class SemanticLayerFetcher:
     ) -> QueryMetricsResult:
         try:
             query_error: Exception | None = None
-            sl_client = await self.client_provider.get_client(
-                config=config,
+            sl_client = await self.client_provider.get_client(config=config)
+            parsed_order_by: list[OrderBySpec] = self._get_order_bys(
+                order_by=order_by, metrics=metrics, group_by=group_by
             )
-            with sl_client.session():
-                # Only query-level failures (the SL processed the query and
-                # rejected it) are returned to the caller as data. Operational
-                # failures (auth, connection, transport) propagate so callers
-                # can distinguish a bad query from an unreachable semantic layer.
-                # The `with` block handles session cleanup either way.
-                try:
-                    parsed_order_by: list[OrderBySpec] = self._get_order_bys(
-                        order_by=order_by, metrics=metrics, group_by=group_by
-                    )
-                    query_result = await asyncio.to_thread(
-                        sl_client.query,
+            normalized_where = self._normalize_where(where)
+
+            # Run the whole session lifecycle off the event loop — see the note
+            # in get_dimension_values; opening a session is blocking I/O.
+            def query() -> pa.Table:
+                with sl_client.session():
+                    return sl_client.query(
                         metrics=metrics,
                         group_by=group_by,  # type: ignore
                         order_by=parsed_order_by,  # type: ignore
-                        where=[normalized_where]
-                        if (normalized_where := self._normalize_where(where))
-                        else None,
+                        where=[normalized_where] if normalized_where else None,
                         limit=limit,
                     )
-                except RetryTimeoutError as e:
-                    # Queries that timeout with COMPILED status have finished SQL
-                    # compilation and are executing against the data platform. In
-                    # agent contexts, this indicates the query is too complex and
-                    # the client should request a simpler query.
-                    if e.status == QueryStatus.COMPILED.value:
-                        raise SemanticLayerQueryTimeoutError(
-                            f"The semantic layer query timed out after {e.timeout_s}s while "
-                            f"executing against the data platform (status: COMPILED). This "
-                            f"indicates the query is too complex or returns too much data "
-                            f"for an agent context. Please simplify the query by adding "
-                            f"filters, reducing dimensions, or limiting results."
-                        ) from e
-                    query_error = e
-                except QueryFailedError as e:
-                    query_error = e
+
+            # Only query-level failures (the SL processed the query and rejected
+            # it) are returned to the caller as data. Operational failures (auth,
+            # connection, transport) propagate so callers can distinguish a bad
+            # query from an unreachable semantic layer.
+            try:
+                query_result = await asyncio.to_thread(query)
+            except RetryTimeoutError as e:
+                # Queries that timeout with COMPILED status have finished SQL
+                # compilation and are executing against the data platform. In
+                # agent contexts, this indicates the query is too complex and
+                # the client should request a simpler query.
+                if e.status == QueryStatus.COMPILED.value:
+                    raise SemanticLayerQueryTimeoutError(
+                        f"The semantic layer query timed out after {e.timeout_s}s while "
+                        f"executing against the data platform (status: COMPILED). This "
+                        f"indicates the query is too complex or returns too much data "
+                        f"for an agent context. Please simplify the query by adding "
+                        f"filters, reducing dimensions, or limiting results."
+                    ) from e
+                query_error = e
+            except QueryFailedError as e:
+                query_error = e
             if query_error:
                 return self._format_query_failed_error(query_error)
             formatter = result_formatter or DEFAULT_RESULT_FORMATTER

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -1,6 +1,7 @@
 import base64
 import datetime as dt
 import json
+import threading
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1067,3 +1068,100 @@ class TestGetDimensionValues:
         )
         assert result.values == ["US", "FR"]
         assert result.truncated is False
+
+
+class TestSessionRunsOffEventLoop:
+    """Opening a Semantic Layer session is blocking I/O (it establishes a
+    GraphQL connection and an ADBC/Arrow-Flight connection). The whole session
+    lifecycle — `__enter__`, the SDK call, and `__exit__` — must run in a worker
+    thread so it never stalls the event loop, not just the SDK call itself.
+    """
+
+    @pytest.fixture
+    def loop_thread_id(self):
+        return threading.get_ident()
+
+    @pytest.fixture
+    def recording_sl_client(self):
+        """A client that records the thread id used at each step of the session."""
+        threads: dict[str, int] = {}
+        client = MagicMock()
+        session_ctx = MagicMock()
+        client.session.return_value = session_ctx
+
+        def _enter():
+            threads["enter"] = threading.get_ident()
+            return client
+
+        def _exit(*_args):
+            threads["exit"] = threading.get_ident()
+            return False
+
+        session_ctx.__enter__ = MagicMock(side_effect=_enter)
+        session_ctx.__exit__ = MagicMock(side_effect=_exit)
+
+        def _record(name, return_value):
+            def _call(**_kwargs):
+                threads[name] = threading.get_ident()
+                return return_value
+
+            return _call
+
+        client.query.side_effect = _record("query", pa.table({"a": [1]}))
+        client.compile_sql.side_effect = _record("compile_sql", "select 1")
+        client.dimension_values.side_effect = _record(
+            "dimension_values", pa.table({"d": ["x"]})
+        )
+        client._recorded_threads = threads
+        return client
+
+    @pytest.fixture
+    def sl_config(self):
+        token_p = MagicMock()
+        token_p.get_token.return_value = "tok"
+        headers_p = MagicMock()
+        headers_p.get_headers.return_value = {}
+        return SemanticLayerConfig(
+            url="https://test-host/api/graphql",
+            host="test-host",
+            prod_environment_id=123,
+            token_provider=token_p,
+            headers_provider=headers_p,
+        )
+
+    @pytest.fixture
+    def fetcher(self, mock_client_provider, recording_sl_client):
+        mock_client_provider.get_client.return_value = recording_sl_client
+        return SemanticLayerFetcher(client_provider=mock_client_provider)
+
+    @pytest.mark.asyncio
+    async def test_query_metrics_session_off_loop(
+        self, fetcher, recording_sl_client, sl_config, loop_thread_id
+    ):
+        await fetcher.query_metrics(config=sl_config, metrics=["revenue"])
+        threads = recording_sl_client._recorded_threads
+        assert threads["enter"] != loop_thread_id
+        assert threads["query"] != loop_thread_id
+        assert threads["exit"] != loop_thread_id
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_compiled_sql_session_off_loop(
+        self, fetcher, recording_sl_client, sl_config, loop_thread_id
+    ):
+        await fetcher.get_metrics_compiled_sql(config=sl_config, metrics=["revenue"])
+        threads = recording_sl_client._recorded_threads
+        assert threads["enter"] != loop_thread_id
+        assert threads["compile_sql"] != loop_thread_id
+        assert threads["exit"] != loop_thread_id
+
+    @pytest.mark.asyncio
+    async def test_get_dimension_values_session_off_loop(
+        self, fetcher, recording_sl_client, sl_config, loop_thread_id
+    ):
+        await fetcher.get_dimension_values(
+            config=sl_config, dimension="d", metrics=["revenue"]
+        )
+        threads = recording_sl_client._recorded_threads
+        assert threads["enter"] != loop_thread_id
+        assert threads["dimension_values"] != loop_thread_id
+        assert threads["exit"] != loop_thread_id


### PR DESCRIPTION
# Why

`SemanticLayerFetcher` runs synchronous dbt-sl-sdk calls from an async context. A previous fix wrapped the SDK calls (`query`, `compile_sql`, `dimension_values`) in `asyncio.to_thread`, but left the surrounding `with sl_client.session():` block running on the event loop.

Opening a session is itself blocking I/O — it establishes both a GraphQL connection and an ADBC/Arrow-Flight connection synchronously. So session acquisition was still stalling the event loop, showing up as slow-callback / blocked-thread warnings during semantic layer queries.

# What

Move the entire session lifecycle — `session()` enter, the SDK call, and exit — into a single synchronous `query()` function that is run via `asyncio.to_thread`, instead of threading only the SDK call. Applied to all three affected methods: `query_metrics`, `get_metrics_compiled_sql`, and `get_dimension_values`.

Client acquisition stays on the loop (it's `await`ed). Error semantics are unchanged: `query_metrics` still returns query-level failures as data while letting operational failures (auth/connection) propagate — the `try/except` now wraps the `to_thread` call rather than living inside the session block.

A regression test asserts that session enter/exit and the SDK call all run on a worker thread, not the event loop thread.

Drafted by Claude Opus 4.8 under the direction of @wiggzz
