### PR TITLE
Project Filter in List Jobs

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260909-103027.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260909-103027.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: Add an optional project_id filter to list_jobs to retrieve jobs across all environments in a project, while preserving the configured environment default when omitted.
+time: 2026-09-09T10:30:27.406448+05:30

--- a/src/dbt_mcp/dbt_admin/param_descriptions.py
+++ b/src/dbt_mcp/dbt_admin/param_descriptions.py
@@ -8,6 +8,11 @@ PAGINATION_OFFSET = "Number of results to skip for pagination"
 JOB_DEFINITION_ID = "The dbt job definition ID"
 JOB_RUN_ID = "The dbt job run ID"
 
+JOBS_PROJECT_ID_FILTER = (
+    "List jobs across all environments in this project, overriding the configured "
+    "production environment filter. When omitted, use the configured production "
+    "environment, or list all account jobs if none is configured"
+)
 # --- list_jobs_runs ---
 
 JOB_RUNS_JOB_DEFINITION_ID_FILTER = (

--- a/src/dbt_mcp/dbt_admin/tools.py
+++ b/src/dbt_mcp/dbt_admin/tools.py
@@ -23,6 +23,7 @@ from dbt_mcp.dbt_admin.param_descriptions import (
     ARTIFACT_STEP,
     INCLUDE_WARNINGS_WITH_ERRORS,
     JOB_DEFINITION_ID,
+    JOBS_PROJECT_ID_FILTER,
     JOB_RUN_ID,
     JOB_RUNS_JOB_DEFINITION_ID_FILTER,
     JOB_RUNS_ORDER_BY,
@@ -95,17 +96,19 @@ async def list_projects(context: AdminToolContext) -> list[dict[str, Any]]:
 )
 async def list_jobs(
     context: AdminToolContext,
-    # TODO: add support for project_id in the future
-    # project_id: Optional[int] = None,
     limit: Annotated[int | None, Field(description=PAGINATION_LIMIT)] = None,
     offset: Annotated[int | None, Field(description=PAGINATION_OFFSET)] = None,
+    *,
+    project_id: Annotated[
+        int | None, Field(description=JOBS_PROJECT_ID_FILTER, gt=0)
+    ] = None,
 ) -> list[dict[str, Any]]:
-    """List jobs in an account."""
+    """List jobs in an account, optionally across all environments of a project."""
     admin_api_config = await context.admin_api_config_provider.get_config()
     params = {}
-    # if project_id:
-    #     params["project_id"] = project_id
-    if admin_api_config.prod_environment_id:
+    if project_id is not None:
+        params["project_id"] = project_id
+    elif admin_api_config.prod_environment_id:
         params["environment_id"] = admin_api_config.prod_environment_id
     if limit:
         params["limit"] = limit

--- a/src/dbt_mcp/prompts/admin_api/list_jobs.md
+++ b/src/dbt_mcp/prompts/admin_api/list_jobs.md
@@ -2,7 +2,7 @@ List all jobs in a dbt platform account with optional filtering.
 
 This tool retrieves jobs from the dbt Admin API. Jobs are the configuration for scheduled or triggered dbt runs.
 
-When a single project is configured, results are automatically scoped to that environment. Otherwise, all jobs in the account are returned — use `limit` to constrain large result sets.
+Pass `project_id` to list jobs across all environments in that project. This overrides the configured production environment filter. When `project_id` is omitted, results remain scoped to the configured production environment, or to the account if no environment is configured. Use `limit` and `offset` to page through large result sets.
 
 Returns a list of job objects with details like:
 - Job ID, name, and description

--- a/tests/unit/contract/contract_snapshot.json
+++ b/tests/unit/contract/contract_snapshot.json
@@ -2250,7 +2250,7 @@
         "readOnlyHint": true,
         "title": "List Jobs"
       },
