### PR TITLE
chore: bump pinned Node to 22.18.0 in .tool-versions

### DIFF
--- a/.changes/unreleased/Under the Hood-20260716-081137.yaml
+++ b/.changes/unreleased/Under the Hood-20260716-081137.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Bump the pinned Node version to 22.18.0 in .tool-versions so the ui/ ESLint 9 flat-config check runs locally (Node 20.17 hits ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING).
+time: 2026-07-16T08:11:37.386980-07:00

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 20.17.0
+nodejs 22.18.0
 uv 0.11.8
 task 3.43.2
 pnpm 10.15.1


### PR DESCRIPTION
## Summary

Bump the pinned Node version in `.tool-versions` from `20.17.0` to `22.18.0`.

## What Changed

- `.tool-versions`: `nodejs 20.17.0` → `nodejs 22.18.0`
- changie entry (Under the Hood)

## Why

The `ui/` package uses ESLint 9 (flat config). On Node 20.17.0, `task check`'s `cd ui && pnpm run lint` step fails locally with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` — a Node `vm` dynamic-import issue that's resolved on Node 22. CI currently passes on its runner Node, but local `task check` is broken on the pinned version. Pinning Node 22.18.0 makes local dev match.

## Related Issues
Related to #842 (surfaced while running `task check` there)

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- N/A
- [ ] I have added tests that prove my fix is effective or that my feature works -- N/A (tooling pin)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Restores a change originally made during the MCP-apps POC (`a6a43d8`) that was dropped when the POC branch was rebased.