### PR TITLE
[mcp] DI-4795: Capture tool-call token/char estimates in local MCP telemetry

### DIFF
--- a/.changes/unreleased/Under the Hood-20260817-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260817-120000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Add token and character count estimates for tool-call arguments and responses in telemetry events
+time: 2026-08-17T12:00:00.000000-04:00

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -135,6 +135,7 @@ class DbtMCP(FastMCP):
                     error_message=None,
                     mcp_client_name=mcp_client_name,
                     mcp_client_version=mcp_client_version,
+                    result=result,
                 ),
             )
         except Exception:

--- a/src/dbt_mcp/mcp/server.py
+++ b/src/dbt_mcp/mcp/server.py
@@ -28,15 +28,18 @@ from dbt_mcp.proxy.tools import ProxiedToolsManager, register_proxied_tools
 from dbt_mcp.semantic_layer.client import DefaultSemanticLayerClientProvider
 from dbt_mcp.semantic_layer.tools import register_sl_tools
 from dbt_mcp.semantic_layer.tools_multiproject import register_multiproject_sl_tools
-from dbt_mcp.tracking.tracking import DefaultUsageTracker, ToolCalledEvent, UsageTracker
+from dbt_mcp.tracking.tracking import (
+    REDACT_ARGS,
+    DefaultUsageTracker,
+    ToolCalledEvent,
+    UsageTracker,
+)
 
 logger = logging.getLogger(__name__)
 
-_REDACT_ARGS: frozenset[str] = frozenset({"sql_query", "vars"})
-
 
 def _safe_args(arguments: dict[str, Any]) -> dict[str, Any]:
-    return {k: "***" if k in _REDACT_ARGS else v for k, v in arguments.items()}
+    return {k: "***" if k in REDACT_ARGS else v for k, v in arguments.items()}
 
 
 class DbtMCP(FastMCP):

--- a/src/dbt_mcp/tracking/token_estimation.py
+++ b/src/dbt_mcp/tracking/token_estimation.py
@@ -1,0 +1,79 @@
+"""Lightweight token/char estimation for MCP tool-call telemetry.
+
+Local dbt-mcp deliberately avoids a tokenizer dependency: it estimates tokens
+with a simple ~4-characters-per-token heuristic. The exact character counts are
+the durable, tokenizer-independent primitive; the token estimate is directional.
+
+Estimation must never break a tool call, so serialization is defensive and falls
+back to a zeroed measurement on any error.
+"""
+
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Recorded on every event so consumers can treat estimates as approximate and
+# detect when the method changes. Mirrors the proto ``token_estimation_method``.
+TOKEN_ESTIMATION_METHOD = "char_div_4"
+_CHARS_PER_TOKEN = 4
+
+
+@dataclass(frozen=True)
+class PayloadMeasurement:
+    char_count: int
+    token_estimate: int
+
+
+EMPTY_MEASUREMENT = PayloadMeasurement(char_count=0, token_estimate=0)
+
+
+def _to_text(obj: Any) -> str:
+    """Best-effort serialization of a tool payload to the text we measure.
+
+    Handles the shapes MCP tool calls produce without hard-importing their types:
+    plain strings, argument mappings, MCP ``TextContent`` blocks (``.text``),
+    objects exposing ``.content``, sequences of blocks, and pydantic models.
+    """
+    if obj is None:
+        return ""
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, Mapping):
+        return json.dumps(obj, default=str, sort_keys=True)
+    text = getattr(obj, "text", None)
+    if isinstance(text, str):
+        return text
+    content = getattr(obj, "content", None)
+    if content is not None:
+        return _to_text(content)
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return "".join(_to_text(item) for item in obj)
+    for dumper in ("model_dump_json", "json"):
+        fn = getattr(obj, dumper, None)
+        if callable(fn):
+            try:
+                return str(fn())
+            except Exception:
+                pass
+    return str(obj)
+
+
+def measure_payload(obj: Any) -> PayloadMeasurement:
+    """Measure a tool payload (arguments dict or tool result) defensively.
+
+    Never raises: returns a zeroed measurement if serialization fails, so
+    telemetry cannot break the tool call it describes.
+    """
+    try:
+        text = _to_text(obj)
+    except Exception:
+        logger.debug("Payload serialization failed — emitting zeroed measurement")
+        return EMPTY_MEASUREMENT
+    char_count = len(text)
+    return PayloadMeasurement(
+        char_count=char_count, token_estimate=char_count // _CHARS_PER_TOKEN
+    )

