### PR TITLE
Reduce semantic layer GraphQL request timeout to 30s

### DIFF
--- a/.changes/unreleased/Bug Fix-20260707-165549.yaml
+++ b/.changes/unreleased/Bug Fix-20260707-165549.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Reduce the semantic layer GraphQL request timeout from 60s to 30s so unresponsive requests fail faster instead of holding the connection open.
+time: 2026-07-07T16:55:49+01:00

--- a/src/dbt_mcp/config/settings.py
+++ b/src/dbt_mcp/config/settings.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DBT_CLI_TIMEOUT = 60
 PLATFORM_API_TIMEOUT = 15.0
-SEMANTIC_LAYER_GQL_TIMEOUT = 60.0
+SEMANTIC_LAYER_GQL_TIMEOUT = 30.0
 
 
 class DbtMcpLogSettings(BaseSettings):


### PR DESCRIPTION
# Why

The semantic layer GraphQL request timeout is currently 60s. When the semantic layer server is slow or unresponsive, a 60s read timeout keeps each request (`list_metrics`, `query_metrics`, `get_dimensions`, etc.) hanging for a full minute before failing. Under sustained high latency this holds connections open far longer than is useful and adds load without returning results.

# What

Lower `SEMANTIC_LAYER_GQL_TIMEOUT` from 60s to 30s so unresponsive requests fail faster. 30s is the value #588 introduced to fix cold-cache `query_metrics` ReadTimeouts, so this preserves that fix while dropping the extra 30s of hanging on stuck requests.

---
Drafted by Claude Opus 4.8 under the direction of @alan-andrade
