### PR TITLE
fix: preserve unique_id casing in Discovery API queries

### DIFF
--- a/.changes/unreleased/Bug Fix-20260625-120819.yaml
+++ b/.changes/unreleased/Bug Fix-20260625-120819.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Preserve unique_id casing when querying the Discovery API — the uniqueIds filter is case-sensitive, so lowercasing caused empty results for models with uppercase names
+time: 2026-06-25T12:08:19.684895+02:00

--- a/src/dbt_mcp/discovery/client.py
+++ b/src/dbt_mcp/discovery/client.py
@@ -744,21 +744,23 @@ class ResourceDetailsFetcher:
         name: str | None = None,
         unique_id: str | None = None,
     ) -> list[dict]:
-        normalized_name = name.strip().lower() if name else None
-        normalized_unique_id = unique_id.strip().lower() if unique_id else None
+        stripped_name = name.strip() if name else None
+        normalized_name = stripped_name.lower() if stripped_name else None
+        # Do not lowercase unique_id — the Discovery API uniqueIds filter is case-sensitive
+        stripped_unique_id = unique_id.strip() if unique_id else None
         environment_id = config.environment_id
-        if not normalized_name and not normalized_unique_id:
+        if not stripped_name and not stripped_unique_id:
             raise InvalidParameterError("Either name or unique_id must be provided")
         if (
             normalized_name
-            and normalized_unique_id
-            and normalized_name != normalized_unique_id.split(".")[-1]
+            and stripped_unique_id
+            and normalized_name != stripped_unique_id.split(".")[-1].lower()
         ):
             raise InvalidParameterError(
                 f"Name and unique_id do not match. The unique_id does not end with {normalized_name}."
             )
-        if not normalized_unique_id:
-            assert normalized_name is not None, "Name must be provided"
+        if not stripped_unique_id:
+            assert stripped_name is not None, "Name must be provided"
             packages_result = await asyncio.gather(
                 execute_query(
                     self.GET_PACKAGES_QUERY,
@@ -781,12 +783,15 @@ class ResourceDetailsFetcher:
             ]
             if not macro_packages and not model_packages:
                 raise InvalidParameterError("No packages found for project")
+            # Try both the provided casing and lowercase to handle resources with uppercase names
+            name_candidates = sorted({stripped_name, stripped_name.lower()})
             unique_ids = [
-                f"{resource_type.value.lower()}.{package_name}.{normalized_name}"
+                f"{resource_type.value.lower()}.{package_name}.{name_candidate}"
                 for package_name in macro_packages + model_packages
+                for name_candidate in name_candidates
             ]
         else:
-            unique_ids = [normalized_unique_id]
+            unique_ids = [stripped_unique_id]
         query = self.GQL_QUERIES[resource_type]
         variables = {
             "environmentId": environment_id,

--- a/tests/unit/discovery/test_resource_details_fetcher.py
+++ b/tests/unit/discovery/test_resource_details_fetcher.py
@@ -71,7 +71,7 @@ async def test_fetch_details_with_unique_id(
     result = await resource_details_fetcher.fetch_details(
         AppliedResourceType.MODEL,
         unit_discovery_config,
-        unique_id=" Model.Jaffle.Orders ",
+        unique_id=" model.jaffle.orders ",
     )
 
     assert result == [
@@ -124,8 +124,11 @@ async def test_fetch_details_with_name_builds_unique_ids(
             if variables["resource"] == "model":
                 return model_packages_response
         elif query == ResourceDetailsFetcher.GQL_QUERIES[AppliedResourceType.MACRO]:
+            # Both original case and lowercase are tried to handle resources with uppercase names
             expected_unique_ids = [
+                "macro.core_macros.My_Macro",
                 "macro.core_macros.my_macro",
+                "macro.analytics_models.My_Macro",
                 "macro.analytics_models.my_macro",
             ]
             assert variables["filter"]["uniqueIds"] == expected_unique_ids
@@ -154,6 +157,77 @@ async def test_fetch_details_with_name_builds_unique_ids(
             call(model_packages_response),
             call(details_response),
         ]
+    )
+
+
+@patch("dbt_mcp.discovery.client.raise_gql_error")
+async def test_fetch_details_preserves_unique_id_casing(
+    mock_raise_gql_error: Mock,
+    resource_details_fetcher: ResourceDetailsFetcher,
+    mock_api_client: Mock,
+    unit_discovery_config: DiscoveryConfig,
+):
+    """unique_id casing must be preserved — the Discovery API uniqueIds filter is case-sensitive."""
+    details_response = {
+        "data": {
+            "environment": {
+                "applied": {
+                    "resources": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "MY_MODEL",
+                                    "uniqueId": "model.jaffle.MY_MODEL",
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    mock_api_client.return_value = details_response
+
+    await resource_details_fetcher.fetch_details(
+        AppliedResourceType.MODEL,
+        unit_discovery_config,
+        unique_id="model.jaffle.MY_MODEL",
+    )
+
+    _, variables = mock_api_client.call_args[0]
+    assert variables["filter"]["uniqueIds"] == ["model.jaffle.MY_MODEL"]
+
+
+@patch("dbt_mcp.discovery.client.raise_gql_error")
+async def test_fetch_details_with_lowercase_name_no_duplicate_candidates(
+    mock_raise_gql_error: Mock,
+    resource_details_fetcher: ResourceDetailsFetcher,
+    mock_api_client: Mock,
+    unit_discovery_config: DiscoveryConfig,
+):
+    """All-lowercase names should produce a single candidate per package, not duplicates."""
+    packages_response = {"data": {"environment": {"applied": {"packages": ["jaffle"]}}}}
+    details_response: dict[str, dict[str, dict[str, dict[str, dict[str, list]]]]] = {
+        "data": {"environment": {"applied": {"resources": {"edges": []}}}}
+    }
+
+    async def execute_side_effect(query, variables, *, config):
+        if query == ResourceDetailsFetcher.GET_PACKAGES_QUERY:
+            if variables["resource"] == "macro":
+                return {"data": {"environment": {"applied": {"packages": []}}}}
+            return packages_response
+        elif query == ResourceDetailsFetcher.GQL_QUERIES[AppliedResourceType.MODEL]:
+            assert variables["filter"]["uniqueIds"] == ["model.jaffle.orders"]
+            assert variables["first"] == 1
+            return details_response
+        raise AssertionError(f"Unexpected query: {query}")
+
+    mock_api_client.side_effect = execute_side_effect
+
+    await resource_details_fetcher.fetch_details(
+        AppliedResourceType.MODEL,
+        unit_discovery_config,
+        name="orders",
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #821.

The Discovery API `uniqueIds` filter is case-sensitive. `ResourceDetailsFetcher.fetch_details` was calling `.lower()` on the `unique_id` before querying, which caused `get_model_details` (and related tools) to return empty results for models whose manifest IDs contain uppercase characters.

- **`unique_id` path**: strip whitespace only — do not lowercase. The caller-provided casing is the correct casing for the API.
- **`name` path**: try both the original casing and lowercase as candidate unique IDs (deduplicated via set, so all-lowercase names produce a single candidate per package as before).
- **Validation check** (name-vs-unique_id consistency): unchanged — still compares lowercase-to-lowercase, which is the right behaviour for an internal consistency check rather than an API value.

## Test plan

- [x] `task test:unit` — 735 passed
- [x] `task check` — passed