--- a/src/dbt_mcp/tracking/token_estimation.py
+++ b/src/dbt_mcp/tracking/token_estimation.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 # detect when the method changes. Mirrors the proto ``token_estimation_method``.
 TOKEN_ESTIMATION_METHOD = "char_div_4"
 _CHARS_PER_TOKEN = 4
+_SKIP_CONTENT_TYPES = frozenset({"image", "audio"})
 
 
 @dataclass(frozen=True)
@@ -42,6 +43,8 @@ def _to_text(obj: Any) -> str:
         return ""
     if isinstance(obj, str):
         return obj
+    if getattr(obj, "type", None) in _SKIP_CONTENT_TYPES:
+        return ""
     if isinstance(obj, Mapping):
         return json.dumps(obj, default=str, sort_keys=True)
     text = getattr(obj, "text", None)

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -20,6 +20,10 @@ from dbt_mcp.config.dbt_yaml import try_read_yaml
 from dbt_mcp.config.credentials import CredentialsProvider, get_dbt_profiles_path
 from dbt_mcp.config.settings import DbtMcpSettings
 from dbt_mcp.tools.toolsets import Toolset, proxied_tools
+from dbt_mcp.tracking.token_estimation import (
+    TOKEN_ESTIMATION_METHOD,
+    measure_payload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +39,9 @@ class ToolCalledEvent:
     end_time_ms: int
     mcp_client_name: str = ""
     mcp_client_version: str = ""
+    # The tool result, used only to estimate the response token/char size.
+    # None when the call errored before returning.
+    result: Any = None
 
 
 class UsageTracker(Protocol):
@@ -127,6 +134,11 @@ class DefaultUsageTracker:
                 if self.credentials_provider.authentication_method
                 else ""
             )
+            # Estimate token/char size of the (unredacted) arguments and the
+            # response. Counts don't leak content, so we measure the raw
+            # arguments even for tools whose values are redacted above.
+            request_measurement = measure_payload(tool_called_event.arguments)
+            response_measurement = measure_payload(tool_called_event.result)
             log_proto(
                 ToolCalled(
                     event_id=event_id,
@@ -175,6 +187,13 @@ class DefaultUsageTracker:
                         and tool_called_event.mcp_client_version
                         else tool_called_event.mcp_client_name
                     ),
+                    request_token_estimate=request_measurement.token_estimate,
+                    response_token_estimate=response_measurement.token_estimate,
+                    request_char_count=request_measurement.char_count,
+                    response_char_count=response_measurement.char_count,
+                    token_estimation_method=TOKEN_ESTIMATION_METHOD,
+                    # llm_model is left blank: local MCP does not know the
+                    # client's model.
                 )
             )
         except Exception as e:

