### PR TITLE
Fix changelog check to skip auto-generated release PRs

### DIFF
--- a/.changes/unreleased/Under the Hood-20260708-164026.yaml
+++ b/.changes/unreleased/Under the Hood-20260708-164026.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Fix the changelog CI check so it skips auto-generated release pull requests. The previous guard tested a push-only event field that is empty on pull_request events, so it never took effect and release PRs failed the check.
+time: 2026-07-08T16:40:26+01:00

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'Release: v')"
+    if: "!startsWith(github.head_ref, 'release/')"
     steps:
       - name: checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4


### PR DESCRIPTION
# Why

Auto-generated release PRs (branch `release/*`) run `changie merge`, which rewrites `CHANGELOG.md`. The `check-changelog` job then fails them on its "don't edit CHANGELOG.md manually" rule. The job already had a guard meant to exempt release PRs, but it tested `github.event.head_commit.message`, which is only populated on `push` events and is empty on `pull_request` events, so the guard never took effect and every release PR failed the check.

# What

Gate the job on `github.head_ref` instead, so it skips `release/*` branches. Feature PRs are unaffected and still require a changie entry and still may not hand-edit `CHANGELOG.md`.

---
Drafted by Claude Opus 4.8 under the direction of @alan-andrade
