### PR TITLE
fix: wrap get_model_health result in a list to match list[dict] schema

### DIFF
--- a/.changes/unreleased/Bug Fix-20260615-134205.yaml
+++ b/.changes/unreleased/Bug Fix-20260615-134205.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: 'Fix get_model_health response schema: wrap single-node result in a list to match the declared list[dict] return type'
+time: 2026-06-15T13:42:05.557078-07:00

--- a/src/dbt_mcp/config/config.py
+++ b/src/dbt_mcp/config/config.py
@@ -104,7 +104,7 @@ class Config:
     # product_docs tool actually needs the version, then cached for the
     # lifetime of the closure.
     dbt_version_provider: Callable[[], str | None] = field(
-        default_factory=lambda: (lambda: None)
+        default_factory=lambda: lambda: None
     )
 
 

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -577,7 +577,7 @@ class ModelsFetcher:
         edges = result["data"]["environment"]["applied"]["models"]["edges"]
         if not edges:
             return []
-        return edges[0]["node"]
+        return [edges[0]["node"]]
 
 
 class ExposuresFetcher:

--- a/tests/unit/discovery/test_models_fetcher.py
+++ b/tests/unit/discovery/test_models_fetcher.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock
+
+import pytest
+
+from dbt_mcp.discovery.client import ModelsFetcher
+
+
+@pytest.fixture
+def models_fetcher():
+    return ModelsFetcher(paginator=Mock())
+
+
+async def test_fetch_model_health_wraps_single_node_in_list(
+    models_fetcher, mock_api_client, unit_discovery_config
+):
+    """fetch_model_health must return a list[dict], not a bare dict."""
+    node = {
+        "uniqueId": "model.project.my_model",
+        "executionInfo": {"lastSuccessJobDefinitionId": 1, "lastRunStatus": "success"},
+        "tests": [{"name": "not_null", "status": "pass"}],
+        "ancestors": [],
+    }
+    mock_api_client.return_value = {
+        "data": {
+            "environment": {
+                "applied": {
+                    "models": {
+                        "edges": [{"node": node}]
+                    }
+                }
+            }
+        }
+    }
+
+    result = await models_fetcher.fetch_model_health(
+        unique_id="model.project.my_model", config=unit_discovery_config
+    )
+
+    assert isinstance(result, list), (
+        "fetch_model_health must return a list, not a bare dict"
+    )
+    assert len(result) == 1
+    assert result[0] == node
+
+
+async def test_fetch_model_health_empty_edges_returns_empty_list(
+    models_fetcher, mock_api_client, unit_discovery_config
+):
+    """fetch_model_health returns [] when no model is found."""
+    mock_api_client.return_value = {
+        "data": {
+            "environment": {
+                "applied": {
+                    "models": {
+                        "edges": []
+                    }
+                }
+            }
+        }
+    }
+
+    result = await models_fetcher.fetch_model_health(
+        unique_id="model.project.nonexistent", config=unit_discovery_config
+    )
+
+    assert result == []

--- a/tests/unit/discovery/test_models_fetcher.py
+++ b/tests/unit/discovery/test_models_fetcher.py
@@ -21,15 +21,7 @@ async def test_fetch_model_health_wraps_single_node_in_list(
         "ancestors": [],
     }
     mock_api_client.return_value = {
-        "data": {
-            "environment": {
-                "applied": {
-                    "models": {
-                        "edges": [{"node": node}]
-                    }
-                }
-            }
-        }
+        "data": {"environment": {"applied": {"models": {"edges": [{"node": node}]}}}}
     }
 
     result = await models_fetcher.fetch_model_health(
@@ -48,15 +40,7 @@ async def test_fetch_model_health_empty_edges_returns_empty_list(
 ):
     """fetch_model_health returns [] when no model is found."""
     mock_api_client.return_value = {
-        "data": {
-            "environment": {
-                "applied": {
-                    "models": {
-                        "edges": []
-                    }
-                }
-            }
-        }
+        "data": {"environment": {"applied": {"models": {"edges": []}}}}
     }
 
     result = await models_fetcher.fetch_model_health(

--- a/tests/unit/lsp/test_lsp_connection.py
+++ b/tests/unit/lsp/test_lsp_connection.py
@@ -261,8 +261,8 @@ class TestStartStop:
                 mock_loop.return_value.run_in_executor.return_value = (
                     mock_accept_wrapper()
                 )
-                mock_loop.return_value.create_task.side_effect = (
-                    lambda coro: asyncio.create_task(coro)
+                mock_loop.return_value.create_task.side_effect = lambda coro: (
+                    asyncio.create_task(coro)
                 )
 
                 await conn.start()
@@ -950,8 +950,8 @@ class TestReadWriteLoops:
         ):
             mock_loop = MagicMock()
             mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor.side_effect = (
-                lambda _, func, *args: mock_recv_wrapper(*args)
+            mock_loop.run_in_executor.side_effect = lambda _, func, *args: (
+                mock_recv_wrapper(*args)
             )
 
             # Run read loop (will exit when recv returns empty)


### PR DESCRIPTION
## Why

`get_model_health` was failing response validation on every call with:

```
Input should be a valid list [type=list_type, input_type=dict]
```

The tool is declared `-> list[dict]` with `structured_output=True`, so FastMCP generates a Pydantic output model that expects a JSON array. But `fetch_model_health` returned a bare dict (`edges[0]["node"]`), causing Pydantic to reject the response on every invocation. The underlying data was present — this was purely a response-schema mismatch.

## What

Wraps the returned node in a list so the result matches the declared `list[dict]` contract — consistent with how `fetch_model_parents` and `fetch_model_children` return their respective list fields. The empty-model case (`return []`) was already correct.

Adds a regression test covering both the found-model case (result is a `list` of length 1) and the empty-model case.

Drafted by claude-opus-4-8 under the direction of @theyostalservice