### PR TITLE
Support Core Metadata 2.5 in PyPI publishing

### DIFF
--- a/.changes/unreleased/Under the Hood-20260818-154016.yaml
+++ b/.changes/unreleased/Under the Hood-20260818-154016.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Update the PyPI publishing action to support Core Metadata 2.5.
+time: 2026-08-18T15:40:16.313945-05:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         run: task build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ./dist
 


### PR DESCRIPTION
# Why

Hatchling 1.32.0 now emits Core Metadata 2.5 by default, but the previously pinned PyPI publishing action uses a Twine version that rejects it. This caused the dbt-mcp 2.1.0 publish job to fail before upload.

# What

Update the PyPI publishing action to v1.14.2, pinned to its full commit SHA. This upstream release explicitly adds support for publishing distributions with Core Metadata 2.5.

# Refs

- Failed release job: https://github.com/dbt-labs/dbt-mcp/actions/runs/32157152530/job/95777091152
- Upstream action release: https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2

---
Drafted by GPT-5 under the direction of @wiggzz.