--- a/src/dbt_mcp/tracking/tracking.py
+++ b/src/dbt_mcp/tracking/tracking.py
@@ -27,7 +27,7 @@ from dbt_mcp.tracking.token_estimation import (
 
 logger = logging.getLogger(__name__)
 
-_REDACT_ARGS: frozenset[str] = frozenset({"sql_query", "vars"})
+REDACT_ARGS: frozenset[str] = frozenset({"sql_query", "vars"})
 
 
 @dataclass
@@ -111,7 +111,7 @@ class DefaultUsageTracker:
             return
         try:
             arguments_mapping: Mapping[str, str] = {
-                k: (json.dumps("***") if k in _REDACT_ARGS else json.dumps(v))
+                k: (json.dumps("***") if k in REDACT_ARGS else json.dumps(v))
                 for k, v in tool_called_event.arguments.items()
             }
             event_id = str(uuid.uuid4())

--- a/tests/unit/tracking/test_token_estimation.py
+++ b/tests/unit/tracking/test_token_estimation.py
@@ -1,7 +1,5 @@
-from collections.abc import Mapping
 from dataclasses import dataclass
 
-import pytest
 from pydantic import BaseModel
 
 from dbt_mcp.tracking.token_estimation import (
@@ -137,6 +135,38 @@ class TestMeasurePayload:
         result = measure_payload("abcd")
         assert result.char_count == 4
         assert result.token_estimate == 1
+
+    def test_image_content_skipped(self):
+        """Binary content types (image, audio) are skipped to avoid serializing large blobs."""
+
+        @dataclass
+        class ImageContent:
+            type: str
+            data: str
+
+        obj = ImageContent(type="image", data="a" * 100_000)
+        result = measure_payload(obj)
+        assert result == EMPTY_MEASUREMENT
+
+    def test_sequence_skips_image_keeps_text(self):
+        """In a sequence, image blocks are skipped but text blocks are measured."""
+
+        @dataclass
+        class TextContent:
+            type: str
+            text: str
+
+        @dataclass
+        class ImageContent:
+            type: str
+            data: str
+
+        blocks: list = [
+            TextContent(type="text", text="hello"),
+            ImageContent(type="image", data="a" * 100_000),
+        ]
+        result = measure_payload(blocks)
+        assert result.char_count == len("hello")
 
     def test_nested_dict_values_use_default_str(self):
         """Non-JSON-serializable dict values use str() via default=str."""

--- a/tests/unit/tracking/test_token_estimation.py
+++ b/tests/unit/tracking/test_token_estimation.py
@@ -1,0 +1,150 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel
+
+from dbt_mcp.tracking.token_estimation import (
+    EMPTY_MEASUREMENT,
+    TOKEN_ESTIMATION_METHOD,
+    PayloadMeasurement,
+    measure_payload,
+)
+
+
+class TestMeasurePayload:
+    def test_none_returns_zeroed(self):
+        assert measure_payload(None) == EMPTY_MEASUREMENT
+
+    def test_empty_string(self):
+        result = measure_payload("")
+        assert result == PayloadMeasurement(char_count=0, token_estimate=0)
+
+    def test_plain_string(self):
+        text = "metric list result"
+        result = measure_payload(text)
+        assert result.char_count == len(text)
+        assert result.token_estimate == len(text) // 4
+
+    def test_dict_serialized_as_sorted_json(self):
+        args = {"z_key": "val", "a_key": 42}
+        result = measure_payload(args)
+        expected = '{"a_key": 42, "z_key": "val"}'
+        assert result.char_count == len(expected)
+        assert result.token_estimate == len(expected) // 4
+
+    def test_text_content_like_object(self):
+        """Objects with a .text attribute (e.g. MCP TextContent) use .text."""
+
+        @dataclass
+        class TextContent:
+            type: str
+            text: str
+
+        obj = TextContent(type="text", text="hello world")
+        result = measure_payload(obj)
+        assert result.char_count == len("hello world")
+
+    def test_content_attribute_delegates(self):
+        """Objects with .content recurse into that attribute."""
+
+        @dataclass
+        class Inner:
+            text: str
+
+        @dataclass
+        class Outer:
+            content: Inner
+
+        obj = Outer(content=Inner(text="nested"))
+        result = measure_payload(obj)
+        assert result.char_count == len("nested")
+
+    def test_sequence_of_text_blocks(self):
+        """A list of TextContent-like blocks is concatenated."""
+
+        @dataclass
+        class Block:
+            text: str
+
+        blocks = [Block(text="aaa"), Block(text="bbb")]
+        result = measure_payload(blocks)
+        assert result.char_count == 6
+        assert result.token_estimate == 1
+
+    def test_sequence_with_mixed_types(self):
+        """Sequences can contain a mix of strings and objects."""
+
+        @dataclass
+        class Block:
+            text: str
+
+        items: list = ["raw", Block(text="obj")]
+        result = measure_payload(items)
+        assert result.char_count == len("raw") + len("obj")
+
+    def test_pydantic_model(self):
+        class MyModel(BaseModel):
+            name: str
+            count: int
+
+        obj = MyModel(name="test", count=5)
+        result = measure_payload(obj)
+        assert result.char_count == len(obj.model_dump_json())
+        assert result.char_count > 0
+
+    def test_fallback_to_str(self):
+        result = measure_payload(42)
+        assert result.char_count == len("42")
+
+    def test_serialization_error_returns_empty(self):
+        """If _to_text raises, measure_payload returns EMPTY_MEASUREMENT."""
+
+        class Bomb:
+            """An object that defeats every serialization path."""
+
+            @property
+            def text(self):
+                raise RuntimeError("boom")
+
+            @property
+            def content(self):
+                raise RuntimeError("boom")
+
+            def model_dump_json(self):
+                raise RuntimeError("boom")
+
+            def json(self):
+                raise RuntimeError("boom")
+
+            def __str__(self):
+                raise RuntimeError("boom")
+
+            def __iter__(self):
+                raise RuntimeError("boom")
+
+        result = measure_payload(Bomb())
+        assert result == EMPTY_MEASUREMENT
+
+    def test_token_estimation_method_constant(self):
+        assert TOKEN_ESTIMATION_METHOD == "char_div_4"
+
+    def test_token_estimate_rounds_down(self):
+        result = measure_payload("abc")
+        assert result.char_count == 3
+        assert result.token_estimate == 0
+
+        result = measure_payload("abcd")
+        assert result.char_count == 4
+        assert result.token_estimate == 1
+
+    def test_nested_dict_values_use_default_str(self):
+        """Non-JSON-serializable dict values use str() via default=str."""
+
+        @dataclass
+        class Custom:
+            val: int
+
+        args = {"key": Custom(val=99)}
+        result = measure_payload(args)
+        assert result.char_count > 0

--- a/tests/unit/tracking/test_tracking.py
+++ b/tests/unit/tracking/test_tracking.py
@@ -77,6 +77,7 @@ class TestUsageTracker:
                     start_time_ms=0,
                     end_time_ms=1,
                     error_message=None,
+                    result="metric list result",
                 ),
             )
 
