### PR TITLE
Make the --quiet flag configurable on dbt CLI tools

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260617-185651.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260617-185651.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Make the --quiet flag configurable on dbt CLI tools
+time: 2026-06-17T18:56:51.545347-07:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 from collections.abc import Iterable
-from typing import Any
+from typing import Annotated, Any
 import logging
 
 from mcp.server.fastmcp import FastMCP
@@ -59,6 +59,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         sample: str | None = None,
         yml_selector: str | None = None,
         state_path: str | None = None,
+        is_quiet: bool = True,
     ) -> str:
         try:
             # Commands that should always be quiet to reduce output verbosity
@@ -117,7 +118,11 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
 
             full_command = command.copy()
             # Add --quiet flag to specific commands to reduce context window usage
-            if len(full_command) > 0 and full_command[0] in verbose_commands:
+            if (
+                is_quiet
+                and len(full_command) > 0
+                and full_command[0] in verbose_commands
+            ):
                 main_command = full_command[0]
                 command_args = full_command[1:] if len(full_command) > 1 else []
                 full_command = [main_command, "--quiet", *command_args]
@@ -177,6 +182,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         sample: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/sample")
         ),
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
     ) -> str:
         return _run_dbt_command(
             ["build"],
@@ -186,6 +194,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             vars=vars,
             sample=sample,
             yml_selector=yml_selector,
+            is_quiet=is_quiet,
         )
 
     def compile(
@@ -195,13 +204,24 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         yml_selector: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/yml_selector")
         ),
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
     ) -> str:
         return _run_dbt_command(
-            ["compile"], node_selection, is_selectable=True, yml_selector=yml_selector
+            ["compile"],
+            node_selection,
+            is_selectable=True,
+            yml_selector=yml_selector,
+            is_quiet=is_quiet,
         )
 
-    def docs() -> str:
-        return _run_dbt_command(["docs", "generate"])
+    def docs(
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
+    ) -> str:
+        return _run_dbt_command(["docs", "generate"], is_quiet=is_quiet)
 
     def ls(
         node_selection: str | None = Field(
@@ -214,6 +234,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             default=None,
             description=get_prompt("dbt_cli/args/resource_type"),
         ),
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
     ) -> str:
         return _run_dbt_command(
             ["list"],
@@ -221,10 +244,15 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             resource_type=resource_type,
             is_selectable=True,
             yml_selector=yml_selector,
+            is_quiet=is_quiet,
         )
 
-    def parse() -> str:
-        return _run_dbt_command(["parse"])
+    def parse(
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
+    ) -> str:
+        return _run_dbt_command(["parse"], is_quiet=is_quiet)
 
     def run(
         node_selection: str | None = Field(
@@ -242,6 +270,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         sample: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/sample")
         ),
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
     ) -> str:
         return _run_dbt_command(
             ["run"],
@@ -251,6 +282,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             vars=vars,
             sample=sample,
             yml_selector=yml_selector,
+            is_quiet=is_quiet,
         )
 
     def test(
@@ -263,6 +295,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         vars: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/vars")
         ),
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
     ) -> str:
         return _run_dbt_command(
             ["test"],
@@ -270,6 +305,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             is_selectable=True,
             vars=vars,
             yml_selector=yml_selector,
+            is_quiet=is_quiet,
         )
 
     def show(
@@ -311,6 +347,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
         state_path: str | None = Field(
             default=None, description=get_prompt("dbt_cli/args/state_path")
         ),
+        is_quiet: Annotated[
+            bool, Field(description=get_prompt("dbt_cli/args/is_quiet"))
+        ] = True,
     ) -> str:
         return _run_dbt_command(
             ["clone"],
@@ -320,6 +359,7 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
             vars=vars,
             yml_selector=yml_selector,
             state_path=state_path,
+            is_quiet=is_quiet,
         )
 
     def _get_manifest() -> Manifest:

--- a/src/dbt_mcp/prompts/dbt_cli/args/is_quiet.md
+++ b/src/dbt_mcp/prompts/dbt_cli/args/is_quiet.md
@@ -1,0 +1,3 @@
+Whether to pass `--quiet` to the dbt command, which suppresses log output and reduces token usage. Defaults to `true`.
+
+Set to `false` when you need full command output — for example, when using the dbt Cloud CLI (where `--quiet` suppresses all meaningful output) or when diagnosing failures.

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -841,3 +841,63 @@ def test_resource_type_accepts_valid_values(
     )
 
     tools["ls"](resource_type=valid_types)
+
+
+def test_quiet_can_be_explicitly_disabled_for_core(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        mock_dbt_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    tools["run"](is_quiet=False)
+
+    assert mock_calls
+    assert "--quiet" not in mock_calls[0]
+
+
+def test_quiet_can_be_explicitly_enabled_for_cloud_cli(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp
+):
+    mock_calls = []
+
+    def mock_popen(args, **kwargs):
+        mock_calls.append(args)
+        return mock_process
+
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    fastmcp, tools = mock_fastmcp
+    cloud_cli_config = DbtCliConfig(
+        project_dir="/test/project",
+        dbt_path="/path/to/dbt",
+        dbt_cli_timeout=10,
+        binary_type=BinaryType.DBT_CLOUD_CLI,
+    )
+    register_dbt_cli_tools(
+        fastmcp,
+        cloud_cli_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    tools["run"](is_quiet=True)
+
+    assert mock_calls
+    assert "--quiet" in mock_calls[0]


### PR DESCRIPTION
## Summary

Adds an `is_quiet` parameter to all dbt CLI tools that previously hardcoded `--quiet`.

## What Changed

- Added `is_quiet: bool = True` parameter to `build`, `compile`, `run`, `test`, `docs`, `parse`, `list`, and `clone`
- Added prompt description for the new parameter
- Added unit tests covering explicit opt-out and opt-in

## Why

The `--quiet` flag was intentionally hardcoded to reduce token noise. This PR preserves that as the default while letting users set `is_quiet=False` when they need full output — for example, when using the dbt Cloud CLI where `--quiet` suppresses all meaningful output.

## Related Issues

Closes #808

## Checklist
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes