### PR TITLE
Track MCP client identity in Vortex tool call events

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260618-182823.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260618-182823.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Track MCP client identity (name and version from the MCP initialize handshake) in Vortex tool call events via the user_agent field
+time: 2026-06-18T18:28:23.204012+02:00

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -84,7 +84,7 @@ class DbtMCP(FastMCP):
             client_params = self.get_context().request_context.session.client_params
             if client_params:
                 return client_params.clientInfo.name, client_params.clientInfo.version
-        except (LookupError, ValueError):
+        except Exception:
             pass
         return "", ""
 

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -79,12 +79,22 @@ class DbtMCP(FastMCP):
             settings.dbt_project_ids is not None and len(settings.dbt_project_ids) > 0
         )
 
+    def _get_mcp_client_info(self) -> tuple[str, str]:
+        try:
+            client_params = self.get_context().request_context.session.client_params
+            if client_params:
+                return client_params.clientInfo.name, client_params.clientInfo.version
+        except (LookupError, ValueError):
+            pass
+        return "", ""
+
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
     ) -> Sequence[ContentBlock] | dict[str, Any]:
         logger.info(f"Calling tool: {name} with arguments: {_safe_args(arguments)}")
         result = None
         start_time = int(time.time() * 1000)
+        mcp_client_name, mcp_client_version = self._get_mcp_client_info()
         try:
             if await self._is_multi_project():
                 result = await self.multi_project_mcp.call_tool(name, arguments)
@@ -104,6 +114,8 @@ class DbtMCP(FastMCP):
                         start_time_ms=start_time,
                         end_time_ms=end_time,
                         error_message=str(e),
+                        mcp_client_name=mcp_client_name,
+                        mcp_client_version=mcp_client_version,
                     ),
                 )
             except Exception:
@@ -120,6 +132,8 @@ class DbtMCP(FastMCP):
                     start_time_ms=start_time,
                     end_time_ms=end_time,
                     error_message=None,
+                    mcp_client_name=mcp_client_name,
+                    mcp_client_version=mcp_client_version,
                 ),
             )
         except Exception:

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -33,6 +33,8 @@ class ToolCalledEvent:
     error_message: str | None
     start_time_ms: int
     end_time_ms: int
+    mcp_client_name: str = ""
+    mcp_client_version: str = ""
 
 
 class UsageTracker(Protocol):
@@ -167,7 +169,12 @@ class DefaultUsageTracker:
                     disabled_tools=[
                         tool.value for tool in settings.disable_tools or []
                     ],
-                    user_agent="",  # Only used for remote MCP
+                    user_agent=(
+                        f"{tool_called_event.mcp_client_name}/{tool_called_event.mcp_client_version}"
+                        if tool_called_event.mcp_client_name
+                        and tool_called_event.mcp_client_version
+                        else tool_called_event.mcp_client_name
+                    ),
                 )
             )
         except Exception as e:

--- a/tests/unit/mcp/test_dispatcher.py
+++ b/tests/unit/mcp/test_dispatcher.py
@@ -254,6 +254,16 @@ class TestMcpClientInfo:
         assert name == ""
         assert version == ""
 
+    async def test_get_mcp_client_info_returns_empty_when_client_info_missing(self):
+        """Non-compliant clients may omit clientInfo; should not raise."""
+        dispatcher = _make_dispatcher()
+        ctx = MagicMock()
+        ctx.request_context.session.client_params.clientInfo = None
+        with patch.object(dispatcher, "get_context", return_value=ctx):
+            name, version = dispatcher._get_mcp_client_info()
+        assert name == ""
+        assert version == ""
+
 
 class TestAppLifespanLogging:
     async def test_lifespan_logs_exception_with_traceback(self, caplog):

--- a/tests/unit/mcp/test_dispatcher.py
+++ b/tests/unit/mcp/test_dispatcher.py
@@ -11,7 +11,7 @@ from dbt_mcp.errors.common import MissingHostError
 from dbt_mcp.config.settings import DbtMcpSettings
 from dbt_mcp.mcp.server import DbtMCP
 from dbt_mcp.oauth.token_provider import StaticTokenProvider
