### PR TITLE
fix(examples): add missing `import sys` to aws_strands_agent dbt_mcp tool

### DIFF
--- a/examples/aws_strands_agent/dbt_data_scientist/tools/dbt_mcp.py
+++ b/examples/aws_strands_agent/dbt_data_scientist/tools/dbt_mcp.py
@@ -1,6 +1,7 @@
 """dbt MCP Tool - Remote dbt MCP server connection for AWS Bedrock Agent Core."""
 
 import os
+import sys
 from strands import tool
 from dotenv import load_dotenv
 from mcp.client.streamable_http import streamablehttp_client


### PR DESCRIPTION
### Problem

`examples/aws_strands_agent/dbt_data_scientist/tools/dbt_mcp.py` uses `sys.exit()` twice in its `__main__` connection-test block, but the module never imports `sys`:

https://github.com/dbt-labs/dbt-mcp/blob/main/examples/aws_strands_agent/dbt_data_scientist/tools/dbt_mcp.py#L131
https://github.com/dbt-labs/dbt-mcp/blob/main/examples/aws_strands_agent/dbt_data_scientist/tools/dbt_mcp.py#L143

Imports at the top of the file are `os`, `strands.tool`, `dotenv.load_dotenv`, `streamablehttp_client`, `MCPClient` — no `sys`.

The comment above the block says "Test the connection when this module is run directly", so this path is meant to be executed. Both branches through it hit an undefined name:

* **Missing env vars** (line 131) — the script prints the "Missing required environment variables" message and then raises `NameError` instead of exiting 1.
* **Successful test** (line 143) — the script prints `🎉 MCP connection test passed!` and *then* raises `NameError`. Because the traceback propagates, the process exits **1**, so a passing connection test reports failure to the shell/CI — the inverse of what line 143 intends.

### Specification

The two sibling scripts in the same directory already do this correctly, with the identical exit call:

* `examples/aws_strands_agent/dbt_data_scientist/quick_mcp_test.py` — `import sys` (line 5), `sys.exit(0 if success else 1)` (line 57)
* `examples/aws_strands_agent/dbt_data_scientist/test_all_tools.py` — `import sys` (line 5), `sys.exit(0 if success else 1)` (line 330)

This looks like a copy-paste that dropped the import.

### Fix

One line: `import sys` next to `import os`.

### Verification

Ran the module directly with stub `strands` / `mcp` / `dotenv` packages (the real ones aren't needed to exercise the `__main__` block), before and after the patch.

**Before — missing-env path:**

```
❌ Missing required environment variables: DBT_TOKEN, DBT_USER_ID, DBT_PROD_ENV_ID
Please set these in your .env file or environment.
Traceback (most recent call last):
  File ".../dbt_mcp.py", line 131, in <module>
    sys.exit(1)
    ^^^
NameError: name 'sys' is not defined. Did you forget to import 'sys'?
```

**Before — success path:**

```
🎉 MCP connection test passed!
You can now run the agent: python dbt_data_scientist/agent.py
Traceback (most recent call last):
  File ".../dbt_mcp.py", line 143, in <module>
    sys.exit(0 if success else 1)
    ^^^
NameError: name 'sys' is not defined. Did you forget to import 'sys'?
```

Exit code on that success path: **1** (intended: 0).

**After:** both paths run clean; missing-env exits **1**, successful test exits **0**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
