### PR TITLE
Quality: Hardcoded OAuth Client ID in Source Code

### DIFF
--- a/src/dbt_mcp/oauth/client_id.py
+++ b/src/dbt_mcp/oauth/client_id.py
@@ -1,1 +1,3 @@
-OAUTH_CLIENT_ID = "34ec61e834cdffd9dd90a32231937821"
+import os
+
+OAUTH_CLIENT_ID = os.environ.get("DBT_OAUTH_CLIENT_ID", "34ec61e834cdffd9dd90a32231937821")


### PR DESCRIPTION
## Summary

Quality: Hardcoded OAuth Client ID in Source Code

## Problem

**Severity**: `High` | **File**: `src/dbt_mcp/oauth/client_id.py:L1`

The OAuth client ID is hardcoded as a plain string in `src/dbt_mcp/oauth/client_id.py`. This is a sensitive credential that should not be committed to source control. Even if this is a public client ID, it should be configurable via environment variables to allow rotation and avoid accidental exposure in public repositories.

## Solution

Move the OAuth client ID to an environment variable or secure secret management system. Use `os.environ.get('DBT_OAUTH_CLIENT_ID')` with a fallback or require it to be set explicitly.

## Changes

- `src/dbt_mcp/oauth/client_id.py` (modified)