### PR TITLE
feat(docs): auto-generate deprecated tool notices in README

### DIFF
--- a/.changes/unreleased/Under the Hood-20260706-101105.yaml
+++ b/.changes/unreleased/Under the Hood-20260706-101105.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
-body: Update docs gen script to add deprecated tools to README
+body: Update docs gen script to annotate deprecated tools to README
 time: 2026-07-06T10:11:05.118226-07:00

--- a/.changes/unreleased/Under the Hood-20260706-101105.yaml
+++ b/.changes/unreleased/Under the Hood-20260706-101105.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Update docs gen script to add deprecated tools to README
+time: 2026-07-06T10:11:05.118226-07:00

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -70,15 +70,17 @@ def generate_readme_tools_section() -> str:
 
         sorted_tools = sorted(tool_names, key=lambda t: t.value)
         for tool in sorted_tools:
-            desc = HUMAN_DESCRIPTIONS.get(tool, "")
             meta = _TOOL_META.get(tool)
-            replacement = (
-                meta.get("replacement") if meta and meta.get("deprecated") else None
-            )
-            suffix = (
-                f" *(deprecated — use `{replacement}` instead)*" if replacement else ""
-            )
-            lines.append(f"- `{tool.value}`{suffix}: {desc}")
+            if meta and meta.get("deprecated"):
+                replacement = meta.get("replacement")
+                desc = (
+                    f"*(deprecated — use `{replacement}` instead)*"
+                    if replacement
+                    else "*(deprecated)*"
+                )
+            else:
+                desc = HUMAN_DESCRIPTIONS.get(tool, "")
+            lines.append(f"- `{tool.value}`: {desc}")
 
         lines.append("")  # Empty line after each section
 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -3,9 +3,30 @@ import logging
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
+from dbt_mcp.dbt_admin.tools import ADMIN_TOOLS
+from dbt_mcp.discovery.tools import DISCOVERY_TOOLS
+from dbt_mcp.mcp_server_metadata.tools import MCP_SERVER_TOOLS
+from dbt_mcp.product_docs.tools import PRODUCT_DOCS_TOOLS
+from dbt_mcp.semantic_layer.tools import SEMANTIC_LAYER_TOOLS
 from dbt_mcp.tools.readme_mappings import HUMAN_DESCRIPTIONS, TOOLSET_DESCRIPTIONS
+from dbt_mcp.tools.tool_names import ToolName
 from dbt_mcp.tools.toolsets import toolsets
+
+# Tool meta keyed by ToolName for modules that define static tool lists.
+# Factory-function modules (dbt_cli, dbt_codegen, lsp) and proxied tools
+# (sql, search) are registered at runtime and currently carry no deprecated meta.
+_TOOL_META: dict[ToolName, dict[str, Any] | None] = {
+    tool.get_name(): tool.meta
+    for tool in (
+        *DISCOVERY_TOOLS,
+        *ADMIN_TOOLS,
+        *SEMANTIC_LAYER_TOOLS,
+        *MCP_SERVER_TOOLS,
+        *PRODUCT_DOCS_TOOLS,
+    )
+}
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
@@ -50,7 +71,14 @@ def generate_readme_tools_section() -> str:
         sorted_tools = sorted(tool_names, key=lambda t: t.value)
         for tool in sorted_tools:
             desc = HUMAN_DESCRIPTIONS.get(tool, "")
-            lines.append(f"- `{tool.value}`: {desc}")
+            meta = _TOOL_META.get(tool)
+            replacement = (
+                meta.get("replacement") if meta and meta.get("deprecated") else None
+            )
+            suffix = (
+                f" *(deprecated — use `{replacement}` instead)*" if replacement else ""
+            )
+            lines.append(f"- `{tool.value}`{suffix}: {desc}")
 
         lines.append("")  # Empty line after each section
 


### PR DESCRIPTION
## Summary

Updates the README doc generation script to automatically render deprecation notices for tools that carry `meta={"deprecated": True, "replacement": "..."}` on their `@dbt_mcp_tool` decorator.

## What Changed

- `scripts/generate_docs.py` now imports static tool lists from the five modules that define them (`DISCOVERY_TOOLS`, `ADMIN_TOOLS`, `SEMANTIC_LAYER_TOOLS`, `MCP_SERVER_TOOLS`, `PRODUCT_DOCS_TOOLS`) and builds a `{ToolName → meta}` lookup at startup
- The README render loop checks each tool's `meta` field; if `deprecated: True` is set, the tool entry is annotated with *(deprecated — use `<replacement>` instead)*
- No changes to `readme_mappings.py` or any tool definitions — the decorator is the single source of truth

## Why

Benoit flagged in [#824](https://github.com/dbt-labs/dbt-mcp/pull/824#pullrequestreview-4625524178) that the README generation script should be updated to reflect deprecated tools.

## Related Issues

Related to #824
Related to #825

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

This PR is intentionally mergeable standalone — `generate_docs.py` will produce no deprecated notices until a tool carries `meta={"deprecated": True}` in its decorator. Once #825 (or #824) merges and marks tools as deprecated, the next `task docs:generate` run will automatically populate the README with the correct notices, with no further changes needed here.