-      "description": "List all jobs in a dbt platform account with optional filtering.\n\nThis tool retrieves jobs from the dbt Admin API. Jobs are the configuration for scheduled or triggered dbt runs.\n\nWhen a single project is configured, results are automatically scoped to that environment. Otherwise, all jobs in the account are returned \u2014 use `limit` to constrain large result sets.\n\nReturns a list of job objects with details like:\n- Job ID, name, and description\n- Environment ID and project ID the job belongs to\n- Schedule configuration\n- Execute steps (dbt commands)\n- Trigger settings\n\nUse this tool to explore available jobs, understand job configurations, or find specific jobs to trigger.\n",
+      "description": "List all jobs in a dbt platform account with optional filtering.\n\nThis tool retrieves jobs from the dbt Admin API. Jobs are the configuration for scheduled or triggered dbt runs.\n\nPass `project_id` to list jobs across all environments in that project. This overrides the configured production environment filter. When `project_id` is omitted, results remain scoped to the configured production environment, or to the account if no environment is configured. Use `limit` and `offset` to page through large result sets.\n\nReturns a list of job objects with details like:\n- Job ID, name, and description\n- Environment ID and project ID the job belongs to\n- Schedule configuration\n- Execute steps (dbt commands)\n- Trigger settings\n\nUse this tool to explore available jobs, understand job configurations, or find specific jobs to trigger.\n",
       "input_schema": {
         "properties": {
           "limit": {
@@ -2278,6 +2278,20 @@
             "default": null,
             "description": "Number of results to skip for pagination",
             "title": "Offset"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "List jobs across all environments in this project, overriding the configured production environment filter. When omitted, use the configured production environment, or list all account jobs if none is configured",
+            "title": "Project Id"
           }
         },
         "title": "list_jobsArguments",

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -1,10 +1,15 @@
 import json
+from dataclasses import replace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from client.session import client_session_context
-from dbt_mcp.dbt_admin.param_descriptions import PAGINATION_LIMIT, PAGINATION_OFFSET
+from dbt_mcp.dbt_admin.param_descriptions import (
+    JOBS_PROJECT_ID_FILTER,
+    PAGINATION_LIMIT,
+    PAGINATION_OFFSET,
+)
 from dbt_mcp.dbt_admin.tools import (
     ADMIN_TOOLS,
     AdminToolContext,
@@ -629,5 +634,33 @@ async def test_admin_tools_list_jobs_params():
         assert list_jobs_tool.inputSchema is not None
         props = list_jobs_tool.inputSchema.get("properties")
         assert props is not None
+        assert props["project_id"]["description"] == JOBS_PROJECT_ID_FILTER
+        assert "project_id" not in list_jobs_tool.inputSchema.get("required", [])
+        assert {"type": "integer", "exclusiveMinimum": 0} in props["project_id"][
+            "anyOf"
+        ]
         assert props["limit"]["description"] == PAGINATION_LIMIT
         assert props["offset"]["description"] == PAGINATION_OFFSET
+
+
+@pytest.mark.parametrize("project_id", [None, 42])
+@pytest.mark.parametrize("prod_environment_id", [None, 100])
+async def test_list_jobs_project_scope_and_pagination(
+    admin_context: AdminToolContext,
+    project_id: int | None,
+    prod_environment_id: int | None,
+) -> None:
+    config = await admin_context.admin_api_config_provider.get_config()
+    config = replace(config, prod_environment_id=prod_environment_id)
+    admin_context.admin_api_config_provider = Mock(
+        get_config=AsyncMock(return_value=config)
+    )
+
+    await list_jobs.fn(admin_context, project_id=project_id, limit=10, offset=20)
+
+    expected = {"limit": 10, "offset": 20}
+    if project_id is not None:
+        expected["project_id"] = project_id
+    elif prod_environment_id is not None:
+        expected["environment_id"] = prod_environment_id
+    admin_context.admin_client.list_jobs.assert_awaited_once_with(12345, **expected)

--- a/tests/unit/dbt_admin/test_tools.py
+++ b/tests/unit/dbt_admin/test_tools.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import replace
+from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -663,4 +664,5 @@ async def test_list_jobs_project_scope_and_pagination(
         expected["project_id"] = project_id
     elif prod_environment_id is not None:
         expected["environment_id"] = prod_environment_id
-    admin_context.admin_client.list_jobs.assert_awaited_once_with(12345, **expected)
+    list_jobs_mock = cast(AsyncMock, admin_context.admin_client.list_jobs)
+    list_jobs_mock.assert_awaited_once_with(12345, **expected)


### PR DESCRIPTION
## Summary

Add an optional `project_id` filter to the `list_jobs` MCP tool.

## What Changed

- Added an optional, positive-integer `project_id` parameter to `list_jobs`.
- When provided, the tool lists jobs across every environment in that project.
- Preserved existing behavior when omitted:
- scopes results to the configured production environment, when configured
- otherwise lists jobs across the account
- Updated the tool prompt and contract snapshot to document the filtering behavior.
- Added unit coverage for project/environment scoping, pagination, and the MCP input
  schema.
- Added a changelog entry.

## Why

This makes it possible to retrieve all jobs for a project—including jobs in non-production environments—without changing the server’s configured production-environment default.

  ## Checklist

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (in https://github.com/dbt-labs/docs.getdbt.com) if required -- Mention it here
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes