### PR TITLE
fix(examples): resolve NameError in ag2_agent recommend_action handoff

### DIFF
--- a/examples/ag2_agent/main_multiagent.py
+++ b/examples/ag2_agent/main_multiagent.py
@@ -36,33 +36,6 @@ from autogen.agentchat.group import (
 from autogen.agentchat.group.patterns import DefaultPattern
 
 
-# ---------------------------------------------------------------------------
-# Tool-based handoff helper (Priority 3)
-# ---------------------------------------------------------------------------
-# This function can be registered as a tool on the analyst agent.
-# When the analyst calls it, the framework uses the ReplyResult target
-# to route directly to the executor, regardless of any LLM condition.
-# The routing decision is co-located with the logic producing it.
-
-def recommend_action(
-    action: Annotated[str, "The dbt action to recommend, e.g. 'test --select orders'"],
-    reason: Annotated[str, "Why this action is needed"],
-    context_variables: ContextVariables,
-) -> ReplyResult:
-    """Record an action recommendation and hand off to the executor agent."""
-    context_variables["pending_action"] = action
-    context_variables["action_reason"] = reason
-    return ReplyResult(
-        message=(
-            f"Analysis complete. Recommended action: dbt {action}\n"
-            f"Reason: {reason}\n"
-            "Handing off to executor."
-        ),
-        target=AgentTarget(executor_agent),  # defined below
-        context_variables=context_variables,
-    )
-
-
 async def main() -> None:
     host = os.environ.get("DBT_HOST", "cloud.getdbt.com")
     token = os.environ["DBT_TOKEN"]
@@ -88,6 +61,39 @@ async def main() -> None:
 
         # All dbt-mcp tools available in this toolkit.
         toolkit = await create_toolkit(session=session)
+
+        # ------------------------------------------------------------------
+        # Tool-based handoff helper (Priority 3)
+        # ------------------------------------------------------------------
+        # This function is registered as a tool on the analyst agent below.
+        # When the analyst calls it, the framework uses the ReplyResult target
+        # to route directly to the executor, regardless of any LLM condition.
+        # The routing decision is co-located with the logic producing it.
+        #
+        # It is nested inside main() so that it closes over executor_agent,
+        # which is created a few lines further down. The name is resolved when
+        # the analyst actually invokes the tool, by which point executor_agent
+        # is bound.
+        # ------------------------------------------------------------------
+        def recommend_action(
+            action: Annotated[
+                str, "The dbt action to recommend, e.g. 'test --select orders'"
+            ],
+            reason: Annotated[str, "Why this action is needed"],
+            context_variables: ContextVariables,
+        ) -> ReplyResult:
+            """Record an action recommendation and hand off to the executor agent."""
+            context_variables["pending_action"] = action
+            context_variables["action_reason"] = reason
+            return ReplyResult(
+                message=(
+                    f"Analysis complete. Recommended action: dbt {action}\n"
+                    f"Reason: {reason}\n"
+                    "Handing off to executor."
+                ),
+                target=AgentTarget(executor_agent),
+                context_variables=context_variables,
+            )
 
         # ------------------------------------------------------------------
         # Agent 1: Analyst


### PR DESCRIPTION
### Problem

In `examples/ag2_agent/main_multiagent.py`, the Priority-3 handoff helper `recommend_action()` is defined **at module level** (line 47) but references `executor_agent` (line 61):

```python
        target=AgentTarget(executor_agent),  # defined below
```

`executor_agent` is never a module-level name — it is assigned as a **local of `async def main()`** at line 134. The `# defined below` comment is accurate about the ordering, but ordering is not the issue: a module-level function cannot see another function's locals at all, no matter when it runs.

This path is reachable, not dead code:

* line 125 — `functions=[recommend_action]` registers it as a tool on the analyst agent;
* line 115 — the analyst system prompt instructs the model to `call recommend_action() with ...`.

So every time the analyst takes the documented Priority-3 handoff, the tool call raises `NameError: name 'executor_agent' is not defined`.

`examples/` is excluded from `ruff` and `mypy` in `.pre-commit-config.yaml`, which is presumably why this was never flagged.

### Verification

Extracted `recommend_action` from `main_multiagent.py` on `main` and called it with stubs for `AgentTarget` / `ReplyResult` / `ContextVariables` (no autogen, network, or API key needed):

```
recommend_action defined at module level, line 47
'executor_agent' in module scope: False
'executor_agent' assigned as a LOCAL of async def main() at line(s): [134]
recommend_action referenced inside main() at line(s): [125]   (functions=[...] registration)
RESULT: NameError -> name 'executor_agent' is not defined
```

With `executor_agent` supplied (i.e. what a closure would give it), the same function returns normally and populates the context:

```
PATCHED: returned ReplyResult | context_variables -> {'pending_action': 'test --select orders', 'action_reason': 'orders is stale'}
```

### Fix

Nest `recommend_action` inside `main()` so it closes over `executor_agent`. Registration at line 125 still happens before `executor_agent` is created, but that is fine — a closure resolves its free variables **at call time**, and by then `executor_agent` is bound:

```
recommend_action freevars = ('executor_agent',)
```

Minimal scoping demo of the same shape:

```python
def main():
    def recommend_action():
        return ('routed to', executor_agent)
    registered = [recommend_action]        # registration BEFORE the binding
    executor_agent = 'executor_agent_obj'  # created a few lines later
    return registered[0]()
# -> ('routed to', 'executor_agent_obj')
```

The body of the helper is unchanged apart from indentation and one wrapped `Annotated[...]` line; the explanatory comment block moved with it.

### Alternative, if you'd rather not nest it

`recommend_action` sets `pending_action`, and the Priority-1 `OnContextCondition` at line 183 already routes analyst → executor on exactly that condition — so dropping `target=` would also stop the crash. I went with the closure because the comment block states the point of Priority 3 is that "the routing decision is co-located with the logic producing it", and dropping the target would move it back to Priority 1. Happy to switch if you prefer the smaller diff.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
