### PR TITLE
fix: add hatch-vcs fallback-version for mcpb installs without git history

### DIFF
--- a/.changes/unreleased/Bug Fix-20260630-183628.yaml
+++ b/.changes/unreleased/Bug Fix-20260630-183628.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Add hatch-vcs fallback-version to fix mcpb install failures in environments without git history
+time: 2026-06-30T18:36:28.827834+02:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ include = ["src/dbt_mcp/**/*", "README.md", "LICENSE"]
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "0.0.0"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Closes #829.

Local `.mcpb` installs copy source files to `Claude Extensions/` without the `.git` folder. Since the project uses `hatch-vcs` to derive its version from git tags, the build fails in any environment where git history is absent — including clean mcpb installs with no prior cached build artifacts.

Adding `fallback-version = "0.0.0"` to `[tool.hatch.version]` lets the build succeed when VCS detection fails. Normal builds from a tagged git repo are unaffected.