### PR TITLE
Fix automated release pull request checks and signing

### DIFF
--- a/.changes/unreleased/Under the Hood-20260819-093246.yaml
+++ b/.changes/unreleased/Under the Hood-20260819-093246.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Fix release pull request checks and sign automated release commits.
+time: 2026-08-19T09:32:46.962776-05:00

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -10,7 +10,9 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'Release: v')"
+    if: >-
+      !(startsWith(github.head_ref, 'release/') &&
+        github.event.pull_request.user.login == 'github-actions[bot]')
     steps:
       - name: checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          sign-commits: true
           title: "version: ${{ steps.package-version.outputs.version }}"
           branch: release/${{ steps.package-version.outputs.version }}
           commit-message: |


### PR DESCRIPTION
# Why

Automated release pull requests intentionally update `CHANGELOG.md`, but the normal pull request changelog guard rejects that generated change. Their commits are also currently unsigned, requiring maintainers to bypass repository rules.

# What

- Exempt only `release/*` pull requests authored by `github-actions[bot]` from the normal changelog-entry guard.
- Use the release PR action's bot commit-signing support so generated commits receive GitHub verified signatures.

# Refs

- Release PR demonstrating both failures: https://github.com/dbt-labs/dbt-mcp/pull/860
- Upstream commit-signing documentation: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signing

Drafted by Codex under the direction of @wiggzz.
