### PR TITLE
Fix QueryFailedError message formatting and classify warehouse credential errors

### DIFF
--- a/.changes/unreleased/Bug Fix-20260828-120252.yaml
+++ b/.changes/unreleased/Bug Fix-20260828-120252.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Fix semantic layer query error formatting to use QueryFailedError's clean underlying message instead of its str() representation, which was leaking a message="...", status= wrapper artifact into the error shown to callers
+time: 2026-08-28T12:02:52.820897-07:00

--- a/.changes/unreleased/Enhancement or New Feature-20260828-120257.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260828-120257.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Classify warehouse authentication and permission errors from semantic layer query failures, stripping the internal classification marker and appending an actionable hint pointing the caller toward the likely fix
+time: 2026-08-28T12:02:57.19693-07:00

--- a/src/dbt_mcp/errors/hints.py
+++ b/src/dbt_mcp/errors/hints.py
@@ -18,3 +18,54 @@ def with_multicell_hint(message: str) -> str:
     if looks_like_ssl_error(message):
         return f"{message}\n\n{MULTICELL_HINT}"
     return message
+
+
+# The semantic layer may classify a warehouse query failure and mark it by
+# embedding one of these bracketed tokens in the error message, followed by
+# the original underlying error message. Any other message is unclassified
+# and must be left completely untouched.
+_WAREHOUSE_AUTHENTICATION_MARKER = "[WAREHOUSE_AUTHENTICATION_FAILED]"
+_WAREHOUSE_PERMISSION_MARKER = "[WAREHOUSE_PERMISSION_DENIED]"
+
+WAREHOUSE_AUTHENTICATION_HINT = (
+    "Hint: The warehouse rejected the configured credentials as invalid. Check "
+    "your configured warehouse credentials and reconfigure them if they have "
+    "expired, been rotated, or changed."
+)
+
+WAREHOUSE_PERMISSION_HINT = (
+    "Hint: The warehouse accepted the configured credentials but denied access "
+    "to the object being queried. Note this can also mean the referenced object "
+    "does not exist or is misspelled — the warehouse (e.g. Snowflake) reports "
+    "both situations identically, so don't assume it's strictly a permissions "
+    "issue. Double-check both the object name/spelling and the access grants "
+    "for the configured credentials."
+)
+
+
+def classify_warehouse_error(message: str) -> tuple[str, str | None]:
+    """Detect and strip a warehouse error marker from a semantic layer error message.
+
+    Returns a tuple of (message_with_marker_removed, category), where category
+    is one of "authentication", "permission", or None if the message carries no
+    marker (the overwhelmingly common case, which must pass through unchanged).
+
+    Uses substring containment rather than a prefix check, since the marker is
+    not guaranteed to be at the very start of the message.
+    """
+    if _WAREHOUSE_AUTHENTICATION_MARKER in message:
+        stripped = message.replace(_WAREHOUSE_AUTHENTICATION_MARKER, "", 1)
+        return stripped.strip(), "authentication"
+    if _WAREHOUSE_PERMISSION_MARKER in message:
+        stripped = message.replace(_WAREHOUSE_PERMISSION_MARKER, "", 1)
+        return stripped.strip(), "permission"
+    return message, None
+
+
+def warehouse_error_hint(category: str | None) -> str | None:
+    """Return the actionable hint text for a warehouse error category, if any."""
+    if category == "authentication":
+        return WAREHOUSE_AUTHENTICATION_HINT
+    if category == "permission":
+        return WAREHOUSE_PERMISSION_HINT
+    return None

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -440,7 +440,15 @@ class SemanticLayerFetcher:
 
     def _format_semantic_layer_error(self, error: Exception) -> str:
         """Format semantic layer errors by cleaning up common error message patterns."""
