### PR TITLE
Offload query_metrics result formatting off event loop

### DIFF
--- a/.changes/unreleased/Bug Fix-20260903-135652.yaml
+++ b/.changes/unreleased/Bug Fix-20260903-135652.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: offload query_metrics result formatting off the event loop to prevent 25s+ blocks
+time: 2026-09-03T13:56:52.15575+01:00

--- a/src/dbt_mcp/semantic_layer/client.py
+++ b/src/dbt_mcp/semantic_layer/client.py
@@ -622,7 +622,7 @@ class SemanticLayerFetcher:
             if query_error:
                 return self._format_query_failed_error(query_error)
             formatter = result_formatter or DEFAULT_RESULT_FORMATTER
-            json_result = formatter(query_result)
+            json_result = await asyncio.to_thread(formatter, query_result)
             return QueryMetricsSuccess(result=json_result or "")
         except SemanticLayerQueryTimeoutError:
             raise


### PR DESCRIPTION
## Why

A big arrow table goes through `to_pylist()` on the main event loop blocking everything else. **25 second block** received in ai-codegen-api.

[datadog link](https://dbtlabsmt.datadoghq.com/logs?query=service%3Aai-codegen-api%20container_id%3A374e8e743ea7e15dab94e50e6697cfe1c3014b79e5040cd896f4a30948f970b4%20%40extra.blocked_duration%3A%3E5&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&context_event=AaBkVJ5eAACCd1al74M6EQAY&event=AwAAAaBkUc4iKdkqhQAAABhBYUJrVWQ5QUFBREE3c3hwUV9ScUpnQVYAAAAkZjFhMDY0NTItNTFiMC00NmU2LTllYmUtYzI5MGM5YTAyMDZiAAERaA&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1788180599640&to_ts=1788439799640&live=true). **25 seconds** blocked.

## What

`query_metrics` already run actual SL query in `asyncio.to_thread()`,  but then the formatter (`to_pylist()` + JSON serialize) run on the main event loop. Now formatter also runs in a thread freeing up the event loop.


Drafted by Claude Opus 4.6 under the direction of @alan-andrade