### PR TITLE
Fix manifest path resolution when DBT_PROJECT_DIR is a relative path

### DIFF
--- a/.changes/unreleased/Bug Fix-20260715-154116.yaml
+++ b/.changes/unreleased/Bug Fix-20260715-154116.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix manifest path resolution when DBT_PROJECT_DIR is a relative path
+time: 2026-07-15T15:41:16.841703-07:00

--- a/src/dbt_mcp/dbt_cli/tools.py
+++ b/src/dbt_mcp/dbt_cli/tools.py
@@ -325,8 +325,9 @@ def create_dbt_cli_tool_definitions(config: DbtCliConfig) -> list[ToolDefinition
     def _get_manifest() -> Manifest:
         """Helper function to load the dbt manifest.json file."""
         _run_dbt_command(["parse"])  # Ensure manifest is generated
-        cwd_path = config.project_dir if os.path.isabs(config.project_dir) else None
-        manifest_path = os.path.join(cwd_path or ".", "target", "manifest.json")
+        manifest_path = os.path.join(
+            config.project_dir or ".", "target", "manifest.json"
+        )
         with open(manifest_path, encoding="utf-8") as f:
             manifest_data = json.load(f)
         return Manifest(**manifest_data)

--- a/tests/unit/dbt_cli/test_tools.py
+++ b/tests/unit/dbt_cli/test_tools.py
@@ -1,5 +1,7 @@
 import inspect
+import json
 import subprocess
+from pathlib import Path
 
 import pytest
 from pytest import MonkeyPatch
@@ -841,3 +843,39 @@ def test_resource_type_accepts_valid_values(
     )
 
     tools["ls"](resource_type=valid_types)
+
+
+def test_get_lineage_dev_resolves_manifest_from_relative_project_dir(
+    monkeypatch: MonkeyPatch, mock_process, mock_fastmcp, tmp_path: Path
+):
+    """Manifest must be read from <project_dir>/target/manifest.json even when
+    project_dir is a relative path — not from ./target/manifest.json in cwd."""
+    project_name = "my_project"
+    manifest_dir = tmp_path / project_name / "target"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "manifest.json").write_text(json.dumps({}))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_process)
+
+    relative_config = DbtCliConfig(
+        project_dir=project_name,
+        dbt_path="/path/to/dbt",
+        dbt_cli_timeout=10,
+        binary_type=BinaryType.DBT_CORE,
+    )
+
+    fastmcp, tools = mock_fastmcp
+    register_dbt_cli_tools(
+        fastmcp,
+        relative_config,
+        disabled_tools=set(),
+        enabled_tools=None,
+        enabled_toolsets=set(),
+        disabled_toolsets=set(),
+    )
+
+    result = tools["get_lineage_dev"](
+        unique_id="model.my_project.some_model", types=None, depth=5
+    )
+    assert isinstance(result, dict)


### PR DESCRIPTION
## Summary
Fix `get_lineage_dev` failing with `FileNotFoundError: ./target/manifest.json` when `DBT_PROJECT_DIR` is a relative path.

## What Changed
- `src/dbt_mcp/dbt_cli/tools.py`: removed the `isabs` guard in `_get_manifest()` that set `cwd_path = None` for relative paths, causing the manifest read to fall back to `./target/manifest.json`. Now passes `config.project_dir` directly to `os.path.join`, which handles both absolute and relative paths correctly.
- `tests/unit/dbt_cli/test_tools.py`: added a test that configures a relative `project_dir`, `chdir`s into the parent directory, places a manifest at`my_project/target/manifest.json`, and asserts `get_lineage_dev` returns without`FileNotFoundError`.

## Why
`_run_dbt_command(["parse"])` inherits `DBT_PROJECT_DIR` from the environment and writes the manifest to `<project_dir>/target/manifest.json` relative to the server's cwd. The old read path disagreed when `project_dir` was relative. Bc of this, it fell back to `./target/manifest.json` (the server root) instead. The fix makes read and write resolve from the same location.

Note: `get_node_details_dev` (also mentioned in 843) does not call `_get_manifest()`. It runs `dbt ls` directly and was never affected by this bug. This was confirmed by testing both tools on `main` before patching (see validation section below!).

## Related Issues
<!-- Link any related issues using #issue_number -->
Closes #843 


## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Tested on `main` (unpatched) and the fix branch with `DBT_PROJECT_DIR=internal-analytics` using a relative dir and server cwd set to the parent directory:

| Tool | `main` | fix branch |
|---|---|---|
| `get_lineage_dev` | `FileNotFoundError: ./target/manifest.json` | returns lineage correctly |
| `get_node_details_dev` | succeeds (never affected) | succeeds |

