### PR TITLE
Bump pinned GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.changes/unreleased/Under the Hood-20260825-123002.yaml
+++ b/.changes/unreleased/Under the Hood-20260825-123002.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
-body: Bump Node.js version used by the setup-mcpb action from 20 to 24 ahead of GitHub Actions' Node 20 runtime deprecation
+body: Bump pinned GitHub Actions (checkout, setup-node, github-script, pnpm/action-setup, create-pull-request, action-gh-release, changie-action) to their latest Node 24 releases ahead of GitHub Actions' Node 20 runtime deprecation
 time: 2026-08-25T12:30:02.329289+02:00

--- a/.changes/unreleased/Under the Hood-20260825-123002.yaml
+++ b/.changes/unreleased/Under the Hood-20260825-123002.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Bump Node.js version used by the setup-mcpb action from 20 to 24 ahead of GitHub Actions' Node 20 runtime deprecation
+time: 2026-08-25T12:30:02.329289+02:00

--- a/.github/actions/setup-mcpb/action.yml
+++ b/.github/actions/setup-mcpb/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
       with:
         node-version: '24'
 

--- a/.github/actions/setup-mcpb/action.yml
+++ b/.github/actions/setup-mcpb/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Install mcpb
       shell: bash

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.user.login == 'github-actions[bot]')
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: setup python
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Validate unreleased changelog entries
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: next auto

--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f
         with:
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"

--- a/.github/workflows/contract-label.yml
+++ b/.github/workflows/contract-label.yml
@@ -23,7 +23,7 @@ jobs:
       issues: write # creating repo labels (first run) uses the issues API
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: setup python
@@ -37,7 +37,7 @@ jobs:
         id: classify
         run: uv run python -m dbt_mcp.contract.snapshot --classify-against /tmp/base_contract_snapshot.json
       - name: Apply label
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const label = ${{ toJSON(steps.classify.outputs.label) }};

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,13 +23,13 @@ jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
 
       - uses: ./.github/actions/setup-python
 
       - name: Compute next dir for bump
         id: changie-next
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: next ${{ inputs.bump }}
@@ -57,20 +57,20 @@ jobs:
           fi
 
       - name: Batch changes
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: ${{ steps.prepare-batch.outputs.args }}
 
       - name: Merge
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: merge
 
       - name: Get the latest version
         id: changie-latest
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: latest
@@ -92,7 +92,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # peter-evans/create-pull-request@v8.1.1
         with:
           sign-commits: true
           title: "version: ${{ steps.package-version.outputs.version }}"

--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -62,11 +62,15 @@ jobs:
           exit 1
 
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
         with:
           # For pull_request_target, explicitly checkout PR head (untrusted code, but gated by label)
           # For pull_request, use default behavior
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          # v7 blocks fork PR checkout on pull_request_target/workflow_run by default; the
+          # ok-to-test label gate above is our authorization check for that path, and this
+          # input is a no-op for the plain pull_request trigger, so opting in is safe here.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       changie-latest: ${{ steps.changie-latest.outputs.output }}
     if: "startsWith(github.event.head_commit.message, 'version:')"
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - uses: ./.github/actions/setup-python
       - name: Get the latest version
         id: changie-latest
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: latest
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
         with:
           ref: ${{ needs.create-release-tag.outputs.changie-latest }}
           fetch-tags: true
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/setup-python
         id: setup-python
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # pnpm/action-setup@v6.0.10
         with:
           version: 10
 
@@ -79,13 +79,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # Fetches all history for changie to work correctly
 
       - name: Get the latest version
         id: changie-latest
-        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # miniscruff/changie-action@v3.0.1
         with:
           version: latest
           args: latest
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
         with:
           ref: ${{ needs.create-release-tag.outputs.changie-latest }}
           fetch-tags: true
@@ -123,7 +123,7 @@ jobs:
       - name: Setup python
         uses: ./.github/actions/setup-python
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # pnpm/action-setup@v6.0.10
         with:
           version: 10
 
@@ -140,7 +140,7 @@ jobs:
       #   run: task mcpb:sign-and-verify
 
       - name: Upload mcpb package to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ needs.create-release-tag.outputs.changie-latest }}
           files: ${{ env.MCPB_PACKAGE_NAME }}

--- a/.github/workflows/run-checks-pr.yaml
+++ b/.github/workflows/run-checks-pr.yaml
@@ -14,11 +14,11 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - name: setup python
         uses: ./.github/actions/setup-python
         id: setup-python
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # pnpm/action-setup@v6.0.10
         with:
           version: 10
       - name: Install go-task
@@ -39,11 +39,11 @@ jobs:
       - check
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - name: setup python
         uses: ./.github/actions/setup-python
         id: setup-python
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # pnpm/action-setup@v6.0.10
         with:
           version: 10
       - name: Install go-task
@@ -62,7 +62,7 @@ jobs:
       - check
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - name: setup python
         uses: ./.github/actions/setup-python
         id: setup-python
@@ -83,7 +83,7 @@ jobs:
       - check
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - name: setup python
         uses: ./.github/actions/setup-python
         id: setup-python
@@ -105,7 +105,7 @@ jobs:
       - check
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - name: setup mcpb
         uses: ./.github/actions/setup-mcpb
       - name: Install go-task


### PR DESCRIPTION
## Summary
- Bumps `node-version` in the `setup-mcpb` composite action from 20 to 24.
- Bumps all pinned third-party GitHub Actions (`actions/checkout`, `actions/setup-node`, `actions/github-script`, `pnpm/action-setup`, `peter-evans/create-pull-request`, `softprops/action-gh-release`, `miniscruff/changie-action`) to the latest release that runs on the Node 24 Actions runtime, ahead of GitHub's Node 20 deprecation.
- `actions/checkout` v7 added a guard that blocks checking out fork PR code on `pull_request_target`/`workflow_run` triggers unless explicitly opted in. `integration-tests-pr.yaml` intentionally does this (gated behind a maintainer-applied `ok-to-test` label), so `allow-unsafe-pr-checkout: true` is added there; it's a no-op on the plain `pull_request` trigger path.
- Verified each other bumped action's changelog/source for other breaking changes: none apply to how we use them (no auto-caching triggers for `setup-node`, no `require('@actions/github')` usage for `github-script`, etc).

## Test plan
- [x] `task check` passes (lint, pre-commit hooks including the Actions workflow linter, mypy)
- [ ] Confirm CI runs green on this PR for all workflows (checkout, changelog-check, codeowners-check, contract-label, release dry-run paths)