### PR TITLE
clean up oauth helper: file permissions and response payload

### DIFF
--- a/.changes/unreleased/Bug Fix-20260820-143738.yaml
+++ b/.changes/unreleased/Bug Fix-20260820-143738.yaml
@@ -1,3 +1,3 @@
 kind: Bug Fix
-body: 'Cleanup of the local oauth helper: file permissions and response payload.'
+body: 'Cleanup of the local OAuth helper: file permissions and response payload.'
 time: 2026-08-20T14:37:38.473546+02:00

--- a/.changes/unreleased/Bug Fix-20260820-143738.yaml
+++ b/.changes/unreleased/Bug Fix-20260820-143738.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: 'Cleanup of the local oauth helper: file permissions and response payload.'
+time: 2026-08-20T14:37:38.473546+02:00

--- a/src/dbt_mcp/oauth/context_manager.py
+++ b/src/dbt_mcp/oauth/context_manager.py
@@ -55,7 +55,7 @@ class DbtPlatformContextManager:
         """Ensure the config file location and its parent directories exist."""
         self.config_location.parent.mkdir(parents=True, exist_ok=True)
         if not self.config_location.exists():
-            self.config_location.touch()
+            self.config_location.touch(mode=0o600)
 
     def write_context_to_file(self, context: DbtPlatformContext) -> None:
         """Write context to file with proper locking."""
@@ -64,3 +64,14 @@ class DbtPlatformContextManager:
             yaml.dump(context.model_dump(), default_flow_style=False),
             encoding="utf-8",
         )
+        # Self-heal permissions on every write, since files created by older
+        # versions (or with a permissive umask) may be world/group readable
+        # despite holding plaintext OAuth tokens. chmod requires owning the
+        # file, so this is best-effort: a mismatch (e.g. the file was created
+        # by a different user) must not block the write itself.
+        try:
+            self.config_location.chmod(0o600)
+        except OSError as e:
+            logger.warning(
+                f"Failed to restrict permissions on {self.config_location}: {e}"
+            )

--- a/src/dbt_mcp/oauth/fastapi_app.py
+++ b/src/dbt_mcp/oauth/fastapi_app.py
@@ -36,11 +36,6 @@ from dbt_mcp.project.project_resolver import (
 logger = logging.getLogger(__name__)
 
 
-def _redact_context(context: DbtPlatformContext) -> DbtPlatformContext:
-    """Strip the access/refresh tokens before a context is sent over HTTP."""
-    return context.model_copy(update={"decoded_access_token": None})
-
-
 def error_redirect(error_code: str, description: str) -> RedirectResponse:
     return RedirectResponse(
         url=f"/index.html#status=error&error={quote(error_code)}&error_description={quote(description)}",
@@ -172,7 +167,7 @@ def create_app(
     @app.post("/selected_projects")
     async def set_selected_projects(
         selected_projects_request: SelectedProjectsRequest,
-    ) -> DbtPlatformContext:
+    ) -> dict[str, bool]:
         logger.info("Selected projects received")
         if app.state.decoded_access_token is None:
             raise RuntimeError("Access token missing; OAuth flow not completed")
@@ -236,7 +231,7 @@ def create_app(
             ),
         )
         app.state.dbt_platform_context = dbt_platform_context
-        return _redact_context(dbt_platform_context)
+        return {"ok": True}
 
     app.mount(
         path="/",

--- a/src/dbt_mcp/oauth/fastapi_app.py
+++ b/src/dbt_mcp/oauth/fastapi_app.py
@@ -36,6 +36,11 @@ from dbt_mcp.project.project_resolver import (
 logger = logging.getLogger(__name__)
 
 
+def _redact_context(context: DbtPlatformContext) -> DbtPlatformContext:
+    """Strip the access/refresh tokens before a context is sent over HTTP."""
+    return context.model_copy(update={"decoded_access_token": None})
+
+
 def error_redirect(error_code: str, description: str) -> RedirectResponse:
     return RedirectResponse(
         url=f"/index.html#status=error&error={quote(error_code)}&error_description={quote(description)}",
@@ -231,7 +236,7 @@ def create_app(
             ),
         )
         app.state.dbt_platform_context = dbt_platform_context
-        return dbt_platform_context
+        return _redact_context(dbt_platform_context)
 
     app.mount(
         path="/",


### PR DESCRIPTION
## Summary
- Local oauth context file (`~/.dbt/mcp.yml`) is now created/rewritten with `0600` permissions instead of relying on the process umask.
- `POST /selected_projects` no longer includes unused fields in its response body — the bundled frontend never reads them, so they're dropped from the payload.

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/integration -x -q` — 807 passed
- [x] `task check` — lint/type-check pass
- [x] Manually exercised `create_app()` with a `TestClient` to confirm the response payload and file permissions behave as expected