### PR TITLE
fix: correct cancel_job_run tool annotations (destructive, idempotent)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260731-001817.yaml
+++ b/.changes/unreleased/Bug Fix-20260731-001817.yaml
@@ -1,3 +1,3 @@
 kind: Bug Fix
-body: Mark job-run MCP tools as destructive.
+body: Fix cancel_job_run tool annotations (destructive, idempotent).
 time: 2026-07-31T00:18:17.184167+02:00

--- a/.changes/unreleased/Bug Fix-20260731-001817.yaml
+++ b/.changes/unreleased/Bug Fix-20260731-001817.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Mark job-run MCP tools as destructive.
+time: 2026-07-31T00:18:17.184167+02:00

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -110,7 +110,7 @@ async def get_job_details(
     description=get_prompt("admin_api/trigger_job_run"),
     title="Trigger Job Run",
     read_only_hint=False,
-    destructive_hint=False,
+    destructive_hint=True,
     idempotent_hint=False,
 )
 async def trigger_job_run(
@@ -200,7 +200,7 @@ async def get_job_run_details(
     description=get_prompt("admin_api/cancel_job_run"),
     title="Cancel Job Run",
     read_only_hint=False,
-    destructive_hint=False,
+    destructive_hint=True,
     idempotent_hint=False,
 )
 async def cancel_job_run(
@@ -218,7 +218,7 @@ async def cancel_job_run(
     description=get_prompt("admin_api/retry_job_run"),
     title="Retry Job Run",
     read_only_hint=False,
-    destructive_hint=False,
+    destructive_hint=True,
     idempotent_hint=False,
 )
 async def retry_job_run(

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -110,7 +110,7 @@ async def get_job_details(
     description=get_prompt("admin_api/trigger_job_run"),
     title="Trigger Job Run",
     read_only_hint=False,
-    destructive_hint=True,
+    destructive_hint=False,
     idempotent_hint=False,
 )
 async def trigger_job_run(
@@ -201,7 +201,7 @@ async def get_job_run_details(
     title="Cancel Job Run",
     read_only_hint=False,
     destructive_hint=True,
-    idempotent_hint=False,
+    idempotent_hint=True,
 )
 async def cancel_job_run(
     context: AdminToolContext,
@@ -218,7 +218,7 @@ async def cancel_job_run(
     description=get_prompt("admin_api/retry_job_run"),
     title="Retry Job Run",
     read_only_hint=False,
-    destructive_hint=True,
+    destructive_hint=False,
     idempotent_hint=False,
 )
 async def retry_job_run(

--- a/tests/unit/contract/contract_snapshot.json
+++ b/tests/unit/contract/contract_snapshot.json
@@ -26,7 +26,7 @@
     {
       "annotations": {
         "destructiveHint": true,
-        "idempotentHint": false,
+        "idempotentHint": true,
         "openWorldHint": true,
         "readOnlyHint": false,
         "title": "Cancel Job Run"
@@ -2754,7 +2754,7 @@
     },
     {
       "annotations": {
-        "destructiveHint": true,
+        "destructiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true,
         "readOnlyHint": false,
@@ -2911,7 +2911,7 @@
     },
     {
       "annotations": {
-        "destructiveHint": true,
+        "destructiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true,
         "readOnlyHint": false,

--- a/tests/unit/contract/contract_snapshot.json
+++ b/tests/unit/contract/contract_snapshot.json
@@ -25,7 +25,7 @@
   "tools": [
     {
       "annotations": {
-        "destructiveHint": false,
+        "destructiveHint": true,
         "idempotentHint": false,
         "openWorldHint": true,
         "readOnlyHint": false,
@@ -2754,7 +2754,7 @@
     },
     {
       "annotations": {
-        "destructiveHint": false,
+        "destructiveHint": true,
         "idempotentHint": false,
         "openWorldHint": true,
         "readOnlyHint": false,
@@ -2911,7 +2911,7 @@
     },
     {
       "annotations": {
-        "destructiveHint": false,
+        "destructiveHint": true,
         "idempotentHint": false,
         "openWorldHint": true,
         "readOnlyHint": false,

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -394,15 +394,15 @@ async def test_admin_tools_list_jobs_params():
 
 
 @pytest.mark.parametrize(
-    ("name", "title"),
+    ("name", "title", "destructive", "idempotent"),
     [
-        ("trigger_job_run", "Trigger Job Run"),
-        ("cancel_job_run", "Cancel Job Run"),
-        ("retry_job_run", "Retry Job Run"),
+        ("trigger_job_run", "Trigger Job Run", False, False),
+        ("cancel_job_run", "Cancel Job Run", True, True),
+        ("retry_job_run", "Retry Job Run", False, False),
     ],
 )
 async def test_job_run_write_tools_list_complete_safety_annotations(
-    name: str, title: str
+    name: str, title: str, destructive: bool, idempotent: bool
 ):
     """Job-run write tools disclose their complete safety contract."""
     async with client_session_context() as client:
@@ -413,7 +413,7 @@ async def test_job_run_write_tools_list_complete_safety_annotations(
     assert annotations.model_dump(exclude_none=True) == {
         "title": title,
         "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": False,
+        "destructiveHint": destructive,
+        "idempotentHint": idempotent,
         "openWorldHint": True,
     }

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -391,3 +391,29 @@ async def test_admin_tools_list_jobs_params():
         assert props is not None
         assert props["limit"]["description"] == PAGINATION_LIMIT
         assert props["offset"]["description"] == PAGINATION_OFFSET
+
+
+@pytest.mark.parametrize(
+    ("name", "title"),
+    [
+        ("trigger_job_run", "Trigger Job Run"),
+        ("cancel_job_run", "Cancel Job Run"),
+        ("retry_job_run", "Retry Job Run"),
+    ],
+)
+async def test_job_run_write_tools_list_complete_safety_annotations(
+    name: str, title: str
+):
+    """Job-run write tools disclose their complete safety contract."""
+    async with client_session_context() as client:
+        listed_tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+
+    annotations = listed_tools[name].annotations
+    assert annotations is not None
+    assert annotations.model_dump(exclude_none=True) == {
+        "title": title,
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    }


### PR DESCRIPTION
# Why

`cancel_job_run` was annotated with `destructiveHint: false` and `idempotentHint: false`, underreporting its effects. Per the MCP spec, cancelling a run is destructive (it stops something running, as opposed to additive), and idempotent (re-cancelling is a no-op).

`trigger_job_run` and `retry_job_run` are additive, not destructive, so they remain `destructiveHint: false`.

# What

- Mark `cancel_job_run` as destructive and idempotent.
- Update test to assert per-tool annotation differences.
- Regenerate contract snapshot.

Drafted by gpt-5.6-terra and Claude Opus 4.6 under the direction of @alan-andrade.