### PR TITLE
fix: return DimensionValuesError when dimension column absent from Arrow result

### DIFF
--- a/.changes/unreleased/Bug Fix-20260630-104909.yaml
+++ b/.changes/unreleased/Bug Fix-20260630-104909.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix unhandled KeyError in get_dimension_values when the Arrow result schema does not contain the requested dimension column
+time: 2026-06-30T10:49:09.977022+02:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -425,7 +425,8 @@ class SemanticLayerFetcher:
             )
             if column_name is None:
                 return DimensionValuesError(
-                    error=f"Dimension '{dimension}' not found in result schema"
+                    error=f"Dimension '{dimension}' not found in result schema. "
+                    f"Available columns: {schema_names}"
                 )
             raw: list[str] = [
                 str(v)

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -421,8 +421,12 @@ class SemanticLayerFetcher:
             schema_names = raw_table.schema.names
             column_name = next(
                 (n for n in schema_names if n.lower() == dimension.lower()),
-                dimension,
+                None,
             )
+            if column_name is None:
+                return DimensionValuesError(
+                    error=f"Dimension '{dimension}' not found in result schema"
+                )
             raw: list[str] = [
                 str(v)
                 for v in raw_table.column(column_name).to_pylist()

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -1086,6 +1086,27 @@ class TestGetDimensionValues:
         assert "foo" in result.error
 
     @pytest.mark.asyncio
+    async def test_dimension_column_absent_from_result_returns_error(
+        self, dim_fetcher, mock_sl_client, sl_config
+    ):
+        """When the Arrow table returned by the SDK has no column matching the
+        requested dimension (not even case-insensitively), get_dimension_values
+        must return DimensionValuesError rather than raising KeyError."""
+        mock_sl_client.dimension_values.return_value = pa.table(
+            {"some_other_column": ["2024-01-01", "2024-01-02"]}
+        )
+
+        result = await dim_fetcher.get_dimension_values(
+            config=sl_config,
+            dimension="project_activity__date_day",
+            metrics=["some_metric"],
+            limit=100,
+        )
+
+        assert isinstance(result, DimensionValuesError)
+        assert "project_activity__date_day" in result.error
+
+    @pytest.mark.asyncio
     async def test_operational_error_propagates(
         self, dim_fetcher, mock_sl_client, sl_config
     ):

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -1105,6 +1105,7 @@ class TestGetDimensionValues:
 
         assert isinstance(result, DimensionValuesError)
         assert "project_activity__date_day" in result.error
+        assert "some_other_column" in result.error
 
     @pytest.mark.asyncio
     async def test_operational_error_propagates(


### PR DESCRIPTION
Closes #827

## Summary

- `get_dimension_values` crashed with an unhandled `KeyError` when the Arrow table returned by the Semantic Layer SDK contained no column matching the requested dimension name (not even case-insensitively).
- The `next()` fallback in `client.py` returned the raw dimension string, and `raw_table.column(that_string)` raised `KeyError`. The `except` block only caught `QueryFailedError`, so the error propagated unhandled to prod.
- Fix: change the `next()` fallback to `None` and return `DimensionValuesError` with a clear message when no matching column is found.

## Test plan

- [ ] New test `TestGetDimensionValues::test_dimension_column_absent_from_result_returns_error` reproduces the exact prod error and passes after the fix
- [ ] Full unit suite passes (`744 passed`)
- [ ] `task check` clean (ruff, mypy, pre-commit)