@@ -89,6 +90,15 @@ class TestUsageTracker:
         assert tool_called.dbt_cloud_user_id == "3"
         assert tool_called.local_user_id == "local-user"
         assert tool_called.ctx.dbt_cloud_account_identifier == "ab123"
+        # Token/char estimates: arguments serialized as sorted JSON, response
+        # from the raw result string. Tokens use the ~4-chars-per-token heuristic.
+        assert tool_called.token_estimation_method == "char_div_4"
+        assert tool_called.request_char_count == len('{"foo": "bar"}')
+        assert tool_called.request_token_estimate == len('{"foo": "bar"}') // 4
+        assert tool_called.response_char_count == len("metric list result")
+        assert tool_called.response_token_estimate == len("metric list result") // 4
+        # Local MCP does not know the client's model.
+        assert tool_called.llm_model == ""
 
     @pytest.mark.asyncio
     async def test_emit_tool_called_event_account_identifier_none(self):

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-10T13:33:32.337435Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -339,14 +339,14 @@ dev = [
 
 [[package]]
 name = "dbt-protos"
-version = "1.0.431"
+version = "1.0.565"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/67/777aa1c4af897773adb944c2db8d5c2073dd3ae114fa233b5559e900a550/dbt_protos-1.0.431.tar.gz", hash = "sha256:8fd3f52f2cb5532874eab93470fec3d9ace74e1ee342eaaf13b24867c042d0ce", size = 123577, upload-time = "2026-02-06T21:54:29.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b9/b09b002cedb6817ea9d503a0c2adc7645b1b0749c174e2edd36cedeacb6b/dbt_protos-1.0.565.tar.gz", hash = "sha256:fabee73a6f98a7eb7e52ab34571ef24d82cce760829e268c7263a5805f3937cf", size = 188207, upload-time = "2026-08-14T12:37:15.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/56/8db9a3330af4462860fd5e38e8c1759ef9f1701f0c2111c9694c5c2e544c/dbt_protos-1.0.431-py3-none-any.whl", hash = "sha256:5ee60f11f2cae5faaf0e5f8420f7872ab48ae978ccd74fdba60d0f3ab8fd1d26", size = 178455, upload-time = "2026-02-06T21:54:28.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/68/a2a702510b5ae16f52a7b2f459e2e205cef6e79cf508e2611091a616245c/dbt_protos-1.0.565-py3-none-any.whl", hash = "sha256:130a8333fcd644ba1f00c8377e8f8013b28cca696a6af56037feb55a011f964c", size = 260078, upload-time = "2026-08-14T12:37:14.477Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Product wants to quantify the tokens processed by dbt-mcp. both per call and per session.

Today the `ToolCalled` event captures tool arguments but nothing about payload size or the resulting response. This blocks cost attribution and usage analysis across hosted and local MCP surfaces.

## What

Adds token/char estimates for tool-call inputs and outputs on the local MCP emitter, using the six new `ToolCalled` proto fields (proto#667).

- New `token_estimation.py` with a dependency-free char/4 heuristic (no tokenizer added to the OSS package). Exact char counts are the durable primitive; token estimates are directional.
- `llm_model` left blank — local MCP does not know the client model.
- Estimation is fully defensive: never raises, so telemetry cannot break a tool call.

## Stack

| PR | Status |
|----|--------|
| proto#667 | Merged |
| ai-codegen-api#1264 | Merged |
| **This PR** | Ready for review |
| vortex-event-analytics#113 | Approved |
| internal-analytics#4615 | Ready for review |