-from dbt_mcp.tracking.tracking import UsageTracker
+from dbt_mcp.tracking.tracking import ToolCalledEvent, UsageTracker
 
 
 def _make_dispatcher(
@@ -183,6 +183,76 @@ class TestCallToolRouting:
 
         # Tracking was attempted (and failed, but didn't suppress the tool error)
         dispatcher.usage_tracker.emit_tool_called_event.assert_awaited_once()
+
+
+class TestMcpClientInfo:
+    async def test_get_mcp_client_info_extracts_name_and_version(self):
+        """Verify the extraction chain from get_context() to clientInfo fields."""
+        from mcp.types import (
+            ClientCapabilities,
+            Implementation,
+            InitializeRequestParams,
+        )
+
+        client_params = InitializeRequestParams(
+            protocolVersion="2024-11-05",
+            capabilities=ClientCapabilities(),
+            clientInfo=Implementation(name="Claude", version="1.2.3"),
+        )
+        ctx = MagicMock()
+        ctx.request_context.session.client_params = client_params
+
+        dispatcher = _make_dispatcher()
+        with patch.object(dispatcher, "get_context", return_value=ctx):
+            name, version = dispatcher._get_mcp_client_info()
+
+        assert name == "Claude"
+        assert version == "1.2.3"
+
+    async def test_client_info_passed_to_tracking_event(self):
+        single = MagicMock(spec=FastMCP)
+        single.call_tool = AsyncMock(return_value=[TextContent(type="text", text="ok")])
+        dispatcher = _make_dispatcher(single_project_mcp=single)
+
+        with (
+            patch.object(
+                dispatcher, "_is_multi_project", AsyncMock(return_value=False)
+            ),
+            patch.object(
+                dispatcher,
+                "_get_mcp_client_info",
+                return_value=("Claude", "1.2.3"),
+            ),
+        ):
+            await dispatcher.call_tool("some_tool", {})
+
+        event: ToolCalledEvent = (
+            dispatcher.usage_tracker.emit_tool_called_event.call_args.kwargs[
+                "tool_called_event"
+            ]
+        )
+        assert event.mcp_client_name == "Claude"
+        assert event.mcp_client_version == "1.2.3"
+
+    async def test_get_mcp_client_info_returns_empty_when_no_context(self):
+        dispatcher = _make_dispatcher()
+        # FastMCP raises ValueError when request_context is accessed with no active request;
+        # mirror that by having get_context() raise
+        with patch.object(
+            dispatcher, "get_context", side_effect=ValueError("no context")
+        ):
+            name, version = dispatcher._get_mcp_client_info()
+        assert name == ""
+        assert version == ""
+
+    async def test_get_mcp_client_info_returns_empty_when_no_client_params(self):
+        dispatcher = _make_dispatcher()
+        ctx = MagicMock()
+        ctx.request_context.session.client_params = None
+        with patch.object(dispatcher, "get_context", return_value=ctx):
+            name, version = dispatcher._get_mcp_client_info()
+        assert name == ""
+        assert version == ""
 
 
 class TestAppLifespanLogging:

--- a/tests/unit/tracking/test_tracking.py
+++ b/tests/unit/tracking/test_tracking.py
@@ -596,6 +596,106 @@ class TestUsageTracker:
         assert tool_called.tool_name == "list_metrics"
 
     @pytest.mark.asyncio
+    async def test_emit_tool_called_event_includes_mcp_client_in_user_agent(self):
+        """mcp_client_name and mcp_client_version are emitted as user_agent."""
+        mock_settings = DbtMcpSettings.model_construct(
+            do_not_track=None,
+            send_anonymous_usage_data=None,
+        )
+        tracker = DefaultUsageTracker(
+            credentials_provider=MockCredentialsProvider(mock_settings),
+            session_id=uuid.uuid4(),
+        )
+
+        with (
+            patch("dbt_mcp.tracking.tracking.log_proto") as mock_log_proto,
+            patch(
+                "dbt_mcp.tracking.tracking.DefaultUsageTracker._get_local_user_id",
+                return_value="local-user",
+            ),
+        ):
+            await tracker.emit_tool_called_event(
+                tool_called_event=ToolCalledEvent(
+                    tool_name="list_metrics",
+                    arguments={},
+                    start_time_ms=0,
+                    end_time_ms=1,
+                    error_message=None,
+                    mcp_client_name="Claude",
+                    mcp_client_version="1.2.3",
+                ),
+            )
+
+        tool_called = mock_log_proto.call_args.args[0]
+        assert tool_called.user_agent == "Claude/1.2.3"
+
+    @pytest.mark.asyncio
+    async def test_emit_tool_called_event_user_agent_name_only(self):
+        """When mcp_client_version is empty, user_agent is just the name."""
+        mock_settings = DbtMcpSettings.model_construct(
+            do_not_track=None,
+            send_anonymous_usage_data=None,
+        )
+        tracker = DefaultUsageTracker(
+            credentials_provider=MockCredentialsProvider(mock_settings),
+            session_id=uuid.uuid4(),
+        )
+
+        with (
+            patch("dbt_mcp.tracking.tracking.log_proto") as mock_log_proto,
+            patch(
+                "dbt_mcp.tracking.tracking.DefaultUsageTracker._get_local_user_id",
+                return_value="local-user",
+            ),
+        ):
+            await tracker.emit_tool_called_event(
+                tool_called_event=ToolCalledEvent(
+                    tool_name="list_metrics",
+                    arguments={},
+                    start_time_ms=0,
+                    end_time_ms=1,
+                    error_message=None,
+                    mcp_client_name="Claude",
+                    mcp_client_version="",
+                ),
+            )
+
+        tool_called = mock_log_proto.call_args.args[0]
+        assert tool_called.user_agent == "Claude"
+
+    @pytest.mark.asyncio
+    async def test_emit_tool_called_event_user_agent_empty_when_no_client_info(self):
+        """When mcp_client_name is empty, user_agent is empty string."""
+        mock_settings = DbtMcpSettings.model_construct(
+            do_not_track=None,
+            send_anonymous_usage_data=None,
+        )
+        tracker = DefaultUsageTracker(
+            credentials_provider=MockCredentialsProvider(mock_settings),
+            session_id=uuid.uuid4(),
+        )
+
+        with (
+            patch("dbt_mcp.tracking.tracking.log_proto") as mock_log_proto,
+            patch(
+                "dbt_mcp.tracking.tracking.DefaultUsageTracker._get_local_user_id",
+                return_value="local-user",
+            ),
+        ):
+            await tracker.emit_tool_called_event(
+                tool_called_event=ToolCalledEvent(
+                    tool_name="list_metrics",
+                    arguments={},
+                    start_time_ms=0,
+                    end_time_ms=1,
+                    error_message=None,
+                ),
+            )
+
+        tool_called = mock_log_proto.call_args.args[0]
+        assert tool_called.user_agent == ""
+
+    @pytest.mark.asyncio
     async def test_sql_query_and_vars_redacted_in_telemetry(self):
         """sql_query and vars values are redacted; keys and other args are kept."""
         mock_settings = DbtMcpSettings.model_construct(


### PR DESCRIPTION
## Summary

- Reads `clientInfo` (name + version) from the MCP `initialize` handshake, which every compliant MCP client sends when it first connects
- Emits it as `user_agent` in `ToolCalled` Vortex events (format: `name/version`, e.g. `Claude/1.2.3`)
- Previously `user_agent` was always `""` for local MCP (it was only populated for remote MCP via HTTP headers); now it's populated for all connections

This lets us segment tool usage by MCP client (Claude Desktop, Cursor, Cline, etc.) in analytics without waiting for a new proto field.

## How it works

`clientInfo` is a standard part of the MCP protocol — clients send it in the `initialize` request before any tool calls. The MCP SDK stores it on `ServerSession.client_params.clientInfo`. We read it via `FastMCP.get_context().request_context.session.client_params` at the start of each `call_tool` invocation.

If `clientInfo` is unavailable (no active request context, or client didn't send it), `user_agent` falls back to `""` — same as before.