-        error_str = str(error)
+        # QueryFailedError.__str__ wraps its message in a `message="...")," status=`
+        # artifact of that class's __str__ implementation. Use the clean `.message`
+        # attribute instead, so the cleanup chain below operates on the real
+        # underlying message rather than that wrapper.
+        if isinstance(error, QueryFailedError):
+            error_str = error.message
+        else:
+            error_str = str(error)
+
         formatted = (
             error_str.replace("QueryFailedError(", "")
             .rstrip(")")

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -441,7 +441,7 @@ class SemanticLayerFetcher:
 
     def _format_semantic_layer_error(self, error: Exception) -> str:
         """Format semantic layer errors by cleaning up common error message patterns."""
-        # QueryFailedError.__str__ wraps its message in a `message="...")," status=`
+        # QueryFailedError.__str__ wraps its message in a `message="...", status=...`
         # artifact of that class's __str__ implementation. Use the clean `.message`
         # attribute instead, so the cleanup chain below operates on the real
         # underlying message rather than that wrapper.

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -21,6 +21,7 @@ from dbtsl.models.query import QueryStatus
 
 from dbt_mcp.config.config_providers import SemanticLayerConfig
 from dbt_mcp.errors import InvalidParameterError
+from dbt_mcp.errors.hints import classify_warehouse_error, warehouse_error_hint
 from dbt_mcp.errors.semantic_layer import SemanticLayerQueryTimeoutError
 from dbt_mcp.semantic_layer.gql.gql import GRAPHQL_QUERIES
 from dbt_mcp.semantic_layer.gql.gql_request import submit_request
@@ -449,6 +450,12 @@ class SemanticLayerFetcher:
         else:
             error_str = str(error)
 
+        # The semantic layer may prefix a warehouse query failure's message with
+        # a bracketed classification marker. Strip it out before the cosmetic
+        # cleanup below, since that cleanup's `.lstrip("[")` would otherwise
+        # corrupt an unstripped marker.
+        error_str, warehouse_error_category = classify_warehouse_error(error_str)
+
         formatted = (
             error_str.replace("QueryFailedError(", "")
             .rstrip(")")
@@ -464,7 +471,13 @@ class SemanticLayerFetcher:
             .strip()
         )
         if not formatted:
-            return error_str or f"Semantic layer query failed: {type(error).__name__}"
+            formatted = (
+                error_str or f"Semantic layer query failed: {type(error).__name__}"
+            )
+
+        hint = warehouse_error_hint(warehouse_error_category)
+        if hint:
+            formatted = f"{formatted}\n\n{hint}"
         return formatted
 
     def _format_get_metrics_compiled_sql_error(

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -446,7 +446,7 @@ class SemanticLayerFetcher:
         # attribute instead, so the cleanup chain below operates on the real
         # underlying message rather than that wrapper.
         if isinstance(error, QueryFailedError):
-            error_str = error.message
+            error_str = str(error.message) if error.message is not None else ""
         else:
             error_str = str(error)
 

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -18,6 +18,10 @@ from dbtsl.api.shared.query_params import (
 
 from dbt_mcp.config.config_providers import SemanticLayerConfig
 from dbt_mcp.errors import InvalidParameterError
+from dbt_mcp.errors.hints import (
+    WAREHOUSE_AUTHENTICATION_HINT,
+    WAREHOUSE_PERMISSION_HINT,
+)
 from dbt_mcp.errors.semantic_layer import SemanticLayerQueryTimeoutError
 from dbt_mcp.semantic_layer.client import DEFAULT_RESULT_FORMATTER, SemanticLayerFetcher
 from dbt_mcp.semantic_layer.types import (
@@ -861,6 +865,60 @@ class TestQueryMetricsErrorPropagation:
 
         with pytest.raises(ConnectionError):
             await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
+
+    async def test_query_failed_error_without_marker_is_unaffected(
+        self, fetcher, mock_sl_client, mock_config
+    ):
+        """A query failure with no warehouse classification marker must be
+        formatted exactly as it was before the marker classifier existed -
+        this is the overwhelmingly common case and must not regress."""
+        mock_sl_client.query.side_effect = QueryFailedError(
+            "Dimension 'foo' not found", "FAILED"
+        )
+
+        result = await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
+
+        assert isinstance(result, QueryMetricsError)
+        assert result.error == "Dimension 'foo' not found"
+
+    async def test_query_failed_error_with_authentication_marker_classified(
+        self, fetcher, mock_sl_client, mock_config
+    ):
+        """A warehouse-classified authentication failure has its marker
+        stripped from the message and an actionable hint appended."""
+        mock_sl_client.query.side_effect = QueryFailedError(
+            "[WAREHOUSE_AUTHENTICATION_FAILED] Incorrect username or password "
+            "was specified.",
+            "FAILED",
+        )
+
+        result = await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
+
+        assert isinstance(result, QueryMetricsError)
+        assert result.error == (
+            "Incorrect username or password was specified.\n\n"
+            f"{WAREHOUSE_AUTHENTICATION_HINT}"
+        )
+
+    async def test_query_failed_error_with_permission_marker_classified(
+        self, fetcher, mock_sl_client, mock_config
+    ):
+        """A warehouse-classified permission failure has its marker stripped
+        from the message and an actionable hint appended that notes the
+        ambiguity between a permissions issue and a missing/misspelled object."""
+        mock_sl_client.query.side_effect = QueryFailedError(
+            "[WAREHOUSE_PERMISSION_DENIED] Object 'MY_TABLE' does not exist "
+            "or not authorized.",
+            "FAILED",
+        )
+
+        result = await fetcher.query_metrics(config=mock_config, metrics=["revenue"])
+
+        assert isinstance(result, QueryMetricsError)
+        assert result.error == (
+            "Object 'MY_TABLE' does not exist or not authorized.\n\n"
+            f"{WAREHOUSE_PERMISSION_HINT}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -613,7 +613,7 @@ def test_normalize_where(fetcher, input_where, expected) -> None:
 def test_format_semantic_layer_error_cleans_query_failed_error(fetcher) -> None:
     """A real QueryFailedError's message should be cleaned up.
 
-    QueryFailedError.__str__ wraps the message in a `message="...")," status=`
+    QueryFailedError.__str__ wraps the message in a `message=\"...\", status=...`
     artifact; the formatter must clean the underlying `.message` attribute, not
     that mangled `__str__` output.
     """

--- a/tests/unit/semantic_layer/test_client.py
+++ b/tests/unit/semantic_layer/test_client.py
@@ -607,10 +607,16 @@ def test_normalize_where(fetcher, input_where, expected) -> None:
 
 
 def test_format_semantic_layer_error_cleans_query_failed_error(fetcher) -> None:
-    """Normal QueryFailedError messages should be cleaned up."""
-    error = Exception(
-        "QueryFailedError(INVALID_ARGUMENT: [FlightSQL] Failed to prepare statement: "
-        "com.dbt.semanticlayer.exceptions.DataPlatformException: column not found"
+    """A real QueryFailedError's message should be cleaned up.
+
+    QueryFailedError.__str__ wraps the message in a `message="...")," status=`
+    artifact; the formatter must clean the underlying `.message` attribute, not
+    that mangled `__str__` output.
+    """
+    error = QueryFailedError(
+        "INVALID_ARGUMENT: [FlightSQL] Failed to prepare statement: "
+        "com.dbt.semanticlayer.exceptions.DataPlatformException: column not found",
+        "FAILED",
     )
     result = fetcher._format_semantic_layer_error(error)
     assert result == "column not found"


### PR DESCRIPTION
# Why

The semantic layer can now classify certain warehouse query failures (e.g. bad credentials vs. a permission/object-not-found error) and mark that classification in the error message it returns. Today, `query_metrics` and related tools surface these messages to the calling agent/model without distinguishing "your query was wrong" from "your warehouse credentials or access are the problem" — a distinction that matters a lot for what the agent should try next.

Separately, the existing error-cleanup path had a latent formatting bug: `QueryFailedError.__str__` (from the `dbt-sl-sdk` dependency) wraps its message in a `message="...", status=...` artifact, and the cleanup chain that's supposed to strip noise from these messages was operating on that mangled `str()` output instead of the exception's clean `.message` attribute. This produced garbled error text for callers, and it also stood in the way of reliably detecting a warehouse classification marker at the start of the message.

# What

- `SemanticLayerFetcher._format_semantic_layer_error` now reads `QueryFailedError.message` directly instead of `str(error)`, so the existing cleanup chain operates on the real underlying message rather than `__str__`'s wrapper artifact.
- Added a small classifier (`dbt_mcp.errors.hints.classify_warehouse_error`) that detects a warehouse authentication or permission marker embedded in an error message, strips it, and reports a generic category. This runs before the existing cosmetic cleanup so the marker can't be corrupted by cleanup steps that assume no leading bracket.
- When a message is classified, an actionable hint is appended: one pointing the caller at reconfiguring credentials for authentication failures, and one noting that a permission failure can also mean the referenced object doesn't exist or is misspelled (since the warehouse reports both cases identically) for permission failures.
- Messages without a marker — the overwhelmingly common case — are unaffected.

No changes to `QueryMetricsError`'s shape were needed; this ships as a pure message-text change.

# Notes

`ui/` lint (`pnpm run lint`) wasn't run locally — this environment's asdf-pinned Node version didn't match what's installed — but no files under `ui/` were touched by this change. `ruff check`, `ruff format`, and `mypy` all pass via `pre-commit run --all-files`, and `task test:unit` passes (807 passed, plus 3 new tests; the 10 pre-existing failures are unrelated to this change and reproduce identically on a clean `origin/main` checkout).

---

Drafted by Claude Sonnet 5 under the direction of @theyostalservice
